### PR TITLE
Compile fix for Rust 1.15.

### DIFF
--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -395,7 +395,11 @@ fn _get_process_data(path: &Path, proc_list: &mut Process, page_size_kb: u64, pi
                 let s = read_link(tmp.to_str().unwrap_or(""));
 
                 if s.is_ok() {
-                    p.exe = s.unwrap_or_default().to_str().unwrap_or("").to_owned();
+                    p.exe = if let Ok(s) = s {
+                        s.to_str().unwrap_or("").to_owned()
+                    } else {
+                        String::new()
+                    };
                 }
                 tmp = PathBuf::from(path);
                 tmp.push("cwd");


### PR DESCRIPTION
PathBuf does not implement std::default::Default in older Rust versions.