### PR TITLE
Fix a few issues

### DIFF
--- a/src/linux/disk.rs
+++ b/src/linux/disk.rs
@@ -175,7 +175,13 @@ fn get_all_disks_inner(content: &str) -> Vec<Disk> {
             // fs_spec<tab>fs_file<tab>fs_vfstype<tab>other fields
             let mut fields = line.split_whitespace();
             let fs_spec = fields.next().unwrap_or("");
-            let fs_file = fields.next().unwrap_or("");
+            let fs_file = fields
+                .next()
+                .unwrap_or("")
+                .replace("\\134", "\\")
+                .replace("\\040", " ")
+                .replace("\\011", "\t")
+                .replace("\\012", "\n");
             let fs_vfstype = fields.next().unwrap_or("");
             (fs_spec, fs_file, fs_vfstype)
         })
@@ -198,11 +204,11 @@ fn get_all_disks_inner(content: &str) -> Vec<Disk> {
             !(filtered ||
                fs_file.starts_with("/sys") || // check if fs_file is an 'ignored' mount point
                fs_file.starts_with("/proc") ||
-               fs_file.starts_with("/run") ||
+               (fs_file.starts_with("/run") && !fs_file.starts_with("/run/media")) ||
                fs_spec.starts_with("sunrpc"))
         })
         .filter_map(|(fs_spec, fs_file, fs_vfstype)| {
-            new_disk(fs_spec.as_ref(), Path::new(fs_file), fs_vfstype.as_bytes())
+            new_disk(fs_spec.as_ref(), Path::new(&fs_file), fs_vfstype.as_bytes())
         })
         .collect()
 }


### PR DESCRIPTION
1) Correctly unescape the following sequences as per
https://github.com/torvalds/linux/blob/dd86e7fa07a3ec33c92c957ea7b642c4702516a0/fs/proc_namespace.c#L152 :

' ' becomes \040
'\' becomes \134
'\t' becomes \\011
'\n' becomes \\012

2) Allow /run/media as the mount path as this is often used for
mounts by desktop environments using udisks2.

Signed-off-by: Peter De Schrijver <p2@psychaos.be>