### PR TITLE
Bug: right detection of SSD or HDD disk.

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -260,8 +260,8 @@ pub enum DiskType {
 impl From<isize> for DiskType {
     fn from(t: isize) -> DiskType {
         match t {
-            0 => DiskType::HDD,
-            1 => DiskType::SSD,
+            0 => DiskType::SSD,
+            1 => DiskType::HDD,
             id => DiskType::Unknown(id),
         }
     }

--- a/src/linux/disk.rs
+++ b/src/linux/disk.rs
@@ -171,6 +171,7 @@ fn get_all_disks_inner(content: &str) -> Vec<Disk> {
                 "sysfs" | // pseudo file system for kernel objects
                 "proc" |  // another pseudo file system
                 "tmpfs" |
+                "devtmpfs" |
                 "cgroup" |
                 "cgroup2" |
                 "pstore" | // https://www.kernel.org/doc/Documentation/ABI/testing/pstore


### PR DESCRIPTION
Two small modifications:

DiskType::from use the value of /sys/block/<device>/queue/rotational to guess if a mounted device is an SSD
or a HDD.
1 means HDD, and 0 SSD.

Ignore the devtmpfs filesystem, it is the pseudo filesystem used /dev directory.