### PR TITLE
Change return type of SystemExt::get_physical_core_count from "usize" into "Option<usize>"

### DIFF
--- a/src/apple/system.rs
+++ b/src/apple/system.rs
@@ -347,7 +347,7 @@ impl SystemExt for System {
         &self.processors
     }
 
-    fn get_physical_core_count(&self) -> usize {
+    fn get_physical_core_count(&self) -> Option<usize> {
         let mut physical_core_count = 0;
 
         if unsafe {
@@ -357,9 +357,9 @@ impl SystemExt for System {
                 &mut physical_core_count as *mut usize as *mut c_void,
             )
         } {
-            physical_core_count
+            Some(physical_core_count)
         } else {
-            0
+            None
         }
     }
 

--- a/src/linux/processor.rs
+++ b/src/linux/processor.rs
@@ -261,13 +261,13 @@ pub fn get_cpu_frequency(cpu_core_index: usize) -> u64 {
         .unwrap_or_default()
 }
 
-pub fn get_physical_core_count() -> usize {
+pub fn get_physical_core_count() -> Option<usize> {
     let mut s = String::new();
     if File::open("/proc/cpuinfo")
         .and_then(|mut f| f.read_to_string(&mut s))
         .is_err()
     {
-        return 0;
+        return None;
     }
 
     let mut core_ids_and_physical_ids: HashSet<String> = HashSet::new();
@@ -294,7 +294,7 @@ pub fn get_physical_core_count() -> usize {
         }
     }
 
-    core_ids_and_physical_ids.len()
+    Some(core_ids_and_physical_ids.len())
 }
 
 /// Returns the brand/vendor string for the first CPU (which should be the same for all CPUs).

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -421,7 +421,7 @@ impl SystemExt for System {
         &self.processors
     }
 
-    fn get_physical_core_count(&self) -> usize {
+    fn get_physical_core_count(&self) -> Option<usize> {
         get_physical_core_count()
     }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -733,7 +733,7 @@ pub trait SystemExt: Sized + Debug + Default {
     /// ```
     fn get_processors(&self) -> &[Processor];
 
-    /// Returns the number of physical cores on the processor.
+    /// Returns the number of physical cores on the processor or `None` if it couldn't get it.
     ///
     /// In case there are multiple CPUs, it will combine the physical core count of all the CPUs.
     ///
@@ -743,9 +743,9 @@ pub trait SystemExt: Sized + Debug + Default {
     /// use sysinfo::{ProcessorExt, System, SystemExt};
     ///
     /// let s = System::new();
-    /// println!("{}", s.get_physical_core_count());
+    /// println!("{:?}", s.get_physical_core_count());
     /// ```
-    fn get_physical_core_count(&self) -> usize;
+    fn get_physical_core_count(&self) -> Option<usize>;
 
     /// Returns the RAM size in kB.
     ///

--- a/src/unknown/system.rs
+++ b/src/unknown/system.rs
@@ -76,8 +76,8 @@ impl SystemExt for System {
         &[]
     }
 
-    fn get_physical_core_count(&self) -> usize {
-        0
+    fn get_physical_core_count(&self) -> Option<usize> {
+        None
     }
 
     fn get_total_memory(&self) -> u64 {

--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -326,7 +326,7 @@ impl SystemExt for System {
         &self.processors
     }
 
-    fn get_physical_core_count(&self) -> usize {
+    fn get_physical_core_count(&self) -> Option<usize> {
         get_physical_core_count()
     }
 

--- a/tests/processor.rs
+++ b/tests/processor.rs
@@ -24,7 +24,7 @@ fn test_physical_core_numbers() {
     use sysinfo::SystemExt;
 
     let s = sysinfo::System::new();
-    assert_ne!(s.get_physical_core_count(), 0);
-    let s = sysinfo::System::new_all();
-    assert_ne!(s.get_physical_core_count(), 0);
+    let count = s.get_physical_core_count();
+    assert_ne!(count, None);
+    assert!(count.unwrap() > 0);
 }


### PR DESCRIPTION
Follow-up of #408.

@mjarkk: After thinking about it for a while, I think it makes more sense to return `None` instead of `0` when we failed to get the number. At least we make it explicit which makes more sense.