### PR TITLE
Allow for discovering NVMe disks on Linux systems

### DIFF
--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -503,7 +503,10 @@ fn get_all_disks() -> Vec<Disk> {
     #[allow(or_fun_call)]
     let content = get_all_data("/proc/mounts").unwrap_or(String::new());
     let disks = content.lines()
-        .filter(|line| line.trim_left().starts_with("/dev/sd"));
+        .filter(|line| {
+            let line = line.trim_left();
+            line.starts_with("/dev/sd") || line.starts_with("/dev/nvme")
+        });
     let mut ret = vec![];
 
     for line in disks {

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -505,6 +505,10 @@ fn get_all_disks() -> Vec<Disk> {
     let disks = content.lines()
         .filter(|line| {
             let line = line.trim_left();
+            // While the `sd` prefix is most common, some disks instead use the `nvme` prefix. This
+            // prefix refers to NVM (non-volatile memory) cabale SSDs. These disks run on the NVMe
+            // storage controller protocol (not the scsi protocol) and as a result use a different
+            // prefix to support NVMe namespaces.
             line.starts_with("/dev/sd") || line.starts_with("/dev/nvme")
         });
     let mut ret = vec![];


### PR DESCRIPTION
This fixes an issue where `sysinfo::get_disks()` would not include any
disks with the `/dev/nvme` prefix. Rather than just checking the
`/proc/mounts` file for `/dev/sd*` disks, we now also check for
`/dev/nvme*` disks.

Closes #131.