### PR TITLE
Fix error with networks and total outcome on Linux

### DIFF
--- a/src/linux/network.rs
+++ b/src/linux/network.rs
@@ -219,7 +219,7 @@ impl NetworkExt for NetworkData {
     }
 
     fn get_total_outcome(&self) -> u64 {
-        self.rx_bytes as u64
+        self.tx_bytes as u64
     }
 
     fn get_packets_income(&self) -> u64 {


### PR DESCRIPTION
Outcome should be using TX, but on linux it seems to be using RX right now.