### PR TITLE
Fix For Issue 295

### DIFF
--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -902,12 +902,12 @@ fn get_all_disks() -> Vec<Disk> {
                fs_file.starts_with("/proc") ||
                fs_file.starts_with("/run") ||
                fs_file.starts_with("/dev") ||
-               fs_spec.starts_with("sunrpc") 
-                    {
-                        false
-                    } else {
-                        true
-                    }
+               fs_spec.starts_with("sunrpc")
+            {
+                false
+            } else {
+                true
+            }
         })
         .map(|(fs_spec, fs_file, fs_vfstype)| {
             disk::new(fs_spec.as_ref(), Path::new(fs_file), fs_vfstype.as_bytes())

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -885,28 +885,29 @@ fn get_all_disks() -> Vec<Disk> {
         .filter(|(fs_spec, fs_file, fs_vfstype)| {
             // Check if fs_vfstype is one of our 'ignored' file systems
             let filtered = match *fs_vfstype {
-                "sysfs" => true, // pseudo file system for kernel objects
-                "proc" => true,  // another pseudo file system
-                "tmpfs" => true,
-                "cgroup" => true,
-                "cgroup2" => true,
-                "pstore" => true, //https://www.kernel.org/doc/Documentation/ABI/testing/pstore
-                "squashfs" => true, //Squashfs is a compressed read-only file system (for snaps)
+                "sysfs" | // pseudo file system for kernel objects
+                "proc" |  // another pseudo file system
+                "tmpfs" |
+                "cgroup" |
+                "cgroup2" |
+                "pstore" | //https://www.kernel.org/doc/Documentation/ABI/testing/pstore
+                "squashfs" | //Squashfs is a compressed read-only file system (for snaps)
+                "rpc_pipefs" | // the pipefs pseudo file system service
                 "iso9660" => true, // optical media
                 _ => false,
             };
 
             if filtered ||
-        fs_file.starts_with("/sys") || // check if fs_file is an 'ignored' mount point
-        fs_file.starts_with("/proc") ||
-        fs_file.starts_with("/run") ||
-        fs_file.starts_with("/dev") ||
-        fs_spec.starts_with("sunrpc")
-            {
-                false
-            } else {
-                true
-            }
+               fs_file.starts_with("/sys") || // check if fs_file is an 'ignored' mount point
+               fs_file.starts_with("/proc") ||
+               fs_file.starts_with("/run") ||
+               fs_file.starts_with("/dev") ||
+               fs_spec.starts_with("sunrpc") 
+                    {
+                        false
+                    } else {
+                        true
+                    }
         })
         .map(|(fs_spec, fs_file, fs_vfstype)| {
             disk::new(fs_spec.as_ref(), Path::new(fs_file), fs_vfstype.as_bytes())

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -869,14 +869,22 @@ pub fn get_all_data<P: AsRef<Path>>(file_path: P, size: usize) -> io::Result<Str
 fn get_all_disks() -> Vec<Disk> {
     let content = get_all_data("/proc/mounts", 16_385).unwrap_or_default();
 
-    let disks = content.lines().filter(|line| {
+    content.lines()
+    .map(|line| {
         let line = line.trim_start();
         // mounts format
         //http://man7.org/linux/man-pages/man5/fstab.5.html
         //fs_spec<tab>fs_file<tab>fs_vfstype<tab>other fields
-        let fields: Vec<&str> = line.split_whitespace().collect();
+        let mut fields = line.split_whitespace();
+        let fs_spec = fields.next().unwrap_or("");
+        let fs_file = fields.next().unwrap_or("");
+        let fs_vfstype = fields.next().unwrap_or("");
+        (fs_spec, fs_file, fs_vfstype)
+    })
+    .filter(|(fs_spec, fs_file, fs_vfstype)| {
+        
         // Check if fs_vfstype is one of our 'ignored' file systems
-        let skip = match fields[2]{ 
+        let filtered = match *fs_vfstype{ 
             "sysfs" => true, // pseudo file system for kernel objects
             "proc" => true, // another pseudo file system
             "tmpfs" => true,
@@ -887,33 +895,27 @@ fn get_all_disks() -> Vec<Disk> {
             "iso9660" => true, // optical media
             _ => false
         };
-        // check if fs_file is an 'ignored' mount point
-        if skip ||
-           fields[1].starts_with("/sys") ||
-           fields[1].starts_with("/proc") ||
-           fields[1].starts_with("/run") ||
-           fields[1].starts_with("/dev") ||
-           fields[0].starts_with("sunrpc")
-           {
-               false
-           }
-           else{
-               true
-           }
-    });
-    let mut ret = vec![];
-
-    for line in disks {
-        let mut split = line.split(' ');
-        if let (Some(name), Some(mountpt), Some(fs)) = (split.next(), split.next(), split.next()) {
-            ret.push(disk::new(
-                name.as_ref(),
-                Path::new(mountpt),
-                fs.as_bytes(),
-            ));
+        
+        if filtered ||
+        fs_file.starts_with("/sys") || // check if fs_file is an 'ignored' mount point
+        fs_file.starts_with("/proc") ||
+        fs_file.starts_with("/run") ||
+        fs_file.starts_with("/dev") ||
+        fs_spec.starts_with("sunrpc"){
+            false
         }
-    }
-    ret
+        else{
+            true
+        }
+    })
+    .map(|(fs_spec, fs_file, fs_vfstype)|{
+        disk::new(
+            fs_spec.as_ref(),
+            Path::new(fs_file),
+            fs_vfstype.as_bytes()
+        )
+    })
+    .collect()
 }
 
 fn get_uptime() -> u64 {


### PR DESCRIPTION
Hello,

This PR closes Issue #295, where some disks and file systems were not showing up when calling `get_disks`. Also fixes an [issue](https://github.com/bvaisvil/zenith/issues/28) for zenith.

There were two problems, one `get_all_data_from_file` unexpectedly did not get all of the data. Second, the filter used for `/proc/mounts` filtered out file systems (e.g. ZFS stores) that should have been returned.

Current filter is taken from this [PR](https://github.com/bvaisvil/zenith/pull/26)  to zenith and should probably be evaluated.

Performance with the changes has degraded by at least 2x. Though in my testing at least of some of the performance change was due to an increase in the number disks to create and refresh.

Disks before:

```
Disk("/dev/mapper/fedora-root")[FS: [101, 120, 116, 52]][Type: HDD] mounted on "/": 5864124416/37217632256 B
Disk("/dev/mapper/fedora-home")[FS: [101, 120, 116, 52]][Type: HDD] mounted on "/home": 6089064448/18166878208 B
Disk("/dev/sdg1")[FS: [101, 120, 116, 52]][Type: HDD] mounted on "/boot": 718082048/1023303680 B
```

Bench Before

```
running 15 tests
test bench_new                     ... bench:      90,933 ns/iter (+/- 5,473)
test bench_new_all                 ... bench:  19,775,727 ns/iter (+/- 4,247,516)
test bench_refresh_all             ... bench:   6,848,406 ns/iter (+/- 2,115,935)
test bench_refresh_components      ... bench:      81,993 ns/iter (+/- 28,601)
test bench_refresh_components_list ... bench:   1,590,844 ns/iter (+/- 52,067)
test bench_refresh_cpu             ... bench:      10,106 ns/iter (+/- 333)
test bench_refresh_disks           ... bench:       2,242 ns/iter (+/- 149)
test bench_refresh_disks_list      ... bench:      73,465 ns/iter (+/- 972)
test bench_refresh_memory          ... bench:      10,621 ns/iter (+/- 457)
test bench_refresh_networks        ... bench:   1,280,425 ns/iter (+/- 31,943)
test bench_refresh_networks_list   ... bench:   1,298,386 ns/iter (+/- 22,796)
test bench_refresh_process         ... bench:      68,199 ns/iter (+/- 13,111)
test bench_refresh_processes       ... bench:   5,269,735 ns/iter (+/- 1,958,663)
test bench_refresh_system          ... bench:     105,997 ns/iter (+/- 8,512)
test bench_refresh_users_list      ... bench:   2,585,549 ns/iter (+/- 465,896)
```

Disks After:
```
Disk("/dev/mapper/fedora-root")[FS: [101, 120, 116, 52]][Type: HDD] mounted on "/": 5864124416/37217632256 B
Disk("/dev/mapper/fedora-home")[FS: [101, 120, 116, 52]][Type: HDD] mounted on "/home": 6089080832/18166878208 B
Disk("/dev/sdg1")[FS: [101, 120, 116, 52]][Type: HDD] mounted on "/boot": 718082048/1023303680 B
Disk("datastore")[FS: [122, 102, 115]][Type: Unknown(-1)] mounted on "/datastore": 795552776192/874729832448 B
Disk("datastore/timemachine")[FS: [122, 102, 115]][Type: Unknown(-1)] mounted on "/datastore/timemachine": 112674865152/1649267441664 B
Disk("datastore/share")[FS: [122, 102, 115]][Type: Unknown(-1)] mounted on "/datastore/share": 795552776192/7042156462080 B
Disk("datastore/6977ab1bfbfb3adad5c018ddf2865c597a3f4d4c6205ca6586c9a7bb516e244c")[FS: [122, 102, 115]][Type: Unknown(-1)] mounted on "/datastore/docker/zfs/graph/6977ab1bfbfb3adad5c018ddf2865c597a3f4d4c6205ca6586c9a7bb516e244c": 0/0 B
Disk("datastore/84b304103b3dfcfcce8da2cc2560e9452845f7075574eacf3331208459212b66")[FS: [122, 102, 115]][Type: Unknown(-1)] mounted on "/datastore/docker/zfs/graph/84b304103b3dfcfcce8da2cc2560e9452845f7075574eacf3331208459212b66": 0/0 B
Disk("datastore/2410fa9476be7baab772cd3676af981304b8799fdc00eba23ea50eb23e320f2d")[FS: [122, 102, 115]][Type: Unknown(-1)] mounted on "/datastore/docker/zfs/graph/2410fa9476be7baab772cd3676af981304b8799fdc00eba23ea50eb23e320f2d": 0/0 B
Disk("datastore/be95479a121cae22dec311592eee5a125a96f4746570c4ffa2bce541552c5cbc")[FS: [122, 102, 115]][Type: Unknown(-1)] mounted on "/datastore/docker/zfs/graph/be95479a121cae22dec311592eee5a125a96f4746570c4ffa2bce541552c5cbc": 0/0 B
Disk("datastore/a3a44b300de19c06a67c8d2475493914f1cc175e950544de041b188d3dfa22df")[FS: [122, 102, 115]][Type: Unknown(-1)] mounted on "/datastore/docker/zfs/graph/a3a44b300de19c06a67c8d2475493914f1cc175e950544de041b188d3dfa22df": 0/0 B
```

After:
```
running 15 tests
test bench_new                     ... bench:      91,760 ns/iter (+/- 4,527)
test bench_new_all                 ... bench:  21,056,975 ns/iter (+/- 3,619,979)
test bench_refresh_all             ... bench:   7,074,736 ns/iter (+/- 564,201)
test bench_refresh_components      ... bench:      81,358 ns/iter (+/- 4,945)
test bench_refresh_components_list ... bench:   1,582,055 ns/iter (+/- 66,074)
test bench_refresh_cpu             ... bench:      10,501 ns/iter (+/- 835)
test bench_refresh_disks           ... bench:       9,553 ns/iter (+/- 170)
test bench_refresh_disks_list      ... bench:     141,140 ns/iter (+/- 11,380)
test bench_refresh_memory          ... bench:      11,526 ns/iter (+/- 525)
test bench_refresh_networks        ... bench:   1,283,021 ns/iter (+/- 62,088)
test bench_refresh_networks_list   ... bench:   1,298,439 ns/iter (+/- 35,805)
test bench_refresh_process         ... bench:      71,114 ns/iter (+/- 24,258)
test bench_refresh_processes       ... bench:   5,479,523 ns/iter (+/- 1,699,388)
test bench_refresh_system          ... bench:     105,948 ns/iter (+/- 2,773)
test bench_refresh_users_list      ... bench:   2,606,501 ns/iter (+/- 754,547)
```

