### PR TITLE
Add process virtual memory usage

### DIFF
--- a/src/linux/process.rs
+++ b/src/linux/process.rs
@@ -108,6 +108,7 @@ pub struct Process {
     pub(crate) cwd: PathBuf,
     pub(crate) root: PathBuf,
     pub(crate) memory: u64,
+    pub(crate) virtual_memory: u64,
     utime: u64,
     stime: u64,
     old_utime: u64,
@@ -136,6 +137,7 @@ impl ProcessExt for Process {
             cwd: PathBuf::new(),
             root: PathBuf::new(),
             memory: 0,
+            virtual_memory: 0,
             cpu_usage: 0.,
             utime: 0,
             stime: 0,
@@ -186,6 +188,10 @@ impl ProcessExt for Process {
         self.memory
     }
 
+    fn virtual_memory(&self) -> u64 {
+        self.virtual_memory
+    }
+
     fn parent(&self) -> Option<Pid> {
         self.parent
     }
@@ -225,6 +231,7 @@ impl Debug for Process {
         writeln!(f, "current working directory: {:?}", self.cwd);
         writeln!(f, "owner/group: {}:{}", self.uid, self.gid);
         writeln!(f, "memory usage: {} kB", self.memory);
+        writeln!(f, "virtual memory usage: {} kB", self.virtual_memory);
         writeln!(f, "cpu usage: {}%", self.cpu_usage);
         writeln!(f, "status: {}", self.status);
         write!(f, "root path: {:?}", self.root)

--- a/src/mac/process.rs
+++ b/src/mac/process.rs
@@ -124,6 +124,7 @@ pub struct Process {
     cwd: PathBuf,
     pub(crate) root: PathBuf,
     pub(crate) memory: u64,
+    pub(crate) virtual_memory: u64,
     utime: u64,
     stime: u64,
     old_utime: u64,
@@ -155,6 +156,7 @@ impl ProcessExt for Process {
             cwd: PathBuf::new(),
             root: PathBuf::new(),
             memory: 0,
+            virtual_memory: 0,
             cpu_usage: 0.,
             utime: 0,
             stime: 0,
@@ -205,6 +207,10 @@ impl ProcessExt for Process {
         self.memory
     }
 
+    fn virtual_memory(&self) -> u64 {
+        self.virtual_memory
+    }
+
     fn parent(&self) -> Option<Pid> {
         self.parent
     }
@@ -242,6 +248,7 @@ impl Debug for Process {
         writeln!(f, "current working directory: {:?}", self.cwd);
         writeln!(f, "owner/group: {}:{}", self.uid, self.gid);
         writeln!(f, "memory usage: {} kB", self.memory);
+        writeln!(f, "virtual memory usage: {} kB", self.virtual_memory);
         writeln!(f, "cpu usage: {}%", self.cpu_usage);
         writeln!(f, "status: {}", match self.status {
             Some(ref v) => v.to_string(),

--- a/src/mac/system.rs
+++ b/src/mac/system.rs
@@ -357,7 +357,8 @@ fn update_process(wrap: &Wrap, pid: Pid,
             let time = ffi::mach_absolute_time();
             compute_cpu_usage(p, time, task_time);
 
-            p.memory = task_info.pti_resident_size >> 10; // divide by 1024
+            p.memory = task_info.pti_resident_size >> 10;        // divide by 1024
+            p.virtual_memory = task_info.pti_virtual_size >> 10; // divide by 1024
             return Ok(None);
         }
 
@@ -410,7 +411,8 @@ fn update_process(wrap: &Wrap, pid: Pid,
         let mut p = Process::new(pid,
                                  parent,
                                  task_info.pbsd.pbi_start_tvsec);
-        p.memory = task_info.ptinfo.pti_resident_size >> 10; // divide by 1024
+        p.memory = task_info.ptinfo.pti_resident_size >> 10;        // divide by 1024
+        p.virtual_memory = task_info.ptinfo.pti_virtual_size >> 10; // divide by 1024
 
         p.uid = task_info.pbsd.pbi_uid;
         p.gid = task_info.pbsd.pbi_gid;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -79,6 +79,9 @@ pub trait ProcessExt {
     /// Returns the memory usage (in kB).
     fn memory(&self) -> u64;
 
+    /// Returns the virtual memory usage (in kB).
+    fn virtual_memory(&self) -> u64;
+
     /// Returns the parent pid.
     fn parent(&self) -> Option<Pid>;
 

--- a/src/unknown/process.rs
+++ b/src/unknown/process.rs
@@ -63,6 +63,10 @@ impl ProcessExt for Process {
         0
     }
 
+    fn virtual_memory(&self) -> u64 {
+        0
+    }
+
     fn parent(&self) -> Option<Pid> {
         self.parent
     }


### PR DESCRIPTION
This adds virtual memory usage to Linux / OSX / Windows and changes Windows to use the WorkingSetSize for its resident memory usage stat.

Builds without error on Windows and Linux, however I'm unable to test building on OSX.