### PR TITLE
Add Process disk usage (bytes read/written)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ doc-comment = "0.3"
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["fileapi", "handleapi", "ioapiset", "minwindef", "pdh", "psapi", "synchapi", "sysinfoapi", "winbase", "winerror", "winioctl", "winnt", "oleauto", "wbemcli", "rpcdce", "combaseapi", "objidl", "objbase"] }
 ntapi = "0.3"
+winrt = { version = "0.6.0", features = ["windows-system"]}
 
 [target.'cfg(not(any(target_os = "unknown", target_arch = "wasm32")))'.dependencies]
 libc = "0.2"

--- a/src/linux/process.rs
+++ b/src/linux/process.rs
@@ -124,6 +124,8 @@ pub struct Process {
     /// Tasks run by this process.
     pub tasks: HashMap<Pid, Process>,
     pub(crate) stat_file: Option<File>,
+    pub read_bytes: u64,
+    pub write_bytes: u64
 }
 
 impl ProcessExt for Process {
@@ -155,6 +157,8 @@ impl ProcessExt for Process {
                 HashMap::new()
             },
             stat_file: None,
+            read_bytes: 0,
+            write_bytes: 0
         }
     }
 

--- a/src/linux/process.rs
+++ b/src/linux/process.rs
@@ -125,7 +125,7 @@ pub struct Process {
     pub tasks: HashMap<Pid, Process>,
     pub(crate) stat_file: Option<File>,
     pub(crate) read_bytes: u64,
-    pub(crate) written_bytes: u64
+    pub(crate) written_bytes: u64,
 }
 
 impl ProcessExt for Process {
@@ -158,7 +158,7 @@ impl ProcessExt for Process {
             },
             stat_file: None,
             read_bytes: 0,
-            written_bytes: 0
+            written_bytes: 0,
         }
     }
 
@@ -220,11 +220,11 @@ impl ProcessExt for Process {
         self.cpu_usage
     }
 
-    fn read_bytes(&self) -> u64{
+    fn read_bytes(&self) -> u64 {
         self.read_bytes
     }
 
-    fn written_bytes(&self) -> u64{
+    fn written_bytes(&self) -> u64 {
         self.written_bytes
     }
 }

--- a/src/linux/process.rs
+++ b/src/linux/process.rs
@@ -124,8 +124,8 @@ pub struct Process {
     /// Tasks run by this process.
     pub tasks: HashMap<Pid, Process>,
     pub(crate) stat_file: Option<File>,
-    pub read_bytes: u64,
-    pub write_bytes: u64
+    pub(crate) read_bytes: u64,
+    pub(crate) written_bytes: u64
 }
 
 impl ProcessExt for Process {
@@ -158,7 +158,7 @@ impl ProcessExt for Process {
             },
             stat_file: None,
             read_bytes: 0,
-            write_bytes: 0
+            written_bytes: 0
         }
     }
 
@@ -218,6 +218,14 @@ impl ProcessExt for Process {
 
     fn cpu_usage(&self) -> f32 {
         self.cpu_usage
+    }
+
+    fn read_bytes(&self) -> u64{
+        self.read_bytes
+    }
+
+    fn written_bytes(&self) -> u64{
+        self.written_bytes
     }
 }
 

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -695,18 +695,17 @@ fn _get_process_data(
     Ok(Some(p))
 }
 
-fn update_process_disk_activity(p: &mut Process){
+fn update_process_disk_activity(p: &mut Process) {
     let path = PathBuf::from(format!("/proc/{}/io", p.pid));
-    let data = match get_all_data(&path, 16_384){
+    let data = match get_all_data(&path, 16_384) {
         Ok(d) => d,
-        Err(_) => return
+        Err(_) => return,
     };
     let data: Vec<Vec<&str>> = data.split("\n").map(|l| l.split(": ").collect()).collect();
-    for d in data.iter(){
-        if d[0] == "read_bytes"{
+    for d in data.iter() {
+        if d[0] == "read_bytes" {
             p.read_bytes = d[1].parse::<u64>().unwrap_or(0);
-        }
-        else if d[0] == "write_bytes"{
+        } else if d[0] == "write_bytes" {
             p.written_bytes = d[1].parse::<u64>().unwrap_or(0);
         }
     }

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -607,6 +607,7 @@ fn _get_process_data(
             uptime,
             now,
         );
+        update_process_disk_activity(entry);
         return Ok(None);
     }
 
@@ -690,7 +691,25 @@ fn _get_process_data(
         uptime,
         now,
     );
+    update_process_disk_activity(&mut p);
     Ok(Some(p))
+}
+
+fn update_process_disk_activity(p: &mut Process){
+    let path = PathBuf::from(format!("/proc/{}/io", p.pid));
+    let data = match get_all_data(&path, 16_384){
+        Ok(d) => d,
+        Err(_) => return
+    };
+    let data: Vec<Vec<&str>> = data.split("\n").map(|l| l.split(": ").collect()).collect();
+    for d in data.iter(){
+        if d[0] == "read_bytes"{
+            p.read_bytes = d[1].parse::<u64>().unwrap_or(0);
+        }
+        else if d[0] == "write_bytes"{
+            p.write_bytes = d[1].parse::<u64>().unwrap_or(0);
+        }
+    }
 }
 
 fn copy_from_file(entry: &Path) -> Vec<String> {

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -707,7 +707,7 @@ fn update_process_disk_activity(p: &mut Process){
             p.read_bytes = d[1].parse::<u64>().unwrap_or(0);
         }
         else if d[0] == "write_bytes"{
-            p.write_bytes = d[1].parse::<u64>().unwrap_or(0);
+            p.written_bytes = d[1].parse::<u64>().unwrap_or(0);
         }
     }
 }

--- a/src/mac/ffi.rs
+++ b/src/mac/ffi.rs
@@ -87,6 +87,11 @@ extern "C" {
 // pub fn proc_name(pid: i32, buf: *mut i8, bufsize: u32) -> i32;
 }
 
+#[link(name = "proc", kind = "dylib")]
+extern {
+    pub fn proc_pid_rusage(pid: c_int, flavor: c_int, buffer: *mut c_void) -> c_int;
+}
+
 // TODO: waiting for https://github.com/rust-lang/libc/pull/678
 macro_rules! cfg_if {
     ($(
@@ -340,6 +345,31 @@ pub struct xsw_usage {
     pub xsu_used: u64,
     pub xsu_pagesize: u32,
     pub xsu_encrypted: boolean_t,
+}
+
+//https://github.com/andrewdavidmackenzie/libproc-rs/blob/master/src/libproc/pid_rusage.rs
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct RUsageInfoV2 {
+    pub ri_uuid                 : [u8; 16],
+    pub ri_user_time            : u64,
+    pub ri_system_time          : u64,
+    pub ri_pkg_idle_wkups       : u64,
+    pub ri_interrupt_wkups      : u64,
+    pub ri_pageins              : u64,
+    pub ri_wired_size           : u64,
+    pub ri_resident_size        : u64,
+    pub ri_phys_footprint       : u64,
+    pub ri_proc_start_abstime   : u64,
+    pub ri_proc_exit_abstime    : u64,
+    pub ri_child_user_time      : u64,
+    pub ri_child_system_time    : u64,
+    pub ri_child_pkg_idle_wkups : u64,
+    pub ri_child_interrupt_wkups: u64,
+    pub ri_child_pageins        : u64,
+    pub ri_child_elapsed_abstime: u64,
+    pub ri_diskio_bytesread     : u64,
+    pub ri_diskio_byteswritten  : u64,
 }
 
 //pub const HOST_CPU_LOAD_INFO_COUNT: usize = 4;

--- a/src/mac/ffi.rs
+++ b/src/mac/ffi.rs
@@ -88,7 +88,7 @@ extern "C" {
 }
 
 #[link(name = "proc", kind = "dylib")]
-extern {
+extern "C" {
     pub fn proc_pid_rusage(pid: c_int, flavor: c_int, buffer: *mut c_void) -> c_int;
 }
 
@@ -351,25 +351,25 @@ pub struct xsw_usage {
 #[repr(C)]
 #[derive(Debug, Default)]
 pub struct RUsageInfoV2 {
-    pub ri_uuid                 : [u8; 16],
-    pub ri_user_time            : u64,
-    pub ri_system_time          : u64,
-    pub ri_pkg_idle_wkups       : u64,
-    pub ri_interrupt_wkups      : u64,
-    pub ri_pageins              : u64,
-    pub ri_wired_size           : u64,
-    pub ri_resident_size        : u64,
-    pub ri_phys_footprint       : u64,
-    pub ri_proc_start_abstime   : u64,
-    pub ri_proc_exit_abstime    : u64,
-    pub ri_child_user_time      : u64,
-    pub ri_child_system_time    : u64,
-    pub ri_child_pkg_idle_wkups : u64,
+    pub ri_uuid: [u8; 16],
+    pub ri_user_time: u64,
+    pub ri_system_time: u64,
+    pub ri_pkg_idle_wkups: u64,
+    pub ri_interrupt_wkups: u64,
+    pub ri_pageins: u64,
+    pub ri_wired_size: u64,
+    pub ri_resident_size: u64,
+    pub ri_phys_footprint: u64,
+    pub ri_proc_start_abstime: u64,
+    pub ri_proc_exit_abstime: u64,
+    pub ri_child_user_time: u64,
+    pub ri_child_system_time: u64,
+    pub ri_child_pkg_idle_wkups: u64,
     pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins        : u64,
+    pub ri_child_pageins: u64,
     pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread     : u64,
-    pub ri_diskio_byteswritten  : u64,
+    pub ri_diskio_bytesread: u64,
+    pub ri_diskio_byteswritten: u64,
 }
 
 //pub const HOST_CPU_LOAD_INFO_COUNT: usize = 4;

--- a/src/mac/process.rs
+++ b/src/mac/process.rs
@@ -149,6 +149,9 @@ pub struct Process {
     ///
     /// This is very likely this one that you want instead of `process_status`.
     pub status: Option<ThreadStatus>,
+    pub read_bytes: u64,
+    pub write_bytes: u64
+ }
 }
 
 impl Process {
@@ -179,6 +182,8 @@ impl Process {
             gid: 0,
             process_status: ProcessStatus::Unknown(0),
             status: None,
+            read_bytes: 0,
+            write_bytes: 0
         }
     }
 
@@ -422,6 +427,7 @@ pub(crate) fn update_process(
 
             p.memory = task_info.pti_resident_size >> 10; // divide by 1024
             p.virtual_memory = task_info.pti_virtual_size >> 10; // divide by 1024
+            update_proc_disk_activity(&mut p);
             return Ok(None);
         }
 
@@ -606,8 +612,25 @@ pub(crate) fn update_process(
         p.uid = info.pbi_uid;
         p.gid = info.pbi_gid;
         p.process_status = ProcessStatus::from(info.pbi_status);
-
+        update_proc_disk_activity(p);
         Ok(Some(p))
+    }
+}
+
+fn update_proc_disk_activity(p: &mut Process){
+    let mut pidrusage = ffi::RUsageInfoV2::default();
+    let ptr = &mut pidrusage as *mut _ as *mut c_void;
+    let retval: i32;
+    unsafe{
+        retval = ffi::proc_pid_rusage(p.pid() as c_int, 2, ptr);
+    }
+
+    if retval < 0{
+        panic!("proc_pid_rusage failed: {:?}", retval);
+    }
+    else{
+        p.read_bytes = pidrusage.ri_diskio_bytesread;
+        p.write_bytes = pidrusage.ri_diskio_byteswritten;
     }
 }
 

--- a/src/mac/process.rs
+++ b/src/mac/process.rs
@@ -150,15 +150,11 @@ pub struct Process {
     /// This is very likely this one that you want instead of `process_status`.
     pub status: Option<ThreadStatus>,
     pub(crate) read_bytes: u64,
-    pub(crate) written_bytes: u64
+    pub(crate) written_bytes: u64,
 }
 
 impl Process {
-    pub(crate) fn new_empty(
-        pid: Pid,
-        exe: PathBuf,
-        name: String,
-    ) -> Process {
+    pub(crate) fn new_empty(pid: Pid, exe: PathBuf, name: String) -> Process {
         Process {
             name,
             pid,
@@ -182,7 +178,7 @@ impl Process {
             process_status: ProcessStatus::Unknown(0),
             status: None,
             read_bytes: 0,
-            written_bytes: 0
+            written_bytes: 0,
         }
     }
 
@@ -219,7 +215,7 @@ impl Process {
             process_status: ProcessStatus::Unknown(0),
             status: None,
             read_bytes: 0,
-            written_bytes: 0
+            written_bytes: 0,
         }
     }
 }
@@ -249,7 +245,7 @@ impl ProcessExt for Process {
             process_status: ProcessStatus::Unknown(0),
             status: None,
             read_bytes: 0,
-            written_bytes: 0
+            written_bytes: 0,
         }
     }
 
@@ -309,11 +305,11 @@ impl ProcessExt for Process {
         self.cpu_usage
     }
 
-    fn read_bytes(&self) -> u64{
+    fn read_bytes(&self) -> u64 {
         self.read_bytes
     }
 
-    fn written_bytes(&self) -> u64{
+    fn written_bytes(&self) -> u64 {
         self.written_bytes
     }
 }
@@ -452,7 +448,11 @@ pub(crate) fn update_process(
         ) != mem::size_of::<libc::proc_bsdinfo>() as _
         {
             let mut buffer: Vec<u8> = Vec::with_capacity(ffi::PROC_PIDPATHINFO_MAXSIZE as _);
-            match ffi::proc_pidpath(pid, buffer.as_mut_ptr() as *mut _, ffi::PROC_PIDPATHINFO_MAXSIZE) {
+            match ffi::proc_pidpath(
+                pid,
+                buffer.as_mut_ptr() as *mut _,
+                ffi::PROC_PIDPATHINFO_MAXSIZE,
+            ) {
                 x if x > 0 => {
                     buffer.set_len(x as _);
                     let tmp = String::from_utf8_unchecked(buffer);
@@ -628,18 +628,17 @@ pub(crate) fn update_process(
     }
 }
 
-fn update_proc_disk_activity(p: &mut Process){
+fn update_proc_disk_activity(p: &mut Process) {
     let mut pidrusage = ffi::RUsageInfoV2::default();
     let ptr = &mut pidrusage as *mut _ as *mut c_void;
     let retval: i32;
-    unsafe{
+    unsafe {
         retval = ffi::proc_pid_rusage(p.pid() as c_int, 2, ptr);
     }
 
-    if retval < 0{
+    if retval < 0 {
         panic!("proc_pid_rusage failed: {:?}", retval);
-    }
-    else{
+    } else {
         p.read_bytes = pidrusage.ri_diskio_bytesread;
         p.written_bytes = pidrusage.ri_diskio_byteswritten;
     }

--- a/src/mac/process.rs
+++ b/src/mac/process.rs
@@ -149,8 +149,8 @@ pub struct Process {
     ///
     /// This is very likely this one that you want instead of `process_status`.
     pub status: Option<ThreadStatus>,
-    pub read_bytes: u64,
-    pub write_bytes: u64
+    pub(crate) read_bytes: u64,
+    pub(crate) written_bytes: u64
 }
 
 impl Process {
@@ -182,7 +182,7 @@ impl Process {
             process_status: ProcessStatus::Unknown(0),
             status: None,
             read_bytes: 0,
-            write_bytes: 0
+            written_bytes: 0
         }
     }
 
@@ -219,7 +219,7 @@ impl Process {
             process_status: ProcessStatus::Unknown(0),
             status: None,
             read_bytes: 0,
-            write_bytes: 0
+            written_bytes: 0
         }
     }
 }
@@ -249,7 +249,7 @@ impl ProcessExt for Process {
             process_status: ProcessStatus::Unknown(0),
             status: None,
             read_bytes: 0,
-            write_bytes: 0
+            written_bytes: 0
         }
     }
 
@@ -307,6 +307,14 @@ impl ProcessExt for Process {
 
     fn cpu_usage(&self) -> f32 {
         self.cpu_usage
+    }
+
+    fn read_bytes(&self) -> u64{
+        self.read_bytes
+    }
+
+    fn written_bytes(&self) -> u64{
+        self.written_bytes
     }
 }
 
@@ -633,7 +641,7 @@ fn update_proc_disk_activity(p: &mut Process){
     }
     else{
         p.read_bytes = pidrusage.ri_diskio_bytesread;
-        p.write_bytes = pidrusage.ri_diskio_byteswritten;
+        p.written_bytes = pidrusage.ri_diskio_byteswritten;
     }
 }
 

--- a/src/mac/process.rs
+++ b/src/mac/process.rs
@@ -151,7 +151,6 @@ pub struct Process {
     pub status: Option<ThreadStatus>,
     pub read_bytes: u64,
     pub write_bytes: u64
- }
 }
 
 impl Process {
@@ -219,6 +218,8 @@ impl Process {
             gid: 0,
             process_status: ProcessStatus::Unknown(0),
             status: None,
+            read_bytes: 0,
+            write_bytes: 0
         }
     }
 }
@@ -247,6 +248,8 @@ impl ProcessExt for Process {
             gid: 0,
             process_status: ProcessStatus::Unknown(0),
             status: None,
+            read_bytes: 0,
+            write_bytes: 0
         }
     }
 
@@ -427,7 +430,7 @@ pub(crate) fn update_process(
 
             p.memory = task_info.pti_resident_size >> 10; // divide by 1024
             p.virtual_memory = task_info.pti_virtual_size >> 10; // divide by 1024
-            update_proc_disk_activity(&mut p);
+            update_proc_disk_activity(p);
             return Ok(None);
         }
 
@@ -612,7 +615,7 @@ pub(crate) fn update_process(
         p.uid = info.pbi_uid;
         p.gid = info.pbi_gid;
         p.process_status = ProcessStatus::from(info.pbi_status);
-        update_proc_disk_activity(p);
+        update_proc_disk_activity(&mut p);
         Ok(Some(p))
     }
 }

--- a/src/mac/system.rs
+++ b/src/mac/system.rs
@@ -288,15 +288,9 @@ impl SystemExt for System {
             let entries: Vec<Process> = {
                 let wrap = &Wrap(UnsafeCell::new(&mut self.process_list));
                 pids.par_iter()
-                    .flat_map(|pid| {
-                        match update_process(
-                            wrap,
-                            *pid,
-                            arg_max as size_t,
-                        ) {
-                            Ok(x) => x,
-                            Err(_) => None,
-                        }
+                    .flat_map(|pid| match update_process(wrap, *pid, arg_max as size_t) {
+                        Ok(x) => x,
+                        Err(_) => None,
                     })
                     .collect()
             };
@@ -311,11 +305,7 @@ impl SystemExt for System {
         let arg_max = get_arg_max();
         match {
             let wrap = Wrap(UnsafeCell::new(&mut self.process_list));
-            update_process(
-                &wrap,
-                pid,
-                arg_max as size_t,
-            )
+            update_process(&wrap, pid, arg_max as size_t)
         } {
             Ok(Some(p)) => {
                 self.process_list.insert(p.pid(), p);

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -69,6 +69,7 @@ cfg_if! {
         use windows as sys;
         extern crate winapi;
         extern crate ntapi;
+        extern crate winrt;
     } else if #[cfg(unix)] {
         mod linux;
         use linux as sys;

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -44,7 +44,7 @@
 #![crate_name = "sysinfo"]
 #![crate_type = "lib"]
 #![crate_type = "rlib"]
-#![warn(missing_docs)]
+#![deny(missing_docs)]
 //#![deny(warnings)]
 #![allow(unknown_lints)]
 

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -44,7 +44,7 @@
 #![crate_name = "sysinfo"]
 #![crate_type = "lib"]
 #![crate_type = "rlib"]
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 //#![deny(warnings)]
 #![allow(unknown_lints)]
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -93,6 +93,12 @@ pub trait ProcessExt {
 
     /// Returns the total CPU usage.
     fn cpu_usage(&self) -> f32;
+
+    /// Returns number of bytes read from disk
+    fn read_bytes(&self) -> u64;
+
+    /// Returns number of bytes written to disk
+    fn written_bytes(&self) -> u64;
 }
 
 /// Contains all the methods of the `Processor` struct.

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -106,8 +106,8 @@ pub struct Process {
     start_time: u64,
     cpu_usage: f32,
     pub(crate) updated: bool,
-    pub read_bytes: u64,
-    pub write_bytes: u64
+    pub(crate) read_bytes: u64,
+    pub(crate) written_bytes: u64
 }
 
 unsafe fn get_process_name(process_handler: HANDLE, h_mod: *mut c_void) -> String {
@@ -197,7 +197,7 @@ impl Process {
                     start_time: get_start_time(process_handler),
                     updated: true,
                     read_bytes: 0,
-                    write_bytes: 0
+                    written_bytes: 0
                 }
             }
         } else {
@@ -221,7 +221,7 @@ impl Process {
                 start_time: 0,
                 updated: true,
                 read_bytes: 0,
-                write_bytes: 0
+                written_bytes: 0
             }
         }
     }
@@ -268,7 +268,7 @@ impl ProcessExt for Process {
                     start_time: get_start_time(process_handler),
                     updated: true,
                     read_bytes: 0,
-                    write_bytes: 0
+                    written_bytes: 0
                 }
             }
         } else {
@@ -292,7 +292,7 @@ impl ProcessExt for Process {
                 start_time: 0,
                 updated: true,
                 read_bytes: 0,
-                write_bytes: 0
+                written_bytes: 0
             }
         }
     }
@@ -570,7 +570,7 @@ pub(crate) fn get_disk_usage(p: &mut Process){
                                 p.read_bytes = read_bytes.unwrap() as u64;
                             }
                             if write_bytes.is_some(){
-                                p.write_bytes = write_bytes.unwrap() as u64;
+                                p.written_bytes = write_bytes.unwrap() as u64;
                             }
                         }
                     }

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -559,35 +559,37 @@ pub(crate) fn get_system_computation_time() -> ULARGE_INTEGER {
 }
 
 pub(crate) fn get_disk_usage(p: &mut Process){
-    let r = ProcessDiagnosticInfo::try_get_for_process_id(p.pid as u32).ok();
-    if r.is_some(){
-        let r = r.unwrap();
-        if r.is_some(){
-            let du = r.unwrap().get_disk_usage().ok();
-            if du.is_some(){
-                let du = du.unwrap();
-                if du.is_some(){
-                    let report = du.unwrap().get_report().ok();
-                    if report.is_some(){
-                        let report = report.unwrap();
-                        if report.is_some(){
-                            let report = report.unwrap();
-                            let read_bytes = report.get_bytes_read_count().ok();
-                            let write_bytes = report.get_bytes_written_count().ok();
-                            if read_bytes.is_some(){
-                                p.read_bytes = read_bytes.unwrap() as u64;
-                            }
-                            if write_bytes.is_some(){
-                                p.written_bytes = write_bytes.unwrap() as u64;
-                            }
-                        }
-                    }
-                }
-            }
-            
-        }
-        
-    }
+    let diag_info = ProcessDiagnosticInfo::try_get_for_process_id(p.pid as u32).ok();
+    match diag_info{
+        Some(diag_info) => match diag_info{
+            Some(diag_info) => match diag_info.get_disk_usage().ok(){
+                Some(disk_usage) => match disk_usage{
+                    Some(disk_usage) => match disk_usage.get_report().ok(){
+                        Some(report) => match report{
+                            Some(report) => {
+                                let read_bytes = report.get_bytes_read_count().ok();
+                                let write_bytes = report.get_bytes_written_count().ok();
+                                match read_bytes{
+                                    Some(read_bytes) => p.read_bytes = read_bytes as u64,
+                                    None => {}
+                                };
+                                match write_bytes{
+                                    Some(write_bytes) => p.written_bytes = write_bytes as u64,
+                                    None => {}
+                                };
+                            },
+                            None => {}
+                        },
+                        None => {}
+                    },
+                    None => {}
+                },
+                None => {}
+            },
+            None => {}
+        },
+        None => {}
+    };
 }
 
 pub(crate) fn compute_cpu_usage(p: &mut Process, nb_processors: u64, now: ULARGE_INTEGER) {

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -27,8 +27,8 @@ use winapi::um::winnt::{
     HANDLE, /*, PWSTR*/ PROCESS_QUERY_INFORMATION, PROCESS_TERMINATE, PROCESS_VM_READ,
     ULARGE_INTEGER, /*THREAD_GET_CONTEXT, THREAD_QUERY_INFORMATION, THREAD_SUSPEND_RESUME,*/
 };
-use winrt::*;
 use winrt::windows::system::diagnostics::*;
+use winrt::*;
 
 /// Enum describing the different status of a process.
 #[derive(Clone, Copy, Debug)]
@@ -107,7 +107,7 @@ pub struct Process {
     cpu_usage: f32,
     pub(crate) updated: bool,
     pub(crate) read_bytes: u64,
-    pub(crate) written_bytes: u64
+    pub(crate) written_bytes: u64,
 }
 
 unsafe fn get_process_name(process_handler: HANDLE, h_mod: *mut c_void) -> String {
@@ -197,7 +197,7 @@ impl Process {
                     start_time: get_start_time(process_handler),
                     updated: true,
                     read_bytes: 0,
-                    written_bytes: 0
+                    written_bytes: 0,
                 }
             }
         } else {
@@ -221,7 +221,7 @@ impl Process {
                 start_time: 0,
                 updated: true,
                 read_bytes: 0,
-                written_bytes: 0
+                written_bytes: 0,
             }
         }
     }
@@ -268,7 +268,7 @@ impl ProcessExt for Process {
                     start_time: get_start_time(process_handler),
                     updated: true,
                     read_bytes: 0,
-                    written_bytes: 0
+                    written_bytes: 0,
                 }
             }
         } else {
@@ -292,7 +292,7 @@ impl ProcessExt for Process {
                 start_time: 0,
                 updated: true,
                 read_bytes: 0,
-                written_bytes: 0
+                written_bytes: 0,
             }
         }
     }
@@ -357,11 +357,11 @@ impl ProcessExt for Process {
         self.cpu_usage
     }
 
-    fn read_bytes(&self) -> u64{
+    fn read_bytes(&self) -> u64 {
         self.read_bytes
     }
 
-    fn written_bytes(&self) -> u64{
+    fn written_bytes(&self) -> u64 {
         self.written_bytes
     }
 }
@@ -558,26 +558,26 @@ pub(crate) fn get_system_computation_time() -> ULARGE_INTEGER {
     }
 }
 
-pub(crate) fn get_disk_usage(p: &mut Process){
+pub(crate) fn get_disk_usage(p: &mut Process) {
     let diag_info = ProcessDiagnosticInfo::try_get_for_process_id(p.pid as u32).ok();
-    match diag_info{
-        Some(diag_info) => match diag_info{
-            Some(diag_info) => match diag_info.get_disk_usage().ok(){
-                Some(disk_usage) => match disk_usage{
-                    Some(disk_usage) => match disk_usage.get_report().ok(){
-                        Some(report) => match report{
+    match diag_info {
+        Some(diag_info) => match diag_info {
+            Some(diag_info) => match diag_info.get_disk_usage().ok() {
+                Some(disk_usage) => match disk_usage {
+                    Some(disk_usage) => match disk_usage.get_report().ok() {
+                        Some(report) => match report {
                             Some(report) => {
                                 let read_bytes = report.get_bytes_read_count().ok();
                                 let write_bytes = report.get_bytes_written_count().ok();
-                                match read_bytes{
+                                match read_bytes {
                                     Some(read_bytes) => p.read_bytes = read_bytes as u64,
                                     None => {}
                                 };
-                                match write_bytes{
+                                match write_bytes {
                                     Some(write_bytes) => p.written_bytes = write_bytes as u64,
                                     None => {}
                                 };
-                            },
+                            }
                             None => {}
                         },
                         None => {}

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -558,38 +558,37 @@ pub(crate) fn get_system_computation_time() -> ULARGE_INTEGER {
     }
 }
 
-pub(crate) fn get_disk_usage(p: &mut Process) {
-    let diag_info = ProcessDiagnosticInfo::try_get_for_process_id(p.pid as u32).ok();
-    match diag_info {
-        Some(diag_info) => match diag_info {
-            Some(diag_info) => match diag_info.get_disk_usage().ok() {
-                Some(disk_usage) => match disk_usage {
-                    Some(disk_usage) => match disk_usage.get_report().ok() {
-                        Some(report) => match report {
-                            Some(report) => {
-                                let read_bytes = report.get_bytes_read_count().ok();
-                                let write_bytes = report.get_bytes_written_count().ok();
-                                match read_bytes {
-                                    Some(read_bytes) => p.read_bytes = read_bytes as u64,
-                                    None => {}
-                                };
-                                match write_bytes {
-                                    Some(write_bytes) => p.written_bytes = write_bytes as u64,
-                                    None => {}
-                                };
-                            }
-                            None => {}
-                        },
-                        None => {}
-                    },
-                    None => {}
-                },
-                None => {}
-            },
-            None => {}
-        },
-        None => {}
+macro_rules! safe_unwrap {
+    ($x:expr) => {
+        match $x {
+            Some(x) => x,
+            None => return,
+        }
     };
+}
+
+macro_rules! safe_unwrap_to_inner {
+    ($x:expr) => {
+        match $x {
+            Some(x) => safe_unwrap!(x),
+            None => return,
+        }
+    };
+}
+
+pub(crate) fn get_disk_usage(p: &mut Process) {
+    let diag_info =
+        safe_unwrap_to_inner!(ProcessDiagnosticInfo::try_get_for_process_id(p.pid as u32).ok());
+    let disk_usage = safe_unwrap_to_inner!(diag_info.get_disk_usage().ok());
+    let report = safe_unwrap_to_inner!(disk_usage.get_report().ok());
+    let read_bytes = report.get_bytes_read_count().ok();
+    let write_bytes = report.get_bytes_written_count().ok();
+    if let Some(rb) = read_bytes {
+        p.read_bytes = rb as u64;
+    }
+    if let Some(wb) = write_bytes {
+        p.written_bytes = wb as u64;
+    }
 }
 
 pub(crate) fn compute_cpu_usage(p: &mut Process, nb_processors: u64, now: ULARGE_INTEGER) {

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -356,6 +356,14 @@ impl ProcessExt for Process {
     fn cpu_usage(&self) -> f32 {
         self.cpu_usage
     }
+
+    fn read_bytes(&self) -> u64{
+        self.read_bytes
+    }
+
+    fn written_bytes(&self) -> u64{
+        self.written_bytes
+    }
 }
 
 impl Drop for Process {

--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -20,7 +20,8 @@ use SystemExt;
 
 use windows::network::{self, NetworkData};
 use windows::process::{
-    compute_cpu_usage, get_handle, get_system_computation_time, update_proc_info, Process, get_disk_usage
+    compute_cpu_usage, get_disk_usage, get_handle, get_system_computation_time, update_proc_info,
+    Process,
 };
 use windows::processor::CounterValue;
 use windows::tools::*;

--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -20,7 +20,7 @@ use SystemExt;
 
 use windows::network::{self, NetworkData};
 use windows::process::{
-    compute_cpu_usage, get_handle, get_system_computation_time, update_proc_info, Process,
+    compute_cpu_usage, get_handle, get_system_computation_time, update_proc_info, Process, get_disk_usage
 };
 use windows::processor::CounterValue;
 use windows::tools::*;
@@ -331,6 +331,7 @@ impl SystemExt for System {
                             proc_.memory = (pi.WorkingSetSize as u64) >> 10u64;
                             proc_.virtual_memory = (pi.VirtualSize as u64) >> 10u64;
                             compute_cpu_usage(proc_, nb_processors, system_time);
+                            get_disk_usage(proc_);
                             proc_.updated = true;
                             return None;
                         }
@@ -346,6 +347,7 @@ impl SystemExt for System {
                             (pi.VirtualSize as u64) >> 10u64,
                             name,
                         );
+                        get_disk_usage(&mut p);
                         compute_cpu_usage(&mut p, nb_processors, system_time);
                         Some(p)
                     })

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -22,7 +22,7 @@ fn test_process() {
 
 #[test]
 fn test_process_disk_usage(){
-    use sysinfo::{ProcessExt, SystemExt};
+    use sysinfo::{ProcessExt, SystemExt, get_current_pid};
     use std::fs::File;
     use std::fs;
     use std::io::prelude::*;
@@ -31,13 +31,8 @@ fn test_process_disk_usage(){
         file.write_all(b"This is a test file\nwith test data.\n").unwrap();
     }
     fs::remove_file("test.txt").ok();
-    let mut system = sysinfo::System::new();
-    system.refresh_processes();
-    let process_list = system.get_process_list();
-    let mut write_bytes: u64 = 0;
-    for p in process_list.values(){
-        write_bytes += p.written_bytes();
-    }
+    let system = sysinfo::System::new();
+    let p = system.get_process(get_current_pid().expect("Failed retrieving current pid.")).expect("failed to get process");
 
-    assert!(write_bytes > 0);
+    assert!(p.written_bytes() > 0);
 }

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -36,7 +36,7 @@ fn test_process_disk_usage(){
     let process_list = system.get_process_list();
     let mut write_bytes: u64 = 0;
     for p in process_list.values(){
-        write_bytes += p.write_bytes;
+        write_bytes += p.written_bytes();
     }
 
     assert!(write_bytes > 0);

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -19,3 +19,25 @@ fn test_process() {
         .values()
         .any(|p| p.exe().to_str().unwrap_or_else(|| "").len() != 0));
 }
+
+#[test]
+fn test_process_disk_usage(){
+    use sysinfo::{ProcessExt, SystemExt};
+    use std::fs::File;
+    use std::fs;
+    use std::io::prelude::*;
+    {
+        let mut file = File::create("test.txt").unwrap();
+        file.write_all(b"This is a test file\nwith test data.\n").unwrap();
+    }
+    fs::remove_file("test.txt").ok();
+    let mut system = sysinfo::System::new();
+    system.refresh_processes();
+    let process_list = system.get_process_list();
+    let mut write_bytes: u64 = 0;
+    for p in process_list.values(){
+        write_bytes += p.write_bytes;
+    }
+
+    assert!(write_bytes > 0);
+}

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -21,18 +21,21 @@ fn test_process() {
 }
 
 #[test]
-fn test_process_disk_usage(){
-    use sysinfo::{ProcessExt, SystemExt, get_current_pid};
-    use std::fs::File;
+fn test_process_disk_usage() {
     use std::fs;
+    use std::fs::File;
     use std::io::prelude::*;
+    use sysinfo::{get_current_pid, ProcessExt, SystemExt};
     {
         let mut file = File::create("test.txt").unwrap();
-        file.write_all(b"This is a test file\nwith test data.\n").unwrap();
+        file.write_all(b"This is a test file\nwith test data.\n")
+            .unwrap();
     }
     fs::remove_file("test.txt").ok();
     let system = sysinfo::System::new();
-    let p = system.get_process(get_current_pid().expect("Failed retrieving current pid.")).expect("failed to get process");
+    let p = system
+        .get_process(get_current_pid().expect("Failed retrieving current pid."))
+        .expect("failed to get process");
 
     assert!(p.written_bytes() > 0);
 }


### PR DESCRIPTION
This PR adds two new fields to process, `read_bytes` and `written_bytes` and accessor methods for `ProcessExt` by the same name for MacOS, Linux, and Windows. In addition, I've added a test for the new functionality.

Please note: For windows, this adds a new dependency with `winrt`. This was the only way I could find to get the information. 