### PR TITLE
Implement Android system information retrieval

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,6 +59,11 @@ jobs:
           ## ARMv6
           - { os: 'ubuntu-latest', target: 'arm-unknown-linux-gnueabihf',  cross: true }
           - { os: 'ubuntu-latest', target: 'arm-unknown-linux-musleabihf', cross: true }
+          # Android
+          - { os: 'ubuntu-latest', target: 'aarch64-linux-android', cross: true }
+          - { os: 'ubuntu-latest', target: 'armv7-linux-androideabi', cross: true }
+          - { os: 'ubuntu-latest', target: 'x86_64-linux-android', cross: true }
+          - { os: 'ubuntu-latest', target: 'i686-linux-android', cross: true }
         toolchain:
           - "1.45.0"  # minimum supported rust version
           - stable

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Supports the following platforms:
  * iOS
  * Windows
 
-It also compiles for Android but never been tested on it.
-
 The minimum-supported version fo `rustc` is **1.45**.
 
 ### Use in binaries distributed on the MacOS App Store


### PR DESCRIPTION
This PR adds support for fetching system property strings on Android.

Two things were modified in the process:
1. The code specific to Android missing `RLIMIT_NOFILE` has been removed. This was fixed [almost a year ago in libc](https://github.com/rust-lang/libc/pull/1746).
2. `SystemExt::get_kernel_version` was rewritten to use the [uname](https://docs.rs/libc/0.2.85/libc/fn.uname.html) syscall instead. Reading from `/proc/version` is not allowed on Android inside the app sandbox by default.

The new code added to fetch values in an Android specific way has been tested on an emulator and physical device via adb:
```
SystemExt::get_host_name(): Some("localhost")

SystemExt::get_os_version(): 
	- Emulator: Some("11")
	- Physical: Some("10")
	
SystemExt::get_kernel_version(): 
	- Emulator: Some("5.4.61-android11-0-00791-gbad091cc4bf3-ab6833933")
	- Physical: Some("4.9.186-19871035")
	
SystemExt::get_name(): 
	- Emulator: Some("sdk_gphone_x86_64_arm64")
	- Physical: Some("SM-N960U1")
```