### PR TITLE
Get cmd line

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,11 @@ cfg-if = "0.1"
 rayon = "^1.0"
 doc-comment = "0.3"
 once_cell = "1.0"
-lazy_static = "1.4.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["fileapi", "handleapi", "ifdef", "ioapiset", "minwindef", "pdh", "psapi", "synchapi", "sysinfoapi", "winbase", "winerror", "winioctl", "winnt", "oleauto", "wbemcli", "rpcdce", "combaseapi", "objidl", "powerbase", "netioapi", "lmcons", "lmaccess", "lmapibuf", "memoryapi", "shellapi"] }
 ntapi = "0.3"
+lazy_static = "1.4.0"
 
 [target.'cfg(not(any(target_os = "unknown", target_arch = "wasm32")))'.dependencies]
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ once_cell = "1.0"
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["fileapi", "handleapi", "ifdef", "ioapiset", "minwindef", "pdh", "psapi", "synchapi", "sysinfoapi", "winbase", "winerror", "winioctl", "winnt", "oleauto", "wbemcli", "rpcdce", "combaseapi", "objidl", "powerbase", "netioapi", "lmcons", "lmaccess", "lmapibuf", "memoryapi", "shellapi"] }
 ntapi = "0.3"
-lazy_static = "1.4.0"
 
 [target.'cfg(not(any(target_os = "unknown", target_arch = "wasm32")))'.dependencies]
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ cfg-if = "0.1"
 rayon = "^1.0"
 doc-comment = "0.3"
 once_cell = "1.0"
+lazy_static = "1.4.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["fileapi", "handleapi", "ifdef", "ioapiset", "minwindef", "pdh", "psapi", "synchapi", "sysinfoapi", "winbase", "winerror", "winioctl", "winnt", "oleauto", "wbemcli", "rpcdce", "combaseapi", "objidl", "powerbase", "netioapi", "lmcons", "lmaccess", "lmapibuf", "memoryapi", "shellapi"] }

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -58,8 +58,7 @@ extern crate rayon;
 #[macro_use]
 extern crate doc_comment;
 
-#[macro_use]
-extern crate lazy_static;
+extern crate once_cell;
 
 #[cfg(doctest)]
 doctest!("../README.md");

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -58,6 +58,9 @@ extern crate rayon;
 #[macro_use]
 extern crate doc_comment;
 
+#[macro_use]
+extern crate lazy_static;
+
 #[cfg(doctest)]
 doctest!("../README.md");
 

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -19,9 +19,14 @@ use Pid;
 use ProcessExt;
 
 use ntapi::ntpsapi::{
-    NtQueryInformationProcess, ProcessBasicInformation, PROCESS_BASIC_INFORMATION,
+    NtQueryInformationProcess, ProcessBasicInformation, ProcessCommandLineInformation,
+    PROCESSINFOCLASS, PROCESS_BASIC_INFORMATION,
 };
-use winapi::shared::minwindef::{DWORD, FALSE, FILETIME, MAX_PATH, TRUE};
+use winapi::shared::minwindef::{DWORD, FALSE, FILETIME, MAX_PATH, TRUE, ULONG};
+use winapi::shared::ntdef::{NT_SUCCESS, UNICODE_STRING};
+use winapi::shared::ntstatus::{
+    STATUS_BUFFER_OVERFLOW, STATUS_BUFFER_TOO_SMALL, STATUS_INFO_LENGTH_MISMATCH,
+};
 use winapi::um::handleapi::CloseHandle;
 use winapi::um::processthreadsapi::{GetProcessTimes, OpenProcess};
 use winapi::um::psapi::{
@@ -434,7 +439,69 @@ unsafe fn get_start_time(handle: HANDLE) -> u64 {
     tmp / 10_000_000 - 11_644_473_600
 }
 
-fn get_cmd_line(handle: HANDLE) -> Vec<String> {
+unsafe fn ph_query_process_variable_size(
+    process_handle: HANDLE,
+    process_information_class: PROCESSINFOCLASS,
+) -> Option<Vec<u16>> {
+    let mut return_length = MaybeUninit::<ULONG>::uninit();
+
+    let mut status = NtQueryInformationProcess(
+        process_handle,
+        process_information_class,
+        std::ptr::null_mut(),
+        0,
+        return_length.as_mut_ptr() as *mut _,
+    );
+
+    if status != STATUS_BUFFER_OVERFLOW
+        && status != STATUS_BUFFER_TOO_SMALL
+        && status != STATUS_INFO_LENGTH_MISMATCH
+    {
+        return None;
+    }
+
+    let mut return_length = return_length.assume_init();
+    let buf_len = (return_length as usize) / 2;
+    let mut buffer: Vec<u16> = Vec::with_capacity(buf_len + 1);
+    buffer.set_len(buf_len);
+
+    status = NtQueryInformationProcess(
+        process_handle,
+        process_information_class,
+        buffer.as_mut_ptr() as *mut _,
+        return_length,
+        &mut return_length as *mut _,
+    );
+    if !NT_SUCCESS(status) {
+        return None;
+    }
+    return Some(buffer);
+}
+
+unsafe fn get_cmdline_from_buffer(buffer: *const u16) -> Vec<String> {
+    // Get argc and argv from the command line
+    let mut argc = MaybeUninit::<i32>::uninit();
+    let argv_p =
+        winapi::um::shellapi::CommandLineToArgvW(buffer, argc.as_mut_ptr());
+    if argv_p.is_null() {
+        return Vec::new();
+    }
+    let argc = argc.assume_init();
+    let argv = std::slice::from_raw_parts(argv_p, argc as usize);
+
+    let mut res = Vec::new();
+    for arg in argv {
+        let len = libc::wcslen(*arg);
+        let str_slice = std::slice::from_raw_parts(*arg, len);
+        res.push(String::from_utf16_lossy(str_slice));
+    }
+
+    winapi::um::winbase::LocalFree(argv_p as *mut _);
+
+    res
+}
+
+fn get_cmd_line_old(handle: HANDLE) -> Vec<String> {
     use ntapi::ntpebteb::{PEB, PPEB};
     use ntapi::ntrtl::{PRTL_USER_PROCESS_PARAMETERS, RTL_USER_PROCESS_PARAMETERS};
     use winapi::shared::basetsd::SIZE_T;
@@ -500,27 +567,25 @@ fn get_cmd_line(handle: HANDLE) -> Vec<String> {
         }
         buffer_copy.push(0);
 
-        // Get argc and argv from command line
-        let mut argc = MaybeUninit::<i32>::uninit();
-        let argv_p =
-            winapi::um::shellapi::CommandLineToArgvW(buffer_copy.as_ptr(), argc.as_mut_ptr());
-        if argv_p.is_null() {
-            return Vec::new();
-        }
-        let argc = argc.assume_init();
-        let argv = std::slice::from_raw_parts(argv_p, argc as usize);
-
-        let mut res = Vec::new();
-        for arg in argv {
-            let len = libc::wcslen(*arg);
-            let str_slice = std::slice::from_raw_parts(*arg, len);
-            res.push(String::from_utf16_lossy(str_slice));
-        }
-
-        winapi::um::winbase::LocalFree(argv_p as *mut _);
-
-        res
+        get_cmdline_from_buffer(buffer_copy.as_ptr())
     }
+}
+
+fn get_cmd_line_new(handle: HANDLE) -> Vec<String> {
+    unsafe {
+        if let Some(buffer) = 
+            ph_query_process_variable_size(handle, ProcessCommandLineInformation) {
+            let buffer = (*(buffer.as_ptr() as *const UNICODE_STRING)).Buffer;
+
+            return get_cmdline_from_buffer(buffer);
+        } else {
+            vec![]
+        }
+    }
+}
+
+fn get_cmd_line(handle: HANDLE) -> Vec<String> {
+    get_cmd_line_new(handle)
 }
 
 unsafe fn get_proc_env(_handle: HANDLE, _pid: u32, _name: &str) -> Vec<String> {

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -475,6 +475,7 @@ unsafe fn ph_query_process_variable_size(
     if !NT_SUCCESS(status) {
         return None;
     }
+    buffer.push(0);
     return Some(buffer);
 }
 
@@ -571,13 +572,15 @@ fn get_cmd_line_old(handle: HANDLE) -> Vec<String> {
     }
 }
 
+#[allow(clippy::cast_ptr_alignment)]
 fn get_cmd_line_new(handle: HANDLE) -> Vec<String> {
     unsafe {
         if let Some(buffer) = 
             ph_query_process_variable_size(handle, ProcessCommandLineInformation) {
+
             let buffer = (*(buffer.as_ptr() as *const UNICODE_STRING)).Buffer;
 
-            return get_cmdline_from_buffer(buffer);
+            get_cmdline_from_buffer(buffer)
         } else {
             vec![]
         }


### PR DESCRIPTION
This is new window command-line getting approach, same as ProcessHacker uses. The approach doesn't require PROCESS_VM_READ access right and works with 32 and 64 bit processes. But unfortunately, it doesn't work in windows 8 and older.