### PR TITLE
Fix compilation for unknown target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ matrix:
       rust: stable
       dist: trusty
     - os: linux
+      env: TARGET=wasm32-unknown-unknown
+      rust: stable
+      dist: trusty
+    - os: linux
       rust: nightly
       dist: trusty
     - os: linux

--- a/src/unknown/component.rs
+++ b/src/unknown/component.rs
@@ -25,4 +25,7 @@ impl ComponentExt for Component {
     fn get_label(&self) -> &str {
         ""
     }
+
+    fn refresh(&mut self) {
+    }
 }

--- a/src/unknown/processor.rs
+++ b/src/unknown/processor.rs
@@ -4,9 +4,6 @@
 // Copyright (c) 2015 Guillaume Gomez
 //
 
-use std::default::Default;
-
-use LoadAvg;
 use ProcessorExt;
 
 /// Dummy struct that represents a processor.

--- a/src/unknown/system.rs
+++ b/src/unknown/system.rs
@@ -11,6 +11,7 @@ use sys::Disk;
 use sys::Networks;
 use Pid;
 use User;
+use LoadAvg;
 use {RefreshKind, SystemExt};
 
 use std::collections::HashMap;
@@ -27,7 +28,7 @@ impl SystemExt for System {
         System {
             processes_list: Default::default(),
             networks: Networks::new(),
-            global_processor: Processor::new {},
+            global_processor: Processor::new(),
         }
     }
 
@@ -46,8 +47,6 @@ impl SystemExt for System {
     fn refresh_disks_list(&mut self) {}
 
     fn refresh_users_list(&mut self) {}
-
-    fn refresh_network(&mut self) {}
 
     // COMMON PART
     //
@@ -105,15 +104,15 @@ impl SystemExt for System {
         &[]
     }
 
-    fn get_components_mut(&self) -> &[Component] {
-        &[]
+    fn get_components_mut(&mut self) -> &mut [Component] {
+        &mut []
     }
 
     fn get_disks(&self) -> &[Disk] {
         &[]
     }
 
-    fn get_disks_mut(&self) -> &mut [Disk] {
+    fn get_disks_mut(&mut self) -> &mut [Disk] {
         &mut []
     }
 


### PR DESCRIPTION
Additionally I have added one more target for Travis script. I'm using `wasm32-unknown-unknow` because I have encountered this problem compiling to that target. Please let me know if I should change anything in this pull request.