### PR TITLE
Add available memory

### DIFF
--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -131,6 +131,7 @@ pub struct System {
     process_list: Process,
     mem_total: u64,
     mem_free: u64,
+    mem_available: u64,
     mem_buffers: u64,
     mem_page_cache: u64,
     mem_slab_reclaimable: u64,
@@ -271,6 +272,7 @@ impl SystemExt for System {
             process_list: Process::new(0, None, 0),
             mem_total: 0,
             mem_free: 0,
+            mem_available: 0,
             mem_buffers: 0,
             mem_page_cache: 0,
             mem_slab_reclaimable: 0,
@@ -319,6 +321,7 @@ impl SystemExt for System {
                 let field = match line.split(':').next() {
                     Some("MemTotal") => &mut self.mem_total,
                     Some("MemFree") => &mut self.mem_free,
+                    Some("MemAvailable") => &mut self.mem_available,
                     Some("Buffers") => &mut self.mem_buffers,
                     Some("Cached") => &mut self.mem_page_cache,
                     Some("SReclaimable") => &mut self.mem_slab_reclaimable,
@@ -425,6 +428,10 @@ impl SystemExt for System {
 
     fn get_free_memory(&self) -> u64 {
         self.mem_free
+    }
+
+    fn get_available_memory(&self) -> u64 {
+        self.mem_available
     }
 
     fn get_used_memory(&self) -> u64 {

--- a/src/mac/system.rs
+++ b/src/mac/system.rs
@@ -27,6 +27,7 @@ pub struct System {
     process_list: HashMap<Pid, Process>,
     mem_total: u64,
     mem_free: u64,
+    mem_available: u64,
     swap_total: u64,
     swap_free: u64,
     global_processor: Processor,
@@ -104,6 +105,7 @@ impl SystemExt for System {
             process_list: HashMap::with_capacity(200),
             mem_total: 0,
             mem_free: 0,
+            mem_available: 0,
             swap_total: 0,
             swap_free: 0,
             global_processor,
@@ -166,14 +168,14 @@ impl SystemExt for System {
                 //  * used to hold data that was read speculatively from disk but
                 //  * haven't actually been used by anyone so far.
                 //  */
-                // self.mem_free = u64::from(stat.free_count) * self.page_size_kb;
-                self.mem_free = self.mem_total
+                self.mem_available = self.mem_total
                     - (u64::from(stat.active_count)
                         + u64::from(stat.inactive_count)
                         + u64::from(stat.wire_count)
                         + u64::from(stat.speculative_count)
                         - u64::from(stat.purgeable_count))
                         * self.page_size_kb;
+                self.mem_free = u64::from(stat.free_count) * self.page_size_kb;
             }
         }
     }
@@ -324,6 +326,10 @@ impl SystemExt for System {
 
     fn get_free_memory(&self) -> u64 {
         self.mem_free
+    }
+
+    fn get_available_memory(&self) -> u64 {
+        self.mem_available
     }
 
     fn get_used_memory(&self) -> u64 {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -753,6 +753,16 @@ pub trait SystemExt: Sized + Debug + Default {
     /// ```
     fn get_free_memory(&self) -> u64;
 
+    /// Returns the amount of available RAM in kB.
+    ///
+    /// ```no_run
+    /// use sysinfo::{System, SystemExt};
+    ///
+    /// let s = System::new_all();
+    /// println!("{} kB", s.get_available_memory());
+    /// ```
+    fn get_available_memory(&self) -> u64;
+
     /// Returns the amound of used RAM in kB.
     ///
     /// ```no_run

--- a/src/unknown/system.rs
+++ b/src/unknown/system.rs
@@ -84,6 +84,10 @@ impl SystemExt for System {
         0
     }
 
+    fn get_available_memory(&self) -> u64 {
+        0
+    }
+
     fn get_used_memory(&self) -> u64 {
         0
     }


### PR DESCRIPTION
Generally, "free" memory refers to unallocated memory and "available"
memory refers to that that is available for (re)use.

Currently, available memory is being reported on Mac and Windows as
"free", whereas only free memory is reported on Linux.

As Windows does not seem to report free memory, with this commit it
continues to report available memory via `get_free_memory`, but the
correct values will be reported on Mac and Linux for both.

References:
Linux: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773
Mac: https://opensource.apple.com/source/xnu/xnu-1504.7.4/osfmk/mach/vm_statistics.h.auto.html
Windows: https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-memorystatusex