### PR TITLE
Split `get_version()` into `get_kernel_version()` and `get_os_version()` [macOS, iOS, Linux]

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ for (pid, process) in sys.get_processes() {
 }
 
 // Display system information:
-println!("System name:      {:?}", sys.get_name());
+println!("System name:             {:?}", sys.get_name());
 println!("System kernel version:   {:?}", sys.get_kernel_version());
-println!("System OS version:   {:?}", sys.get_os_version());
-println!("System host name: {:?}", sys.get_host_name());
+println!("System OS version:       {:?}", sys.get_os_version());
+println!("System host name:        {:?}", sys.get_host_name());
 ```
 
 By default, `sysinfo` uses multiple threads. However, this can increase the memory usage on some platforms (macOS for example).  The behavior can be disabled by setting `default-features = false` in `Cargo.toml` (which disables the `multithread` cargo feature).

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ for (pid, process) in sys.get_processes() {
 
 // Display system information:
 println!("System name:      {:?}", sys.get_name());
-println!("System version:   {:?}", sys.get_version());
+println!("System kernel version:   {:?}", sys.get_kernel_version());
+println!("System OS version:   {:?}", sys.get_os_version());
 println!("System host name: {:?}", sys.get_host_name());
 ```
 

--- a/examples/src/simple.rs
+++ b/examples/src/simple.rs
@@ -381,24 +381,12 @@ fn interpret_input(input: &str, sys: &mut System) -> bool {
         "system" => {
             writeln!(
                 &mut io::stdout(),
-                "System name:      {}",
-                sys.get_name().unwrap_or_else(|| "<unknown>".to_owned())
-            );
-            writeln!(
-                &mut io::stdout(),
-                "System kernel version:   {}",
-                sys.get_kernel_version().unwrap_or_else(|| "<unknown>".to_owned())
-            );
-            writeln!(
-                &mut io::stdout(),
-                "System OS version:   {}",
-                sys.get_os_version().unwrap_or_else(|| "<unknown>".to_owned())
-            );
-            writeln!(
-                &mut io::stdout(),
-                "System host name: {}",
+                "System name:           {}\nSystem kernel version: {}\nSystem OS version:     {}\nSystem host name:      {}",
+                sys.get_name().unwrap_or_else(|| "<unknown>".to_owned()),
+                sys.get_kernel_version().unwrap_or_else(|| "<unknown>".to_owned()),
+                sys.get_os_version().unwrap_or_else(|| "<unknown>".to_owned()),
                 sys.get_host_name()
-                    .unwrap_or_else(|| "<unknown>".to_owned())
+                    .unwrap_or_else(|| "<unknown>".to_owned()),
             );
         }
         e => {

--- a/examples/src/simple.rs
+++ b/examples/src/simple.rs
@@ -381,7 +381,10 @@ fn interpret_input(input: &str, sys: &mut System) -> bool {
         "system" => {
             writeln!(
                 &mut io::stdout(),
-                "System name:           {}\nSystem kernel version: {}\nSystem OS version:     {}\nSystem host name:      {}",
+                "System name:           {}\n\
+                System kernel version: {}\n\
+                System OS version:     {}\n\
+                System host name:      {}",
                 sys.get_name().unwrap_or_else(|| "<unknown>".to_owned()),
                 sys.get_kernel_version().unwrap_or_else(|| "<unknown>".to_owned()),
                 sys.get_os_version().unwrap_or_else(|| "<unknown>".to_owned()),

--- a/examples/src/simple.rs
+++ b/examples/src/simple.rs
@@ -386,8 +386,13 @@ fn interpret_input(input: &str, sys: &mut System) -> bool {
             );
             writeln!(
                 &mut io::stdout(),
-                "System version:   {}",
-                sys.get_version().unwrap_or_else(|| "<unknown>".to_owned())
+                "System kernel version:   {}",
+                sys.get_kernel_version().unwrap_or_else(|| "<unknown>".to_owned())
+            );
+            writeln!(
+                &mut io::stdout(),
+                "System OS version:   {}",
+                sys.get_os_version().unwrap_or_else(|| "<unknown>".to_owned())
             );
             writeln!(
                 &mut io::stdout(),

--- a/src/apple/system.rs
+++ b/src/apple/system.rs
@@ -458,11 +458,7 @@ impl SystemExt for System {
         unsafe {
             // get the size for the buffer first
             let mut size = 0;
-            get_sys_value_by_name(
-                b"kern.osproductversion\0",
-                &mut size,
-                std::ptr::null_mut(),
-            );
+            get_sys_value_by_name(b"kern.osproductversion\0", &mut size, std::ptr::null_mut());
             // now create a buffer with the size and get the real value
             let mut buf = vec![0_u8; size as usize];
             get_sys_value_by_name(

--- a/src/apple/system.rs
+++ b/src/apple/system.rs
@@ -453,6 +453,28 @@ impl SystemExt for System {
     fn get_version(&self) -> Option<String> {
         get_system_info(libc::KERN_OSRELEASE, None)
     }
+
+    fn get_os_version(&self) -> Option<String> {
+        unsafe {
+            // get the size for the buffer first
+            let mut size = 0;
+            libc::sysctlbyname(
+                b"kern.osproductversion\0".as_ptr() as *const c_char,
+                std::ptr::null_mut(),
+                &mut size,
+                std::ptr::null_mut(),
+                0,
+            );
+            // now create a buffer with the size and get the real value
+            let mut buf = vec![0_u8; size as usize];
+            get_sys_value_by_name(
+                b"kern.osproductversion\0",
+                size,
+                buf.as_mut_ptr() as *mut c_void,
+            );
+            String::from_utf8(buf).ok()
+        }
+    }
 }
 
 impl Default for System {

--- a/src/apple/system.rs
+++ b/src/apple/system.rs
@@ -569,7 +569,7 @@ unsafe fn get_sys_value_by_name(name: &[u8], len: &mut usize, value: *mut libc::
         name.as_ptr() as *const c_char,
         value,
         len,
-        ::std::ptr::null_mut(),
+        std::ptr::null_mut(),
         0,
     ) == 0
 }

--- a/src/apple/system.rs
+++ b/src/apple/system.rs
@@ -458,15 +458,26 @@ impl SystemExt for System {
         unsafe {
             // get the size for the buffer first
             let mut size = 0;
-            get_sys_value_by_name(b"kern.osproductversion\0", &mut size, std::ptr::null_mut());
-            // now create a buffer with the size and get the real value
-            let mut buf = vec![0_u8; size as usize];
-            get_sys_value_by_name(
-                b"kern.osproductversion\0",
-                &mut size,
-                buf.as_mut_ptr() as *mut c_void,
-            );
-            String::from_utf8(buf).ok()
+            if get_sys_value_by_name(b"kern.osproductversion\0", &mut size, std::ptr::null_mut())
+                && size > 0
+            {
+                // now create a buffer with the size and get the real value
+                let mut buf = vec![0_u8; size as usize];
+
+                if get_sys_value_by_name(
+                    b"kern.osproductversion\0",
+                    &mut size,
+                    buf.as_mut_ptr() as *mut c_void,
+                ) {
+                    String::from_utf8(buf).ok()
+                } else {
+                    // getting the system value failed
+                    None
+                }
+            } else {
+                // getting the system value failed, or did not return a buffer size
+                None
+            }
         }
     }
 }

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -13,7 +13,7 @@ use crate::{Disk, LoadAvg, Networks, Pid, ProcessExt, RefreshKind, SystemExt, Us
 use libc::{self, c_char, gid_t, sysconf, uid_t, _SC_CLK_TCK, _SC_HOST_NAME_MAX, _SC_PAGESIZE};
 use std::cell::UnsafeCell;
 use std::collections::HashMap;
-use std::fs::{self, File};
+use std::fs::{self, File, read_to_string};
 use std::io::{self, BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -520,16 +520,10 @@ impl SystemExt for System {
     }
 
     fn get_kernel_version(&self) -> Option<String> {
-        let mut s = String::new();
-
-        if File::open("/proc/version")
-            .and_then(|mut f| f.read_to_string(&mut s))
-            .is_err()
-        {
-            return None;
+        match read_to_string("/proc/version") {
+            Ok(s) => s.trim().split(' ').nth(2).map(String::from),
+            Err(_) => None,
         }
-
-        s.trim().split(' ').nth(2).map(String::from)
     }
 
     fn get_os_version(&self) -> Option<String> {

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -13,7 +13,7 @@ use crate::{Disk, LoadAvg, Networks, Pid, ProcessExt, RefreshKind, SystemExt, Us
 use libc::{self, c_char, gid_t, sysconf, uid_t, _SC_CLK_TCK, _SC_HOST_NAME_MAX, _SC_PAGESIZE};
 use std::cell::UnsafeCell;
 use std::collections::HashMap;
-use std::fs::{self, File, read_to_string};
+use std::fs::{self, read_to_string, File};
 use std::io::{self, BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -526,7 +526,24 @@ impl SystemExt for System {
         }
     }
 
-    fn get_version(&self) -> Option<String> {
+    fn get_kernel_version(&self) -> Option<String> {
+        let mut s = String::new();
+    
+        if File::open("/proc/version")
+            .and_then(|mut f| f.read_to_string(&mut s))
+            .is_err()
+        {
+            return None;
+        }
+        
+        Some(s
+            .trim()
+            .split(' ')
+            .nth(2)
+            .map(String::from))
+    } 
+
+    fn get_os_version(&self) -> Option<String> {
         get_system_info("VERSION_ID=")
     }
 }

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -528,20 +528,16 @@ impl SystemExt for System {
 
     fn get_kernel_version(&self) -> Option<String> {
         let mut s = String::new();
-    
+
         if File::open("/proc/version")
             .and_then(|mut f| f.read_to_string(&mut s))
             .is_err()
         {
             return None;
         }
-        
-        Some(s
-            .trim()
-            .split(' ')
-            .nth(2)
-            .map(String::from))
-    } 
+
+        s.trim().split(' ').nth(2).map(String::from)
+    }
 
     fn get_os_version(&self) -> Option<String> {
         get_system_info("VERSION_ID=")

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -217,6 +217,10 @@ mod test {
         assert!(s.get_users().len() >= MIN_USERS);
     }
 
+    // FIXME we are still working out the windows API for proper version info
+    // see https://github.com/GuillaumeGomez/sysinfo/issues/415
+    // and https://github.com/GuillaumeGomez/sysinfo/issues/410
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn check_system_info() {
         // We don't want to test on unknown systems.

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -223,7 +223,7 @@ mod test {
         if MIN_USERS > 0 {
             let s = System::new();
             assert!(!s.get_name().expect("Failed to get system name").is_empty());
-            
+
             cfg_if! {
                 if #[cfg(not(target_os = "windows"))] {
                     assert!(!s

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -217,20 +217,22 @@ mod test {
         assert!(s.get_users().len() >= MIN_USERS);
     }
 
-    // FIXME we are still working out the windows API for proper version info
-    // see https://github.com/GuillaumeGomez/sysinfo/issues/415
-    // and https://github.com/GuillaumeGomez/sysinfo/issues/410
-    #[cfg(not(target_os = "windows"))]
     #[test]
     fn check_system_info() {
         // We don't want to test on unknown systems.
         if MIN_USERS > 0 {
             let s = System::new();
             assert!(!s.get_name().expect("Failed to get system name").is_empty());
-            assert!(!s
-                .get_kernel_version()
-                .expect("Failed to get system version")
-                .is_empty());
+            
+            cfg_if! {
+                if #[cfg(not(target_os = "windows"))] {
+                    assert!(!s
+                    .get_kernel_version()
+                    .expect("Failed to get system version")
+                    .is_empty());
+                    }
+            }
+
             assert!(!s
                 .get_os_version()
                 .expect("Failed to get system version")

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -41,10 +41,10 @@
 //! println!("used swap   : {} KB", system.get_used_swap());
 //!
 //! // Display system information:
-//! println!("System name:      {:?}", system.get_name());
+//! println!("System name:             {:?}", system.get_name());
 //! println!("System kernel version:   {:?}", system.get_kernel_version());
-//! println!("System os version:   {:?}", system.get_os_version());
-//! println!("System host name: {:?}", system.get_host_name());
+//! println!("System OS version:       {:?}", system.get_os_version());
+//! println!("System host name:        {:?}", system.get_host_name());
 //! ```
 
 #![crate_name = "sysinfo"]
@@ -225,6 +225,10 @@ mod test {
             assert!(!s.get_name().expect("Failed to get system name").is_empty());
             assert!(!s
                 .get_kernel_version()
+                .expect("Failed to get system version")
+                .is_empty());
+            assert!(!s
+                .get_os_version()
                 .expect("Failed to get system version")
                 .is_empty());
         }

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -42,7 +42,8 @@
 //!
 //! // Display system information:
 //! println!("System name:      {:?}", system.get_name());
-//! println!("System version:   {:?}", system.get_version());
+//! println!("System kernel version:   {:?}", system.get_kernel_version());
+//! println!("System os version:   {:?}", system.get_os_version());
 //! println!("System host name: {:?}", system.get_host_name());
 //! ```
 
@@ -223,7 +224,7 @@ mod test {
             let s = ::System::new();
             assert!(!s.get_name().expect("Failed to get system name").is_empty());
             assert!(!s
-                .get_version()
+                .get_kernel_version()
                 .expect("Failed to get system version")
                 .is_empty());
         }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -973,7 +973,7 @@ pub trait SystemExt: Sized + Debug + Default {
     /// ```
     fn get_kernel_version(&self) -> Option<String>;
 
-    /// Returns the system version (e.g. for MacOS this will return 11.1 rather than the kernel version)
+    /// Returns the system version (e.g. for MacOS this will return 11.1 rather than the kernel version).
     ///
     /// **Important**: this information is computed every time this function is called.
     ///
@@ -981,7 +981,7 @@ pub trait SystemExt: Sized + Debug + Default {
     /// use sysinfo::{System, SystemExt};
     ///
     /// let s = System::new();
-    /// println!("MacOS: {:?}", s.get_os_version());
+    /// println!("OS version: {:?}", s.get_os_version());
     /// ```
     fn get_os_version(&self) -> Option<String>;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -973,6 +973,19 @@ pub trait SystemExt: Sized + Debug + Default {
     /// ```
     fn get_version(&self) -> Option<String>;
 
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    /// Returns the system version (e.g. for MacOS this will return 11.1 rather than the kernel version)
+    ///
+    /// **Important**: this information is computed every time this function is called.
+    ///
+    /// ```no_run
+    /// use sysinfo::{System, SystemExt};
+    ///
+    /// let s = System::new();
+    /// println!("MacOS: {:?}", s.get_os_version());
+    /// ```
+    fn get_os_version(&self) -> Option<String>;
+
     /// Returns the system hostname based off DNS
     ///
     /// **Important**: this information is computed every time this function is called.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -961,7 +961,7 @@ pub trait SystemExt: Sized + Debug + Default {
     /// ```
     fn get_name(&self) -> Option<String>;
 
-    /// Returns the system version.
+    /// Returns the system's kernel version.
     ///
     /// **Important**: this information is computed every time this function is called.
     ///
@@ -969,7 +969,7 @@ pub trait SystemExt: Sized + Debug + Default {
     /// use sysinfo::{System, SystemExt};
     ///
     /// let s = System::new();
-    /// println!("OS version: {:?}", s.get_version());
+    /// println!("kernel version: {:?}", s.get_kernel_version());
     /// ```
     fn get_kernel_version(&self) -> Option<String>;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -971,9 +971,8 @@ pub trait SystemExt: Sized + Debug + Default {
     /// let s = System::new();
     /// println!("OS version: {:?}", s.get_version());
     /// ```
-    fn get_version(&self) -> Option<String>;
+    fn get_kernel_version(&self) -> Option<String>;
 
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
     /// Returns the system version (e.g. for MacOS this will return 11.1 rather than the kernel version)
     ///
     /// **Important**: this information is computed every time this function is called.

--- a/src/unknown/system.rs
+++ b/src/unknown/system.rs
@@ -148,11 +148,15 @@ impl SystemExt for System {
         None
     }
 
-    fn get_host_name(&self) -> Option<String> {
+    fn get_kernel_version(&self) -> Option<String> {
+        None
+    }
+    
+    fn get_os_version(&self) -> Option<String> {
         None
     }
 
-    fn get_version(&self) -> Option<String> {
+    fn get_host_name(&self) -> Option<String> {
         None
     }
 }

--- a/src/unknown/system.rs
+++ b/src/unknown/system.rs
@@ -151,7 +151,7 @@ impl SystemExt for System {
     fn get_kernel_version(&self) -> Option<String> {
         None
     }
-    
+
     fn get_os_version(&self) -> Option<String> {
         None
     }

--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -407,10 +407,17 @@ impl SystemExt for System {
         get_dns_hostname()
     }
 
+    // FIXME currently we are figuring out the best way to return kernel version for Windows
+    // see https://github.com/GuillaumeGomez/sysinfo/issues/415
+    // and https://github.com/GuillaumeGomez/sysinfo/issues/410
+    // this function currently returns None
     fn get_kernel_version(&self) -> Option<String> {
-        get_system_version()
+        None
     }
 
+    // FIXME currently we are figuring out the best way to return OS version for Windows
+    // see https://github.com/GuillaumeGomez/sysinfo/issues/415
+    // and https://github.com/GuillaumeGomez/sysinfo/issues/410
     fn get_os_version(&self) -> Option<String> {
         get_system_version()
     }

--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -407,7 +407,11 @@ impl SystemExt for System {
         get_dns_hostname()
     }
 
-    fn get_version(&self) -> Option<String> {
+    fn get_kernel_version(&self) -> Option<String> {
+        get_system_version()
+    }
+
+    fn get_os_version(&self) -> Option<String> {
         get_system_version()
     }
 }


### PR DESCRIPTION
This may not be the best way to go about it, but I'm happy to adjust! 

closes #413 
related #415 

Also during an `xcodebuild test ... iOS` of a project I am working on I cannot confirm this works for iOS can someone help confirm this will return something like `14.3` on iOS? 