### PR TITLE
fix memory usage in linux platform

### DIFF
--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -131,6 +131,8 @@ pub struct System {
     process_list: Process,
     mem_total: u64,
     mem_free: u64,
+    mem_buffers: u64,
+    mem_cache: u64,
     swap_total: u64,
     swap_free: u64,
     global_processor: Processor,
@@ -265,6 +267,8 @@ impl SystemExt for System {
             process_list: Process::new(0, None, 0),
             mem_total: 0,
             mem_free: 0,
+            mem_buffers: 0,
+            mem_cache: 0,
             swap_total: 0,
             swap_free: 0,
             global_processor: Processor::new_with_values(
@@ -309,7 +313,9 @@ impl SystemExt for System {
             for line in data.split('\n') {
                 let field = match line.split(':').next() {
                     Some("MemTotal") => &mut self.mem_total,
-                    Some("MemAvailable") | Some("MemFree") => &mut self.mem_free,
+                    Some("MemFree") => &mut self.mem_free,
+                    Some("Buffers") => &mut self.mem_buffers,
+                    Some("Cached") => &mut self.mem_cache,
                     Some("SwapTotal") => &mut self.swap_total,
                     Some("SwapFree") => &mut self.swap_free,
                     _ => continue,
@@ -416,7 +422,7 @@ impl SystemExt for System {
     }
 
     fn get_used_memory(&self) -> u64 {
-        self.mem_total - self.mem_free
+        self.mem_total - self.mem_free - self.mem_buffers - self.mem_cache
     }
 
     fn get_total_swap(&self) -> u64 {


### PR DESCRIPTION
Hi, this is a patch for the memory info report.

According to `man free`:

> **used**   Used memory (calculated as **total** - **free** - **buffers** - **cache**)
