### PR TITLE
Get cmd line

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ doc-comment = "0.3"
 once_cell = "1.0"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["fileapi", "handleapi", "ifdef", "ioapiset", "minwindef", "pdh", "psapi", "synchapi", "sysinfoapi", "winbase", "winerror", "winioctl", "winnt", "oleauto", "wbemcli", "rpcdce", "combaseapi", "objidl", "objbase", "powerbase", "netioapi", "memoryapi"] }
+winapi = { version = "0.3", features = ["fileapi", "handleapi", "ifdef", "ioapiset", "minwindef", "pdh", "psapi", "synchapi", "sysinfoapi", "winbase", "winerror", "winioctl", "winnt", "oleauto", "wbemcli", "rpcdce", "combaseapi", "objidl", "objbase", "powerbase", "netioapi", "memoryapi", "shellapi"] }
 ntapi = "0.3"
 
 [target.'cfg(not(any(target_os = "unknown", target_arch = "wasm32")))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ doc-comment = "0.3"
 once_cell = "1.0"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["fileapi", "handleapi", "ifdef", "ioapiset", "minwindef", "pdh", "psapi", "synchapi", "sysinfoapi", "winbase", "winerror", "winioctl", "winnt", "oleauto", "wbemcli", "rpcdce", "combaseapi", "objidl", "objbase", "powerbase", "netioapi"] }
+winapi = { version = "0.3", features = ["fileapi", "handleapi", "ifdef", "ioapiset", "minwindef", "pdh", "psapi", "synchapi", "sysinfoapi", "winbase", "winerror", "winioctl", "winnt", "oleauto", "wbemcli", "rpcdce", "combaseapi", "objidl", "objbase", "powerbase", "netioapi", "memoryapi"] }
 ntapi = "0.3"
 
 [target.'cfg(not(any(target_os = "unknown", target_arch = "wasm32")))'.dependencies]

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -786,7 +786,7 @@ fn copy_from_file(entry: &Path) -> Vec<String> {
                 let mut start = 0;
                 for (pos, x) in data.iter().enumerate() {
                     if *x == 0 {
-                        if pos - start > 1 {
+                        if pos - start >= 1 {
                             if let Ok(s) = ::std::str::from_utf8(&data[start..pos])
                                 .map(|x| x.trim().to_owned())
                             {

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -402,10 +402,6 @@ unsafe fn get_start_time(handle: HANDLE) -> u64 {
     tmp / 10_000_000 - 11_644_473_600
 }
 
-fn parse_cmd_line(cmdline: &str) -> Vec<String> {
-    unimplemented!()
-}
-
 fn get_cmd_line(handle: HANDLE) -> Vec<String> {
     use ntapi::ntpebteb::{PEB, PPEB};
     use ntapi::ntrtl::{PRTL_USER_PROCESS_PARAMETERS, RTL_USER_PROCESS_PARAMETERS};

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -469,7 +469,7 @@ fn get_cmd_line(handle: HANDLE) -> Vec<String> {
         }
         buffer_copy.push(0);
 
-        // Get argc and argv from coomand line
+        // Get argc and argv from command line
         let mut argc = MaybeUninit::<i32>::uninit();
         let argv_p =
             winapi::um::shellapi::CommandLineToArgvW(buffer_copy.as_ptr(), argc.as_mut_ptr());

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -6,7 +6,6 @@
 
 extern crate sysinfo;
 
-#[cfg(not(windows))]
 use sysinfo::ProcessExt;
 use sysinfo::SystemExt;
 
@@ -37,7 +36,18 @@ fn test_process_refresh() {
 
 #[test]
 #[cfg(windows)]
-fn test_get_cmd_line() {}
+fn test_get_cmd_line() {
+    let p = std::process::Command::new("ping")
+        .arg("localhost")
+        .arg("-n")
+        .arg("2")
+        .spawn()
+        .unwrap();
+    let mut s = sysinfo::System::new();
+    s.refresh_processes();
+    let process = s.get_process(p.id() as sysinfo::Pid).unwrap();
+    assert_eq!(process.cmd(), &["ping", "localhost", "-n", "2"]);
+}
 
 #[test]
 #[cfg(not(windows))]

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -34,3 +34,22 @@ fn test_process_refresh() {
         true
     );
 }
+
+#[test]
+#[cfg(windows)]
+fn test_get_cmd_line() {}
+
+#[test]
+#[cfg(not(windows))]
+fn test_get_cmd_line() {
+    let p = std::process::Command::new("timeout")
+        .arg("3")
+        .arg("ping")
+        .arg("localhost")
+        .spawn()
+        .unwrap();
+    let mut s = sysinfo::System::new();
+    s.refresh_processes();
+    let process = s.get_process(p.id() as sysinfo::Pid).unwrap();
+    assert_eq!(process.cmd(), &["timeout", "3", "ping", "localhost"]);
+}


### PR DESCRIPTION
In this PR I implemented those things:
1) Bugfix: in linux cmd() didn't return arguments with length == 1
2) get_cmd_line for windows by ReadProcessMemory
3) cmd() tests. I checked them only in linux and windows.