### PR TITLE
Add PECI CPU temperature sensors work on all Macs

### DIFF
--- a/src/mac/component.rs
+++ b/src/mac/component.rs
@@ -12,7 +12,6 @@ use ComponentExt;
 pub(crate) const COMPONENTS_TEMPERATURE_IDS: &[(&str, &[i8])] = &[
     ("PECI CPU", &['T' as i8, 'C' as i8, 'X' as i8, 'C' as i8]), // PECI CPU "TCXC"
     ("PECI CPU", &['T' as i8, 'C' as i8, 'X' as i8, 'c' as i8]), // PECI CPU "TCXc"
-    ("CPU", &['T' as i8, 'C' as i8, '0' as i8, 'F' as i8]), // CPU Die "TC0F"
     (
         "CPU Proximity",
         &['T' as i8, 'C' as i8, '0' as i8, 'P' as i8],

--- a/src/mac/component.rs
+++ b/src/mac/component.rs
@@ -10,6 +10,8 @@ use sys::ffi;
 use ComponentExt;
 
 pub(crate) const COMPONENTS_TEMPERATURE_IDS: &[(&str, &[i8])] = &[
+    ("PECI CPU", &['T' as i8, 'C' as i8, 'X' as i8, 'C' as i8]), // PECI CPU "TCXC"
+    ("PECI CPU", &['T' as i8, 'C' as i8, 'X' as i8, 'c' as i8]), // PECI CPU "TCXc"
     ("CPU", &['T' as i8, 'C' as i8, '0' as i8, 'F' as i8]), // CPU Die "TC0F"
     (
         "CPU Proximity",


### PR DESCRIPTION
Current `src/mac/component.rs` defines several CPU temperature sensors. They all work on the (older) MacBooks, but, unfortunately, provide wrong values on the newer iMac (see issue #357).

This PR addresses #357 by adding definition for [Platform Environment Control Interface (PECI)](https://en.wikipedia.org/wiki/Platform_Environment_Control_Interface) CPU sensors that appear to return correct values on all the Mac platforms I've tested them so far.

From the Wiki:
> While previous thermal management technologies have made use of thermal diodes, **PECI instead uses on-die digital thermal sensors (DTS)**. These sensors, after being calibrated at the factory, are able to provide digital data concerning processor temperature information. The PECI bus, allowing access to this data from chipset components, is a proprietary single-wire interface with a variable data transfer speed (from 2 kbit/s to 2 Mbit/s).
>
> Since the value reported by PECI takes into account internal processor information about safe operating temperatures, it alleviates the need for the BIOS or operating system to make potentially incorrect assumptions about this limit. Furthermore, it supports dynamic fan control with a high degree of accuracy, where fan speed can be progressively increased as the value approaches zero.

I recommend keeping the "CPU Proximity" sensor, but removing "CPU" because it returns correct value only on some Macs, while PECI CPU sensors work on all the Intel-based Macs from 2006.