### PR TITLE
Add crate::utils::into_iter, which is controlled by a `multithread` feature

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -100,7 +100,6 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
           override: true
-
       - name: Execute tests (not mac)
         run: cargo test
         if: matrix.os != 'macos-latest'
@@ -108,6 +107,16 @@ jobs:
           RUST_BACKTRACE: full
       - name: Execute tests (mac)
         run: cargo test -- --test-threads 1
+        if: matrix.os == 'macos-latest'
+        env:
+          RUST_BACKTRACE: full
+      - name: Execute tests (not mac, no features)
+        run: cargo test --no-default-features
+        if: matrix.os != 'macos-latest'
+        env:
+          RUST_BACKTRACE: full
+      - name: Execute tests (mac, no features)
+        run: cargo test --no-default-features -- --test-threads 1
         if: matrix.os == 'macos-latest'
         env:
           RUST_BACKTRACE: full

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 
 [dependencies]
 cfg-if = "1.0"
-rayon = "^1.5"
+rayon = { version = "^1.5", optional = true }
 doc-comment = "0.3"
 once_cell = "1.0"
 
@@ -37,7 +37,9 @@ crate_type = ["rlib", "cdylib"]
 path = "src/sysinfo.rs"
 
 [features]
+default = ["multithread"]
 c-interface = []
+multithread = ["rayon"]
 debug = ["libc/extra_traits"]
 
 [badges]

--- a/README.md
+++ b/README.md
@@ -92,8 +92,6 @@ for (pid, process) in sys.get_processes() {
 
 By default, `sysinfo` uses multiple threads. However, this can increase the memory usage on some platforms (macOS for example).  The behavior can be disabled by setting `default-features = false` in `Cargo.toml` (which disables the `multithread` cargo feature).
 
-Sysinfo supports parallel retrieval of system processes with the `multithread` cargo feature, which is enabled by default.
-
 ## C interface
 
 It's possible to use this crate directly from C. Take a look at the `Makefile` and at the `examples/src/simple.c` file.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ for (pid, process) in sys.get_processes() {
 }
 ```
 
+By default, `sysinfo` uses multiple threads. However, this can increase the memory usage on some platforms (macOS for example).  The behavior can be disabled by setting `default-features = false` in `Cargo.toml` (which disables the `multithread` cargo feature).
+
+Sysinfo supports parallel retrieval of system processes with the `multithread` cargo feature, which is enabled by default.
+
 ## C interface
 
 It's possible to use this crate directly from C. Take a look at the `Makefile` and at the `examples/src/simple.c` file.

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -53,6 +53,7 @@
 extern crate cfg_if;
 #[cfg(not(any(target_os = "unknown", target_arch = "wasm32")))]
 extern crate libc;
+#[cfg(feature = "multithread")]
 extern crate rayon;
 
 #[macro_use]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -101,3 +101,23 @@ pub fn get_current_pid() -> Result<Pid, &'static str> {
     }
     inner()
 }
+
+/// Converts the value into a parallel iterator (if the multithread feature is enabled)
+/// Uses the rayon::iter::IntoParallelIterator trait
+#[cfg(feature = "multithread")]
+pub fn into_iter<T>(val: T) -> T::Iter
+where
+    T: rayon::iter::IntoParallelIterator,
+{
+    val.into_par_iter()
+}
+
+/// Converts the value into a sequential iterator (if the multithread feature is disabled)
+/// Uses the std::iter::IntoIterator trait
+#[cfg(not(feature = "multithread"))]
+pub fn into_iter<T>(val: T) -> T::IntoIter
+where
+    T: IntoIterator,
+{
+    val.into_iter()
+}


### PR DESCRIPTION
When the feature is enabled, Rayon and parallel iterators are used.  

When the feature is disabled, std::iter::Iterator is used and operations are sequential.