### PR TITLE
Fix out of bound slice access

### DIFF
--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -98,11 +98,11 @@ macro_rules! to_str {
 fn boot_time() -> u64 {
     if let Ok(f) = File::open("/proc/stat") {
         let buf = BufReader::new(f);
-        let mut it = buf.split(b'\n');
-        while let Some(Ok(line)) = it.next() {
-            if &line[..5] != b"btime" {
-                continue;
-            }
+        let line = buf.split(b'\n')
+            .filter_map(|r| r.ok())
+            .find(|l| l.starts_with(b"btime"));
+
+        if let Some(line) = line {
             return line
                 .split(|x| *x == b' ')
                 .filter(|s| !s.is_empty())


### PR DESCRIPTION
We can not assume that the slice always has 5 elements. This rewrites
the code to use `starts_with`.

(Would be nice to get a bug fix release that includes this patch)