### PR TITLE
Make it compile on unknown operating system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,13 @@ build = "build.rs"
 [dependencies]
 cfg-if = "0.1"
 rayon = "^1.0"
-libc = "0.2"
 doc-comment = "0.3"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["fileapi", "handleapi", "ioapiset", "minwindef", "pdh", "psapi", "synchapi", "sysinfoapi", "tlhelp32", "winbase", "winerror", "winioctl", "winnt"] }
+
+[target.'cfg(not(target_os = "unknown"))'.dependencies]
+libc = "0.2"
 
 [lib]
 name = "sysinfo"

--- a/src/common.rs
+++ b/src/common.rs
@@ -11,7 +11,7 @@ pub trait AsU32 {
 }
 
 cfg_if!{
-    if #[cfg(windows)] {
+    if #[cfg(any(windows, target_os = "unknown"))] {
         /// Process id.
         pub type Pid = usize;
 

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -51,6 +51,7 @@
 
 #[macro_use]
 extern crate cfg_if;
+#[cfg(not(target_os = "unknown"))]
 extern crate libc;
 extern crate rayon;
 
@@ -68,9 +69,12 @@ cfg_if! {
         mod windows;
         use windows as sys;
         extern crate winapi;
-    } else {
+    } else if #[cfg(unix)] {
         mod linux;
         use linux as sys;
+    } else {
+        mod unknown;
+        use unknown as sys;
     }
 }
 

--- a/src/unknown/component.rs
+++ b/src/unknown/component.rs
@@ -1,0 +1,29 @@
+// 
+// Sysinfo
+// 
+// Copyright (c) 2018 Guillaume Gomez
+//
+
+use ComponentExt;
+
+/// Dummy struct representing a component.
+pub struct Component {
+}
+
+impl ComponentExt for Component {
+    fn get_temperature(&self) -> f32 {
+        0.0
+    }
+
+    fn get_max(&self) -> f32 {
+        0.0
+    }
+
+    fn get_critical(&self) -> Option<f32> {
+        None
+    }
+
+    fn get_label(&self) -> &str {
+        ""
+    }
+}

--- a/src/unknown/disk.rs
+++ b/src/unknown/disk.rs
@@ -1,0 +1,49 @@
+// 
+// Sysinfo
+// 
+// Copyright (c) 2017 Guillaume Gomez
+//
+
+use ::DiskExt;
+
+use std::path::Path;
+use std::ffi::OsStr;
+
+/// Enum containing the different handled disks types.
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum DiskType {
+}
+
+/// Struct containing a disk information.
+pub struct Disk {
+}
+
+impl DiskExt for Disk {
+    fn get_type(&self) -> DiskType {
+        unreachable!()
+    }
+
+    fn get_name(&self) -> &OsStr {
+        unreachable!()
+    }
+
+    fn get_file_system(&self) -> &[u8] {
+        &[]
+    }
+
+    fn get_mount_point(&self) -> &Path {
+        Path::new("")
+    }
+
+    fn get_total_space(&self) -> u64 {
+        0
+    }
+
+    fn get_available_space(&self) -> u64 {
+        0
+    }
+
+    fn update(&mut self) -> bool {
+        true
+    }
+}

--- a/src/unknown/mod.rs
+++ b/src/unknown/mod.rs
@@ -1,0 +1,19 @@
+// 
+// Sysinfo
+// 
+// Copyright (c) 2015 Guillaume Gomez
+//
+
+pub mod component;
+pub mod disk;
+pub mod network;
+pub mod process;
+pub mod processor;
+pub mod system;
+
+pub use self::component::Component;
+pub use self::disk::{Disk, DiskType};
+pub use self::network::NetworkData;
+pub use self::process::{Process, ProcessStatus};
+pub use self::processor::Processor;
+pub use self::system::System;

--- a/src/unknown/network.rs
+++ b/src/unknown/network.rs
@@ -1,0 +1,21 @@
+// 
+// Sysinfo
+// 
+// Copyright (c) 2017 Guillaume Gomez
+//
+
+use NetworkExt;
+
+/// Contains network information.
+#[derive(Debug)]
+pub struct NetworkData;
+
+impl NetworkExt for NetworkData {
+    fn get_income(&self) -> u64 {
+        0
+    }
+
+    fn get_outcome(&self) -> u64 {
+        0
+    }
+}

--- a/src/unknown/process.rs
+++ b/src/unknown/process.rs
@@ -1,0 +1,81 @@
+// 
+// Sysinfo
+// 
+// Copyright (c) 2015 Guillaume Gomez
+//
+
+use std::path::Path;
+use Pid;
+use ::ProcessExt;
+
+/// Enum describing the different status of a process.
+#[derive(Clone, Copy, Debug)]
+pub struct ProcessStatus;
+
+/// Struct containing a process' information.
+#[derive(Clone, Debug)]
+pub struct Process {
+    pid: Pid,
+    parent: Option<Pid>,
+}
+
+impl ProcessExt for Process {
+    fn new(pid: Pid, parent: Option<Pid>, _start_time: u64) -> Process {
+        Process {
+            pid,
+            parent,
+        }
+    }
+
+    fn kill(&self, _signal: ::Signal) -> bool {
+        false
+    }
+
+    fn name(&self) -> &str {
+        ""
+    }
+
+    fn cmd(&self) -> &[String] {
+        &[]
+    }
+
+    fn exe(&self) -> &Path {
+        &Path::new("")
+    }
+
+    fn pid(&self) -> Pid {
+        self.pid
+    }
+
+    fn environ(&self) -> &[String] {
+        &[]
+    }
+
+    fn cwd(&self) -> &Path {
+        &Path::new("")
+    }
+
+    fn root(&self) -> &Path {
+        &Path::new("")
+    }
+
+    fn memory(&self) -> u64 {
+        0
+    }
+
+    fn parent(&self) -> Option<Pid> {
+        self.parent
+    }
+
+    fn status(&self) -> ProcessStatus {
+        ProcessStatus
+    }
+
+    fn start_time(&self) -> u64 {
+        0
+    }
+
+    fn cpu_usage(&self) -> f32 {
+        0.0
+    }
+}

--- a/src/unknown/processor.rs
+++ b/src/unknown/processor.rs
@@ -1,0 +1,21 @@
+// 
+// Sysinfo
+// 
+// Copyright (c) 2015 Guillaume Gomez
+//
+
+use ::ProcessorExt;
+
+/// Dummy struct that represents a processor.
+pub struct Processor {
+}
+
+impl ProcessorExt for Processor {
+    fn get_cpu_usage(&self) -> f32 {
+        0.0
+    }
+
+    fn get_name(&self) -> &str {
+        ""
+    }
+}

--- a/src/unknown/system.rs
+++ b/src/unknown/system.rs
@@ -1,0 +1,112 @@
+// 
+// Sysinfo
+// 
+// Copyright (c) 2015 Guillaume Gomez
+//
+
+use sys::component::Component;
+use sys::processor::*;
+use sys::process::*;
+use sys::Disk;
+use sys::NetworkData;
+use ::{RefreshKind, SystemExt};
+use Pid;
+
+use std::collections::HashMap;
+
+/// Structs containing system's information.
+#[derive(Debug)]
+pub struct System {
+    processes_list: HashMap<Pid, Process>,
+    network: NetworkData,
+}
+
+impl SystemExt for System {
+    fn new_with_specifics(_: RefreshKind) -> System {
+        System {
+            processes_list: Default::default(),
+            network: NetworkData,
+        }
+    }
+
+    fn refresh_system(&mut self) {
+    }
+
+    fn refresh_processes(&mut self) {
+    }
+
+    fn refresh_process(&mut self, _pid: Pid) -> bool {
+        false
+    }
+
+    fn refresh_disks(&mut self) {
+    }
+
+    fn refresh_disk_list(&mut self) {
+    }
+
+    fn refresh_network(&mut self) {
+    }
+
+    // COMMON PART
+    //
+    // Need to be moved into a "common" file to avoid duplication.
+
+    fn get_process_list(&self) -> &HashMap<Pid, Process> {
+        &self.processes_list
+    }
+
+    fn get_process(&self, _pid: Pid) -> Option<&Process> {
+        None
+    }
+
+    fn get_network(&self) -> &NetworkData {
+        &self.network
+    }
+
+    fn get_processor_list(&self) -> &[Processor] {
+        &[]
+    }
+
+    fn get_total_memory(&self) -> u64 {
+        0
+    }
+
+    fn get_free_memory(&self) -> u64 {
+        0
+    }
+
+    fn get_used_memory(&self) -> u64 {
+        0
+    }
+
+    fn get_total_swap(&self) -> u64 {
+        0
+    }
+
+    fn get_free_swap(&self) -> u64 {
+        0
+    }
+
+    fn get_used_swap(&self) -> u64 {
+        0
+    }
+
+    fn get_components_list(&self) -> &[Component] {
+        &[]
+    }
+
+    fn get_disks(&self) -> &[Disk] {
+        &[]
+    }
+
+    fn get_uptime(&self) -> u64 {
+        0
+    }
+}
+
+impl Default for System {
+    fn default() -> System {
+        System::new()
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,19 +4,19 @@
 // Copyright (c) 2017 Guillaume Gomez
 //
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "unknown")))]
 use std::fs;
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "unknown")))]
 use std::path::{Path, PathBuf};
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "unknown")))]
 use std::ffi::OsStr;
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "unknown")))]
 use std::os::unix::ffi::OsStrExt;
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "unknown")))]
 use libc::{c_char, lstat, stat, S_IFLNK, S_IFMT};
 use Pid;
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "unknown")))]
 pub fn realpath(original: &Path) -> PathBuf {
     fn and(x: u32, y: u32) -> u32 {
         x & y
@@ -49,7 +49,7 @@ pub fn realpath(original: &Path) -> PathBuf {
 }
 
 /* convert a path to a NUL-terminated Vec<u8> suitable for use with C functions */
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "unknown")))]
 pub fn to_cpath(path: &Path) -> Vec<u8> {
     let path_os: &OsStr = path.as_ref();
     let mut cpath = path_os.as_bytes().to_vec();
@@ -58,7 +58,7 @@ pub fn to_cpath(path: &Path) -> Vec<u8> {
 }
 
 /// Returns the pid for the current process.
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "unknown")))]
 pub fn get_current_pid() -> Pid {
     unsafe { ::libc::getpid() }
 }
@@ -69,4 +69,10 @@ pub fn get_current_pid() -> Pid {
     use winapi::um::processthreadsapi::GetCurrentProcessId;
 
     unsafe { GetCurrentProcessId() as Pid }
+}
+
+/// Returns the pid for the current process.
+#[cfg(target_os = "unknown")]
+pub fn get_current_pid() -> Pid {
+    panic!("Unavailable on this platform")
 }


### PR DESCRIPTION
Close #179 

Ideally, `get_current_pid()` would return a `Result`, and that would return `Err` when `target_os = "unknown"`. But I didn't do that since that would be a breaking change.
