### PR TITLE
Fix memory used calculation

### DIFF
--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -132,7 +132,8 @@ pub struct System {
     mem_total: u64,
     mem_free: u64,
     mem_buffers: u64,
-    mem_cache: u64,
+    mem_page_cache: u64,
+    mem_slab_reclaimable: u64,
     swap_total: u64,
     swap_free: u64,
     global_processor: Processor,
@@ -268,7 +269,8 @@ impl SystemExt for System {
             mem_total: 0,
             mem_free: 0,
             mem_buffers: 0,
-            mem_cache: 0,
+            mem_page_cache: 0,
+            mem_slab_reclaimable: 0,
             swap_total: 0,
             swap_free: 0,
             global_processor: Processor::new_with_values(
@@ -315,7 +317,8 @@ impl SystemExt for System {
                     Some("MemTotal") => &mut self.mem_total,
                     Some("MemFree") => &mut self.mem_free,
                     Some("Buffers") => &mut self.mem_buffers,
-                    Some("Cached") => &mut self.mem_cache,
+                    Some("Cached") => &mut self.mem_page_cache,
+                    Some("SReclaimable") => &mut self.mem_slab_reclaimable,
                     Some("SwapTotal") => &mut self.swap_total,
                     Some("SwapFree") => &mut self.swap_free,
                     _ => continue,
@@ -422,7 +425,7 @@ impl SystemExt for System {
     }
 
     fn get_used_memory(&self) -> u64 {
-        self.mem_total - self.mem_free - self.mem_buffers - self.mem_cache
+        self.mem_total - self.mem_free - self.mem_buffers - self.mem_page_cache - self.mem_slab_reclaimable
     }
 
     fn get_total_swap(&self) -> u64 {


### PR DESCRIPTION
@GuillaumeGomez Sorry for incorrect implementation in my previous PR. I just found there is still a big gap when I compare with the output of `free` command. So I checked out the source code of `procps`,  and fixed it in this PR.

I should be more careful before I submit the previous PR...

The key is `cache` size is the sum of `Cached` and `SReclaimable` in `/proc/meminfo`, but in the previous PR, I assumed `Cached` means `cache`.

> $ man free
> ...
> **used**   Used memory (calculated as total - free - buffers - **cache**)
> ...
> **cache**  Memory used by the page cache and slabs (**Cached** and **SReclaimable** in /proc/meminfo)
