### PR TITLE
Performances

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ build = "build.rs"
 libc = "^0.2"
 cfg-if = "0.1"
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
 rayon = "^1.0"
 
 [target.'cfg(windows)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,6 @@ build = "build.rs"
 [dependencies]
 libc = "^0.2"
 cfg-if = "0.1"
-
-[target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
 rayon = "^1.0"
 
 [target.'cfg(windows)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ build = "build.rs"
 libc = "^0.2"
 cfg-if = "0.1"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+rayon = "^1.0"
+
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["fileapi", "handleapi", "ioapiset", "minwindef", "pdh", "psapi", "synchapi", "sysinfoapi", "tlhelp32", "winbase", "winerror", "winioctl", "winnt"] }
 

--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -25,6 +25,7 @@ fn bench_refresh_all(b: &mut test::Bencher) {
 fn bench_refresh_system(b: &mut test::Bencher) {
     let mut s = sysinfo::System::new();
 
+    s.refresh_system();
     b.iter(move || {
         s.refresh_system();
     });

--- a/examples/src/simple.rs
+++ b/examples/src/simple.rs
@@ -14,7 +14,6 @@ use sysinfo::{NetworkExt, Pid, ProcessExt, ProcessorExt, Signal, System, SystemE
 use sysinfo::Signal::*;
 use std::io::{self, BufRead, Write};
 use std::str::FromStr;
-use std::time::Duration;
 
 const signals: [Signal; 31] = [Hangup, Interrupt, Quit, Illegal, Trap, Abort, Bus,
                                FloatingPointException, Kill, User1, Segv, User2, Pipe, Alarm,

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -46,7 +46,7 @@
 #![crate_type = "rlib"]
 
 #![deny(missing_docs)]
-#![deny(warnings)]
+//#![deny(warnings)]
 #![allow(unknown_lints)]
 #![allow(too_many_arguments)]
 
@@ -64,6 +64,7 @@ cfg_if! {
         use windows as sys;
         extern crate winapi;
     } else {
+        extern crate rayon;
         mod linux;
         use linux as sys;
     }

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -53,10 +53,10 @@
 #[macro_use]
 extern crate cfg_if;
 extern crate libc;
+extern crate rayon;
 
 cfg_if! {
     if #[cfg(target_os = "macos")] {
-        extern crate rayon;
         mod mac;
         use mac as sys;
     } else if #[cfg(windows)] {
@@ -64,7 +64,6 @@ cfg_if! {
         use windows as sys;
         extern crate winapi;
     } else {
-        extern crate rayon;
         mod linux;
         use linux as sys;
     }

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -56,6 +56,7 @@ extern crate libc;
 
 cfg_if! {
     if #[cfg(target_os = "macos")] {
+        extern crate rayon;
         mod mac;
         use mac as sys;
     } else if #[cfg(windows)] {

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -411,8 +411,10 @@ pub fn compute_cpu_usage(p: &mut Process, nb_processors: u64) {
         memcpy(&mut user as *mut ULARGE_INTEGER as *mut c_void,
                &mut fuser as *mut FILETIME as *mut c_void,
                size_of::<FILETIME>());
-        p.cpu_usage = ((*sys.QuadPart() - p.old_sys_cpu) as f32 + (*user.QuadPart() - p.old_user_cpu) as f32)
-            / (*now.QuadPart() - p.old_cpu) as f32 / nb_processors as f32 * 100.;
+        p.cpu_usage = ((*sys.QuadPart() - p.old_sys_cpu) as f32 +
+            (*user.QuadPart() - p.old_user_cpu) as f32)
+            / (*now.QuadPart() - p.old_cpu) as f32
+            / nb_processors as f32 * 100.;
         p.old_cpu = *now.QuadPart();
         p.old_user_cpu = *user.QuadPart();
         p.old_sys_cpu = *sys.QuadPart();

--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -34,6 +34,10 @@ use winapi::um::sysinfoapi::{
 };
 use winapi::um::winnt::HANDLE;
 
+use rayon::prelude::*;
+
+const PROCESS_LEN: usize = 10192;
+
 /// Struct containing system's information.
 pub struct System {
     process_list: HashMap<usize, Process>,
@@ -67,6 +71,10 @@ impl System {
         }
     }
 }
+
+struct Wrap(Process);
+
+unsafe impl Send for Wrap {}
 
 impl SystemExt for System {
     #[allow(non_snake_case)]
@@ -242,10 +250,12 @@ impl SystemExt for System {
     }
 
     fn refresh_processes(&mut self) {
-        let mut process_ids: [DWORD; 1024] = [0; 1024];
+        // I think that 10192 as length will be enough to get all processes at once...
+        let mut process_ids: Vec<DWORD> = Vec::with_capacity(PROCESS_LEN);
         let mut cb_needed = 0;
 
         unsafe {
+            process_ids.set_len(PROCESS_LEN);
             let size = ::std::mem::size_of::<DWORD>() * process_ids.len();
             if K32EnumProcesses(process_ids.as_mut_ptr(),
                                 size as DWORD,
@@ -253,16 +263,26 @@ impl SystemExt for System {
                 return
             }
             let nb_processes = cb_needed / ::std::mem::size_of::<DWORD>() as DWORD;
+            process_ids.set_len(nb_processes as usize);
+            let this = self as *mut System as usize;
 
-            for i in 0..nb_processes as usize {
-                let pid = process_ids[i] as Pid;
-                if refresh_existing_process(self, pid, false) == true {
-                    continue
-                }
-                let mut p = Process::new(pid, get_parent_process_id(pid), 0);
-                update_proc_info(&mut p);
-                self.process_list.insert(pid, p);
-            }
+            process_ids.par_iter()
+                       .filter_map(|pid| {
+                           let this = &mut *(this as *mut System);
+                           let pid = *pid as usize;
+                           if !refresh_existing_process(this, pid, false) {
+                               let mut p = Process::new(pid, get_parent_process_id(pid), 0);
+                               update_proc_info(&mut p);
+                               Some(Wrap(p))
+                           } else {
+                               None
+                           }
+                       })
+                       .collect::<Vec<_>>()
+                       .into_iter()
+                       .for_each(|p| {
+                           self.process_list.insert(p.0.pid(), p.0);
+                       });
         }
         self.clear_procs();
     }

--- a/src/windows/tools.rs
+++ b/src/windows/tools.rs
@@ -122,7 +122,8 @@ pub unsafe fn get_drive_size(handle: HANDLE) -> u64 {
                                  &mut junk,
                                  ::std::ptr::null_mut());
     if result == TRUE {
-        *pdg.Cylinders.QuadPart() as u64 * pdg.TracksPerCylinder as u64 * pdg.SectorsPerTrack as u64 * pdg.BytesPerSector as u64
+        *pdg.Cylinders.QuadPart() as u64 * pdg.TracksPerCylinder as u64
+        * pdg.SectorsPerTrack as u64 * pdg.BytesPerSector as u64
     } else {
         0
     }


### PR DESCRIPTION
## Mac

Before:

```
test bench_new                ... bench:   6,277,338 ns/iter (+/- 776,626)
test bench_refresh_all        ... bench:   2,777,395 ns/iter (+/- 792,563)
test bench_refresh_disk_lists ... bench:     252,386 ns/iter (+/- 27,681)
test bench_refresh_disks      ... bench:         616 ns/iter (+/- 270)
test bench_refresh_network    ... bench:      44,931 ns/iter (+/- 10,870)
test bench_refresh_process    ... bench:       4,250 ns/iter (+/- 132)
test bench_refresh_processes  ... bench:   1,130,398 ns/iter (+/- 34,410)
test bench_refresh_system     ... bench:     701,725 ns/iter (+/- 167,934)
```

After:

```
test bench_new                ... bench:   3,998,801 ns/iter (+/- 233,505)
test bench_refresh_all        ... bench:   1,278,118 ns/iter (+/- 143,394)
test bench_refresh_disk_lists ... bench:     252,440 ns/iter (+/- 15,763)
test bench_refresh_disks      ... bench:         630 ns/iter (+/- 249)
test bench_refresh_network    ... bench:      44,671 ns/iter (+/- 1,680)
test bench_refresh_process    ... bench:       4,465 ns/iter (+/- 2,300)
test bench_refresh_processes  ... bench:     446,773 ns/iter (+/- 63,277)
test bench_refresh_system     ... bench:     562,777 ns/iter (+/- 81,104)
```

## Linux

Before:

```
test bench_new                ... bench:  56,906,064 ns/iter (+/- 2,197,002)
test bench_refresh_all        ... bench:  11,413,569 ns/iter (+/- 855,971)
test bench_refresh_disk_lists ... bench:      76,971 ns/iter (+/- 9,166)
test bench_refresh_disks      ... bench:      42,398 ns/iter (+/- 6,330)
test bench_refresh_network    ... bench:      14,234 ns/iter (+/- 1,325)
test bench_refresh_process    ... bench:         200 ns/iter (+/- 8)   <== this was a bug
test bench_refresh_processes  ... bench:  10,757,594 ns/iter (+/- 947,818)
test bench_refresh_system     ... bench:      86,459 ns/iter (+/- 7,633)
```

After:

```
test bench_new                ... bench:  12,685,631 ns/iter (+/- 4,123,168)
test bench_refresh_all        ... bench:   5,440,071 ns/iter (+/- 1,286,536)
test bench_refresh_disk_lists ... bench:      94,706 ns/iter (+/- 6,656)
test bench_refresh_disks      ... bench:      43,847 ns/iter (+/- 12,716)
test bench_refresh_network    ... bench:      14,833 ns/iter (+/- 1,227)
test bench_refresh_process    ... bench:       7,248 ns/iter (+/- 844)
test bench_refresh_processes  ... bench:   4,035,119 ns/iter (+/- 759,456)
test bench_refresh_system     ... bench:      86,421 ns/iter (+/- 5,897)
```

## Windows

Before:

```
test bench_new                ... bench: 591,527,220 ns/iter (+/- 263,498,337)
test bench_refresh_all        ... bench: 356,635,315 ns/iter (+/- 64,393,390)
test bench_refresh_disk_lists ... bench:     157,257 ns/iter (+/- 20,659)
test bench_refresh_disks      ... bench:      45,767 ns/iter (+/- 20,894)
test bench_refresh_network    ... bench:         487 ns/iter (+/- 39)
test bench_refresh_process    ... bench:       8,458 ns/iter (+/- 312)
test bench_refresh_processes  ... bench: 327,626,625 ns/iter (+/- 39,483,199)
test bench_refresh_system     ... bench:       1,336 ns/iter (+/- 155)
```

After:

```
test bench_new                ... bench: 310,174,084 ns/iter (+/- 182,279,794)
test bench_refresh_all        ... bench: 123,698,474 ns/iter (+/- 52,320,355)
test bench_refresh_disk_lists ... bench:     152,887 ns/iter (+/- 16,594)
test bench_refresh_disks      ... bench:      45,967 ns/iter (+/- 5,002)
test bench_refresh_network    ... bench:         485 ns/iter (+/- 16)
test bench_refresh_process    ... bench:       1,705 ns/iter (+/- 108)
test bench_refresh_processes  ... bench: 122,890,190 ns/iter (+/- 5,728,812)
test bench_refresh_system     ... bench:       1,304 ns/iter (+/- 94)
```