### PR TITLE
Add parent process id

### DIFF
--- a/examples/src/simple.rs
+++ b/examples/src/simple.rs
@@ -21,7 +21,7 @@ fn print_help() -> bool {
     write!(&mut io::stdout(), "signals            : show the available signals\n");
     write!(&mut io::stdout(), "refresh            : reloads processes' information\n");
     write!(&mut io::stdout(), "show [pid | name]  : show information of the given process corresponding to [pid | name]\n");
-    write!(&mut io::stdout(), "kill [pid] [signal]: send [signal] to the processus with this [pid]. 0 < [signal] < 32\n");
+    write!(&mut io::stdout(), "kill [pid] [signal]: send [signal] to the process with this [pid]. 0 < [signal] < 32\n");
     write!(&mut io::stdout(), "proc               : Displays proc state\n");
     write!(&mut io::stdout(), "memory             : Displays memory state\n");
     write!(&mut io::stdout(), "temperature        : Displays components' temperature\n");

--- a/src/linux/process.rs
+++ b/src/linux/process.rs
@@ -19,7 +19,7 @@ pub struct Process {
     /// pid of the process
     pub pid: i64,
     /// pid of the parent process
-    pub parent: i64,
+    pub parent: Option<i64>,
     /// environment of the process
     pub environ: Vec<String>,
     /// current working directory
@@ -40,7 +40,7 @@ pub struct Process {
 }
 
 impl Process {
-    pub fn new(pid: i64, parent: i64, start_time: u64) -> Process {
+    pub fn new(pid: i64, parent: Option<i64>, start_time: u64) -> Process {
         Process {
             name: String::new(),
             pid: pid,
@@ -70,7 +70,7 @@ impl Process {
 impl Debug for Process {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "pid: {}\n", self.pid);
-        write!(f, "parent: {}\n", self.parent);
+        write!(f, "parent: {:?}\n", self.parent);
         write!(f, "name: {}\n", self.name);
         write!(f, "environment:\n");
         for var in self.environ.iter() {

--- a/src/linux/process.rs
+++ b/src/linux/process.rs
@@ -16,9 +16,9 @@ pub struct Process {
     pub cmd: String,
     /// path to the executable
     pub exe: String,
-    /// pid of the processus
+    /// pid of the process
     pub pid: i64,
-    /// environment of the processus
+    /// environment of the process
     pub environ: Vec<String>,
     /// current working directory
     pub cwd: String,

--- a/src/linux/process.rs
+++ b/src/linux/process.rs
@@ -18,6 +18,8 @@ pub struct Process {
     pub exe: String,
     /// pid of the process
     pub pid: i64,
+    /// pid of the parent process
+    pub parent: i64,
     /// environment of the process
     pub environ: Vec<String>,
     /// current working directory
@@ -38,10 +40,11 @@ pub struct Process {
 }
 
 impl Process {
-    pub fn new(pid: i64, start_time: u64) -> Process {
+    pub fn new(pid: i64, parent: i64, start_time: u64) -> Process {
         Process {
             name: String::new(),
             pid: pid,
+            parent: parent,
             cmd: String::new(),
             environ: Vec::new(),
             exe: String::new(),
@@ -67,6 +70,7 @@ impl Process {
 impl Debug for Process {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "pid: {}\n", self.pid);
+        write!(f, "parent: {}\n", self.parent);
         write!(f, "name: {}\n", self.name);
         write!(f, "environment:\n");
         for var in self.environ.iter() {

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -252,8 +252,14 @@ fn _get_process_data(path: &Path, proc_list: &mut HashMap<usize, Process>, page_
                 update_time_and_memory(entry, &parts, page_size_kb);
                 return;
             }
+
+            let parent = match i64::from_str(parts[3]).unwrap() {
+                0 => None,
+                p => Some(p)
+            };
+
             let mut p = Process::new(nb,
-                                     i64::from_str(parts[3]).unwrap(),
+                                     parent,
                                      u64::from_str(parts[21]).unwrap() /
                                      unsafe { sysconf(_SC_CLK_TCK) } as u64);
 

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -253,6 +253,7 @@ fn _get_process_data(path: &Path, proc_list: &mut HashMap<usize, Process>, page_
                 return;
             }
             let mut p = Process::new(nb,
+                                     i64::from_str(parts[3]).unwrap(),
                                      u64::from_str(parts[21]).unwrap() /
                                      unsafe { sysconf(_SC_CLK_TCK) } as u64);
 

--- a/src/mac/ffi.rs
+++ b/src/mac/ffi.rs
@@ -93,7 +93,7 @@ pub struct proc_bsdinfo {
     pub pbi_status: u32,
     pub pbi_xstatus: u32,
     pub pbi_pid: u32,
-    pub ppbi_pid: u32,
+    pub pbi_ppid: u32,
     pub pbi_uid: uid_t,
     pub pbi_gid: gid_t,
     pub pbi_ruid: uid_t,

--- a/src/mac/process.rs
+++ b/src/mac/process.rs
@@ -19,7 +19,7 @@ pub struct Process {
     /// pid of the process
     pub pid: i64,
     /// pid of the parent process
-    pub parent: i64,
+    pub parent: Option<i64>,
     /// environment of the process
     pub environ: Vec<String>,
     /// current working directory
@@ -40,7 +40,7 @@ pub struct Process {
 }
 
 impl Process {
-    pub fn new(pid: i64, parent: i64, start_time: u64) -> Process {
+    pub fn new(pid: i64, parent: Option<i64>, start_time: u64) -> Process {
         Process {
             name: String::new(),
             pid: pid,
@@ -70,7 +70,7 @@ impl Process {
 impl Debug for Process {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "pid: {}\n", self.pid);
-        write!(f, "parent: {}\n", self.parent);
+        write!(f, "parent: {:?}\n", self.parent);
         write!(f, "name: {}\n", self.name);
         write!(f, "environment:\n");
         for var in self.environ.iter() {

--- a/src/mac/process.rs
+++ b/src/mac/process.rs
@@ -16,9 +16,9 @@ pub struct Process {
     pub cmd: String,
     /// path to the executable
     pub exe: String,
-    /// pid of the processus
+    /// pid of the process
     pub pid: i64,
-    /// environment of the processus
+    /// environment of the process
     pub environ: Vec<String>,
     /// current working directory
     pub cwd: String,

--- a/src/mac/process.rs
+++ b/src/mac/process.rs
@@ -18,6 +18,8 @@ pub struct Process {
     pub exe: String,
     /// pid of the process
     pub pid: i64,
+    /// pid of the parent process
+    pub parent: i64,
     /// environment of the process
     pub environ: Vec<String>,
     /// current working directory
@@ -38,10 +40,11 @@ pub struct Process {
 }
 
 impl Process {
-    pub fn new(pid: i64, start_time: u64) -> Process {
+    pub fn new(pid: i64, parent: i64, start_time: u64) -> Process {
         Process {
             name: String::new(),
             pid: pid,
+            parent: parent,
             cmd: String::new(),
             environ: Vec::new(),
             exe: String::new(),
@@ -67,6 +70,7 @@ impl Process {
 impl Debug for Process {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "pid: {}\n", self.pid);
+        write!(f, "parent: {}\n", self.parent);
         write!(f, "name: {}\n", self.name);
         write!(f, "environment:\n");
         for var in self.environ.iter() {

--- a/src/mac/system.rs
+++ b/src/mac/system.rs
@@ -387,8 +387,13 @@ impl System {
                     continue
                 }
 
+                let parent = match task_info.pbsd.pbi_ppid as i64 {
+                    0 => None,
+                    p => Some(p)
+                };
+
                 let mut p = Process::new(pid as i64,
-                                         task_info.pbsd.pbi_ppid as i64,
+                                         parent,
                                          task_info.pbsd.pbi_start_tvsec);
                 p.memory = task_info.ptinfo.pti_resident_size / 1024;
 

--- a/src/mac/system.rs
+++ b/src/mac/system.rs
@@ -387,7 +387,9 @@ impl System {
                     continue
                 }
 
-                let mut p = Process::new(pid as i64, task_info.pbsd.pbi_start_tvsec);
+                let mut p = Process::new(pid as i64,
+                                         task_info.pbsd.pbi_ppid as i64,
+                                         task_info.pbsd.pbi_start_tvsec);
                 p.memory = task_info.ptinfo.pti_resident_size / 1024;
 
                 let ptr = proc_args.as_mut_slice().as_mut_ptr();

--- a/src/mac/system.rs
+++ b/src/mac/system.rs
@@ -9,7 +9,7 @@ use sys::component::Component;
 use sys::processor::*;
 use sys::process::*;
 use std::collections::HashMap;
-use libc::{self, c_void, c_int, size_t, stat, c_char, sysconf, _SC_PAGESIZE};
+use libc::{self, c_void, c_int, size_t, c_char, sysconf, _SC_PAGESIZE};
 use std::rc::Rc;
 use sys::processor;
 

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -34,7 +34,7 @@ mod system;
 #[repr(C)]
 #[derive(Clone, PartialEq, PartialOrd, Debug, Copy)]
 pub enum Signal {
-    /// Hangup detected on controlling terminal or death of controlling processus
+    /// Hangup detected on controlling terminal or death of controlling process
     Hangup = 1,
     /// Interrupt from keyboard
     Interrupt = 2,


### PR DESCRIPTION
This implements #25 for Linux and Mac OS. It is tested on both platforms (OS X 10.11, Debian 8.6). Looks like there's no testsuite for sysinfo to run this against, correct?