### PR TITLE
Properly Support Cross Compilation on Unix

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,6 @@
-#[cfg(target_os = "macos")]
 fn main() {
-    println!("cargo:rustc-link-lib=framework=IOKit");
-    println!("cargo:rustc-link-lib=framework=CoreFoundation");
+    if std::env::var("TARGET").unwrap().contains("-apple") {
+        println!("cargo:rustc-link-lib=framework=IOKit");
+        println!("cargo:rustc-link-lib=framework=CoreFoundation");
+    }
 }
-
-#[cfg(not(target_os = "macos"))]
-fn main() {}


### PR DESCRIPTION
Similar issue to: https://github.com/servo/core-foundation-rs/pull/114

Build scripts are always compiled for the target machine building them. So in cases where you are using a unix CI server with `x86_64-apple-darwin` toolchain the `target_os` is not `macos. Thus it will not add the necessary frameworks and fail compilation.

