### PR TITLE
Replace Windows panic's with print output and make sure that Windows InternalQuery cleans up when dropped

### DIFF
--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -166,7 +166,7 @@ impl SystemExt for System {
                                         0)
                 };
                 if status != PDH_MORE_DATA as i32 {
-                    panic!("got invalid status: {:x}", status);
+                    eprintln!("PdhEnumObjectItems invalid status: {:x}", status);
                 }
                 let mut pwsCounterListBuffer: Vec<u16> = Vec::with_capacity(dwCounterListSize as usize);
                 let mut pwsInstanceListBuffer: Vec<u16> = Vec::with_capacity(dwInstanceListSize as usize);
@@ -186,7 +186,7 @@ impl SystemExt for System {
                                         0)
                 };
                 if status != ERROR_SUCCESS as i32 {
-                    panic!("got invalid status: {:x}", status);
+                    eprintln!("PdhEnumObjectItems invalid status: {:x}", status);
                 }
 
                 for (pos, x) in pwsInstanceListBuffer.split(|x| *x == 0)

--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -175,68 +175,69 @@ impl SystemExt for System {
                 };
                 if status != PDH_MORE_DATA as i32 {
                     eprintln!("PdhEnumObjectItems invalid status: {:x}", status);
-                }
-                let mut pwsCounterListBuffer: Vec<u16> =
-                    Vec::with_capacity(dwCounterListSize as usize);
-                let mut pwsInstanceListBuffer: Vec<u16> =
-                    Vec::with_capacity(dwInstanceListSize as usize);
-                unsafe {
-                    pwsCounterListBuffer.set_len(dwCounterListSize as usize);
-                    pwsInstanceListBuffer.set_len(dwInstanceListSize as usize);
-                }
-                let status = unsafe {
-                    PdhEnumObjectItemsW(
-                        ::std::ptr::null(),
-                        ::std::ptr::null(),
-                        network_trans_utf16.as_ptr(),
-                        pwsCounterListBuffer.as_mut_ptr(),
-                        &mut dwCounterListSize,
-                        pwsInstanceListBuffer.as_mut_ptr(),
-                        &mut dwInstanceListSize,
-                        PERF_DETAIL_WIZARD,
-                        0,
-                    )
-                };
-                if status != ERROR_SUCCESS as i32 {
-                    eprintln!("PdhEnumObjectItems invalid status: {:x}", status);
-                }
-
-                for (pos, x) in pwsInstanceListBuffer
-                    .split(|x| *x == 0)
-                    .filter(|x| x.len() > 0)
-                    .enumerate()
-                {
-                    let net_interface = String::from_utf16(x).expect("invalid utf16");
-                    if let Some(ref network_in_trans) = network_in_trans {
-                        let mut key_in = None;
-                        add_counter(
-                            format!(
-                                "\\{}({})\\{}",
-                                network_trans, net_interface, network_in_trans
-                            ),
-                            query,
-                            &mut key_in,
-                            format!("net{}_in", pos),
-                            CounterValue::Integer(0),
-                        );
-                        if key_in.is_some() {
-                            network::get_keys_in(&mut s.network).push(key_in.unwrap());
-                        }
+                } else {
+                    let mut pwsCounterListBuffer: Vec<u16> =
+                        Vec::with_capacity(dwCounterListSize as usize);
+                    let mut pwsInstanceListBuffer: Vec<u16> =
+                        Vec::with_capacity(dwInstanceListSize as usize);
+                    unsafe {
+                        pwsCounterListBuffer.set_len(dwCounterListSize as usize);
+                        pwsInstanceListBuffer.set_len(dwInstanceListSize as usize);
                     }
-                    if let Some(ref network_out_trans) = network_out_trans {
-                        let mut key_out = None;
-                        add_counter(
-                            format!(
-                                "\\{}({})\\{}",
-                                network_trans, net_interface, network_out_trans
-                            ),
-                            query,
-                            &mut key_out,
-                            format!("net{}_out", pos),
-                            CounterValue::Integer(0),
-                        );
-                        if key_out.is_some() {
-                            network::get_keys_out(&mut s.network).push(key_out.unwrap());
+                    let status = unsafe {
+                        PdhEnumObjectItemsW(
+                            ::std::ptr::null(),
+                            ::std::ptr::null(),
+                            network_trans_utf16.as_ptr(),
+                            pwsCounterListBuffer.as_mut_ptr(),
+                            &mut dwCounterListSize,
+                            pwsInstanceListBuffer.as_mut_ptr(),
+                            &mut dwInstanceListSize,
+                            PERF_DETAIL_WIZARD,
+                            0,
+                        )
+                    };
+                    if status != ERROR_SUCCESS as i32 {
+                        eprintln!("PdhEnumObjectItems invalid status: {:x}", status);
+                    } else {
+                        for (pos, x) in pwsInstanceListBuffer
+                            .split(|x| *x == 0)
+                            .filter(|x| x.len() > 0)
+                            .enumerate()
+                        {
+                            let net_interface = String::from_utf16(x).expect("invalid utf16");
+                            if let Some(ref network_in_trans) = network_in_trans {
+                                let mut key_in = None;
+                                add_counter(
+                                    format!(
+                                        "\\{}({})\\{}",
+                                        network_trans, net_interface, network_in_trans
+                                    ),
+                                    query,
+                                    &mut key_in,
+                                    format!("net{}_in", pos),
+                                    CounterValue::Integer(0),
+                                );
+                                if key_in.is_some() {
+                                    network::get_keys_in(&mut s.network).push(key_in.unwrap());
+                                }
+                            }
+                            if let Some(ref network_out_trans) = network_out_trans {
+                                let mut key_out = None;
+                                add_counter(
+                                    format!(
+                                        "\\{}({})\\{}",
+                                        network_trans, net_interface, network_out_trans
+                                    ),
+                                    query,
+                                    &mut key_out,
+                                    format!("net{}_out", pos),
+                                    CounterValue::Integer(0),
+                                );
+                                if key_out.is_some() {
+                                    network::get_keys_out(&mut s.network).push(key_out.unwrap());
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
I noticed that InternalQuery never cleans up the handles and counters it's holding so I've added an impl Drop for it. We also had some issues here with the panics in the Windows System impl so I've replaced those with eprintln and only progress further on success.