### PR TITLE
[FIX] More robust parsing of /proc/stat

### DIFF
--- a/src/linux/disk.rs
+++ b/src/linux/disk.rs
@@ -9,7 +9,7 @@ use ::utils;
 use super::system::get_all_data;
 
 use libc::statvfs;
-use std::{mem, str};
+use std::mem;
 use std::fmt::{Debug, Error, Formatter};
 use std::path::{Path, PathBuf};
 use std::ffi::{OsStr, OsString};

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -106,29 +106,29 @@ impl SystemExt for System {
 
                 let (parts, _): (Vec<&str>, Vec<&str>) = line.split(' ').partition(|s| !s.is_empty());
                 if first {
-                    self.processors.push(new_processor(parts[0],
-                        u64::from_str(parts[1]).unwrap_or(0),
-                        u64::from_str(parts[2]).unwrap_or(0),
-                        u64::from_str(parts[3]).unwrap_or(0),
-                        u64::from_str(parts[4]).unwrap_or(0),
-                        u64::from_str(parts[5]).unwrap_or(0),
-                        u64::from_str(parts[6]).unwrap_or(0),
-                        u64::from_str(parts[7]).unwrap_or(0),
-                        u64::from_str(parts[8]).unwrap_or(0),
-                        u64::from_str(parts[9]).unwrap_or(0),
-                        u64::from_str(parts[10]).unwrap_or(0)));
+                    self.processors.push(new_processor(parts.get(0).unwrap_or(&""),
+                        parts.get(1).and_then(|v| {u64::from_str(v).ok()}).unwrap_or(0),
+                        parts.get(2).and_then(|v| {u64::from_str(v).ok()}).unwrap_or(0),
+                        parts.get(3).and_then(|v| {u64::from_str(v).ok()}).unwrap_or(0),
+                        parts.get(4).and_then(|v| {u64::from_str(v).ok()}).unwrap_or(0),
+                        parts.get(5).and_then(|v| {u64::from_str(v).ok()}).unwrap_or(0),
+                        parts.get(6).and_then(|v| {u64::from_str(v).ok()}).unwrap_or(0),
+                        parts.get(7).and_then(|v| {u64::from_str(v).ok()}).unwrap_or(0),
+                        parts.get(8).and_then(|v| {u64::from_str(v).ok()}).unwrap_or(0),
+                        parts.get(9).and_then(|v| {u64::from_str(v).ok()}).unwrap_or(0),
+                        parts.get(10).and_then(|v| {u64::from_str(v).ok()}).unwrap_or(0)));
                 } else {
                     set_processor(&mut self.processors[i],
-                        u64::from_str(parts[1]).unwrap_or(0),
-                        u64::from_str(parts[2]).unwrap_or(0),
-                        u64::from_str(parts[3]).unwrap_or(0),
-                        u64::from_str(parts[4]).unwrap_or(0),
-                        u64::from_str(parts[5]).unwrap_or(0),
-                        u64::from_str(parts[6]).unwrap_or(0),
-                        u64::from_str(parts[7]).unwrap_or(0),
-                        u64::from_str(parts[8]).unwrap_or(0),
-                        u64::from_str(parts[9]).unwrap_or(0),
-                        u64::from_str(parts[10]).unwrap_or(0));
+                        parts.get(1).and_then(|v| {u64::from_str(v).ok()}).unwrap_or(0),
+                        parts.get(2).and_then(|v| {u64::from_str(v).ok()}).unwrap_or(0),
+                        parts.get(3).and_then(|v| {u64::from_str(v).ok()}).unwrap_or(0),
+                        parts.get(4).and_then(|v| {u64::from_str(v).ok()}).unwrap_or(0),
+                        parts.get(5).and_then(|v| {u64::from_str(v).ok()}).unwrap_or(0),
+                        parts.get(6).and_then(|v| {u64::from_str(v).ok()}).unwrap_or(0),
+                        parts.get(7).and_then(|v| {u64::from_str(v).ok()}).unwrap_or(0),
+                        parts.get(8).and_then(|v| {u64::from_str(v).ok()}).unwrap_or(0),
+                        parts.get(9).and_then(|v| {u64::from_str(v).ok()}).unwrap_or(0),
+                        parts.get(10).and_then(|v| {u64::from_str(v).ok()}).unwrap_or(0));
                     i += 1;
                 }
             }


### PR DESCRIPTION
Currently, parsing the CPU time from /proc/stat on our RHEL 6.5 fails with the following error:

`
   0: std::sys::imp::backtrace::tracing::imp::unwind_backtrace
             at /checkout/src/libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1: std::sys_common::backtrace::_print
             at /checkout/src/libstd/sys_common/backtrace.rs:71
   2: std::panicking::default_hook::{{closure}}
             at /checkout/src/libstd/sys_common/backtrace.rs:60
             at /checkout/src/libstd/panicking.rs:380
   3: std::panicking::default_hook
             at /checkout/src/libstd/panicking.rs:390
   4: std::panicking::rust_panic_with_hook
             at /checkout/src/libstd/panicking.rs:611
   5: std::panicking::begin_panic_new
             at /checkout/src/libstd/panicking.rs:553
   6: std::panicking::begin_panic_fmt
             at /checkout/src/libstd/panicking.rs:521
   7: rust_begin_unwind
             at /checkout/src/libstd/panicking.rs:497
   8: core::panicking::panic_fmt
             at /checkout/src/libcore/panicking.rs:92
   9: core::panicking::panic_bounds_check
             at /checkout/src/libcore/panicking.rs:68
  10: <alloc::vec::Vec<T> as core::ops::index::Index<usize>>::index
             at /checkout/src/liballoc/vec.rs:1555
  11: <sysinfo::linux::system::System as sysinfo::traits::SystemExt>::refresh_system
             at /home/cim0009/.cargo/registry/src/github.com-1ecc6299db9ec823/sysinfo-0.3.16/src/linux/system.rs:119
  12: sysinfo::traits::SystemExt::refresh_all
             at /home/cim0009/.cargo/registry/src/github.com-1ecc6299db9ec823/sysinfo-0.3.16/src/traits.rs:85
  13: <sysinfo::linux::system::System as sysinfo::traits::SystemExt>::new
             at /home/cim0009/.cargo/registry/src/github.com-1ecc6299db9ec823/sysinfo-0.3.16/src/linux/system.rs:75
`

This is caused due to the index-out-of-bound error when accessing 11th element (column) of the lines containing CPU time. As shown below, these lines only have 10 columns on our system.

`
$ cat /proc/stat

cpu  5168472 345672 825411 1886846797 534660 94 50964 0 0
`

This commit fixes this issue by parsing these lines more robustly providing sensible fallback values.