### PR TITLE
Remove memchr and add more examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,6 @@ core-foundation-sys = "0.8"
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.build-dependencies]
 cc = "1.0"
 
-[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-memchr = "2.3"
-
 [lib]
 name = "sysinfo"
 crate_type = ["rlib", "cdylib"]

--- a/examples/src/simple.rs
+++ b/examples/src/simple.rs
@@ -132,6 +132,10 @@ fn print_help() {
         "frequency          : Displays processor frequency"
     );
     writeln!(&mut io::stdout(), "users              : Displays all users");
+    writeln!(
+        &mut io::stdout(),
+        "system             : Displays system information (such as name, version and hostname)"
+    );
     writeln!(&mut io::stdout(), "quit               : exit the program");
 }
 
@@ -373,6 +377,24 @@ fn interpret_input(input: &str, sys: &mut System) -> bool {
                     x
                 );
             }
+        }
+        "system" => {
+            writeln!(
+                &mut io::stdout(),
+                "System name:      {}",
+                sys.get_name().unwrap_or_else(|| "<unknown>".to_owned())
+            );
+            writeln!(
+                &mut io::stdout(),
+                "System version:   {}",
+                sys.get_version().unwrap_or_else(|| "<unknown>".to_owned())
+            );
+            writeln!(
+                &mut io::stdout(),
+                "System host name: {}",
+                sys.get_host_name()
+                    .unwrap_or_else(|| "<unknown>".to_owned())
+            );
         }
         e => {
             writeln!(

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -511,10 +511,10 @@ impl SystemExt for System {
         let hostname_max = unsafe { sysconf(_SC_HOST_NAME_MAX) };
         let mut buffer = vec![0_u8; hostname_max as usize];
         if unsafe { libc::gethostname(buffer.as_mut_ptr() as *mut c_char, buffer.len()) } == 0 {
-            //shrink buffer to terminate the null bytes
-            let null_position = memchr::memchr(0, &buffer)?;
-            buffer.resize(null_position, 0);
-
+            if let Some(pos) = buffer.iter().position(|x| *x == 0) {
+                // Shrink buffer to terminate the null bytes
+                buffer.resize(pos, 0);
+            }
             String::from_utf8(buffer).ok()
         } else {
             sysinfo_debug!("gethostname failed: hostname cannot be retrieved...");

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -97,9 +97,6 @@ cfg_if! {
     } else if #[cfg(any(target_os = "linux", target_os = "android"))] {
         mod linux;
         use linux as sys;
-        // Can remove once `slice_internals` is stabilized
-        // https://doc.rust-lang.org/core/slice/memchr/fn.memchr.html
-        extern crate memchr;
 
         #[cfg(test)]
         const MIN_USERS: usize = 1;


### PR DESCRIPTION
@deg4uss3r : Just realized that it was a `vec` and that there was a much simpler way to do it which doesn't require to have the `memchr` dependency in #393. I also realized that I forgot to ask you to add an extra command in the example. And since I forgot to do it for the system name and version, I did the 3 at once. :)

Once this is merged, the next PR will be to upgrade the crate version.