### PR TITLE
linux/disk.rs: fix unknown disk type error

### DIFF
--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -898,7 +898,7 @@ fn get_all_disks() -> Vec<Disk> {
         let mut split = line.split(' ');
         if let (Some(name), Some(mountpt), Some(fs)) = (split.next(), split.next(), split.next()) {
             ret.push(disk::new(
-                name[5..].as_ref(),
+                name.as_ref(),
                 Path::new(mountpt),
                 fs.as_bytes(),
             ));


### PR DESCRIPTION
Fixes the mis-aslignment between the name inside `/proc/mounts` and `/sys/block` devices. For example, the device `/dev/mapper/fedora_localhost--live-root` is a symbolic link to `/dev/dm-0` and there's no device `fedora_localhost--live-root` under `/sys/block`. Instead find the target of the symbolic link and use the real name.

Also, parses different devices according to their names. For example, when parsing nvme devices, parse the name `nvme0n1p1` to `nvmen1` instead of previous `nvmen1p`.

Closes: https://github.com/GuillaumeGomez/sysinfo/issues/204
Signed-off-by: Allen Bai <carpe.diem.allen@gmail.com>