### PR TITLE
Use RSS for Process::memory on Linux

### DIFF
--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -267,10 +267,9 @@ fn update_time_and_memory(path: &Path, entry: &mut Process, parts: &[&str], page
                           parent_memory: u64, pid: pid_t) {
     //entry.name = parts[1][1..].to_owned();
     //entry.name.pop();
-    // we get the rss then we add the vsize
+    // we get the rss
     {
-        entry.memory = u64::from_str(parts[23]).unwrap() * page_size_kb +
-                       u64::from_str(parts[22]).unwrap() / 1024;
+        entry.memory = u64::from_str(parts[23]).unwrap() * page_size_kb;
         if entry.memory >= parent_memory {
             entry.memory -= parent_memory;
         }


### PR DESCRIPTION
It doesn't make sense to add VSZ to RSS for Process::memory on Linux (I believe this library is using only RSS on Mac). VSZ is just all memory that the process can access, including memory that is swapped out and memory that is from shared libraries.

I have 8 GB total memory on my pc and I am getting more than 64GB memory used if I sum memory of all processes.