### PR TITLE
Replace all "kB" with "KiB"

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ cargo build --target=armv7-unknown-linux-gnueabihf
 You have an example into the `examples` folder. Just run `cargo run` inside the `examples` folder to start it. Otherwise, here is a little code sample:
 
 ```rust
-extern crate sysinfo;
-
 use sysinfo::{NetworkExt, System, SystemExt};
 
 let mut sys = System::new();
@@ -56,10 +54,10 @@ for component in sys.get_components_list() {
 }
 
 // Memory information:
-println!("total memory: {} kB", sys.get_total_memory());
-println!("used memory : {} kB", sys.get_used_memory());
-println!("total swap  : {} kB", sys.get_total_swap());
-println!("used swap   : {} kB", sys.get_used_swap());
+println!("total memory: {} KiB", sys.get_total_memory());
+println!("used memory : {} KiB", sys.get_used_memory());
+println!("total swap  : {} KiB", sys.get_total_swap());
+println!("used swap   : {} KiB", sys.get_used_swap());
 
 // Number of processors
 println!("NB processors: {}", sys.get_processor_list().len());

--- a/examples/src/simple.rs
+++ b/examples/src/simple.rs
@@ -67,10 +67,10 @@ fn interpret_input(input: &str, sys: &mut System) -> bool {
             }
         }
         "memory" => {
-            writeln!(&mut io::stdout(), "total memory: {} kB", sys.get_total_memory());
-            writeln!(&mut io::stdout(), "used memory : {} kB", sys.get_used_memory());
-            writeln!(&mut io::stdout(), "total swap  : {} kB", sys.get_total_swap());
-            writeln!(&mut io::stdout(), "used swap   : {} kB", sys.get_used_swap());
+            writeln!(&mut io::stdout(), "total memory: {} KiB", sys.get_total_memory());
+            writeln!(&mut io::stdout(), "used memory : {} KiB", sys.get_used_memory());
+            writeln!(&mut io::stdout(), "total swap  : {} KiB", sys.get_total_swap());
+            writeln!(&mut io::stdout(), "used swap   : {} KiB", sys.get_used_swap());
         }
         "quit" | "exit" => return true,
         "all" => {

--- a/src/linux/process.rs
+++ b/src/linux/process.rs
@@ -246,8 +246,8 @@ impl Debug for Process {
         writeln!(f, "executable path: {:?}", self.exe);
         writeln!(f, "current working directory: {:?}", self.cwd);
         writeln!(f, "owner/group: {}:{}", self.uid, self.gid);
-        writeln!(f, "memory usage: {} kB", self.memory);
-        writeln!(f, "virtual memory usage: {} kB", self.virtual_memory);
+        writeln!(f, "memory usage: {} KiB", self.memory);
+        writeln!(f, "virtual memory usage: {} KiB", self.virtual_memory);
         writeln!(f, "cpu usage: {}%", self.cpu_usage);
         writeln!(f, "status: {}", self.status);
         write!(f, "root path: {:?}", self.root)

--- a/src/mac/process.rs
+++ b/src/mac/process.rs
@@ -321,8 +321,8 @@ impl Debug for Process {
         writeln!(f, "executable path: {:?}", self.exe);
         writeln!(f, "current working directory: {:?}", self.cwd);
         writeln!(f, "owner/group: {}:{}", self.uid, self.gid);
-        writeln!(f, "memory usage: {} kB", self.memory);
-        writeln!(f, "virtual memory usage: {} kB", self.virtual_memory);
+        writeln!(f, "memory usage: {} KiB", self.memory);
+        writeln!(f, "virtual memory usage: {} KiB", self.virtual_memory);
         writeln!(f, "cpu usage: {}%", self.cpu_usage);
         writeln!(
             f,

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -35,10 +35,10 @@
 //! }
 //!
 //! // And finally the RAM and SWAP information:
-//! println!("total memory: {} kB", system.get_total_memory());
-//! println!("used memory : {} kB", system.get_used_memory());
-//! println!("total swap  : {} kB", system.get_total_swap());
-//! println!("used swap   : {} kB", system.get_used_swap());
+//! println!("total memory: {} KiB", system.get_total_memory());
+//! println!("used memory : {} KiB", system.get_used_memory());
+//! println!("total swap  : {} KiB", system.get_total_swap());
+//! println!("used swap   : {} KiB", system.get_used_swap());
 //! ```
 
 #![crate_name = "sysinfo"]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -76,10 +76,10 @@ pub trait ProcessExt {
     /// Always empty on Windows.
     fn root(&self) -> &Path;
 
-    /// Returns the memory usage (in kB).
+    /// Returns the memory usage (in KiB).
     fn memory(&self) -> u64;
 
-    /// Returns the virtual memory usage (in kB).
+    /// Returns the virtual memory usage (in KiB).
     fn virtual_memory(&self) -> u64;
 
     /// Returns the parent pid.

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -374,8 +374,8 @@ impl Debug for Process {
         }
         writeln!(f, "executable path: {:?}", self.exe);
         writeln!(f, "current working directory: {:?}", self.cwd);
-        writeln!(f, "memory usage: {} kB", self.memory);
-        writeln!(f, "virtual memory usage: {} kB", self.virtual_memory);
+        writeln!(f, "memory usage: {} KiB", self.memory);
+        writeln!(f, "virtual memory usage: {} KiB", self.virtual_memory);
         writeln!(f, "cpu usage: {}", self.cpu_usage);
         writeln!(f, "root path: {:?}", self.root)
     }

--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -272,7 +272,7 @@ impl SystemExt for System {
     }
 
     fn refresh_processes(&mut self) {
-        // Windows 10 notebook requires at least 512kb of memory to make it in one go
+        // Windows 10 notebook requires at least 512KiB of memory to make it in one go
         let mut buffer_size: usize = 512 * 1024;
 
         loop {


### PR DESCRIPTION
This is about closing issue #239. "KiB" should be the correct unit for everywhere it previously said _kB_, but I have not verified it for `sysinfo::ProcessExt::virtual_memory`.