### PR TITLE
Add Get Long OS Version

### DIFF
--- a/src/apple/system.rs
+++ b/src/apple/system.rs
@@ -467,7 +467,13 @@ impl SystemExt for System {
     fn get_long_os_version(&self) -> Option<String> {
         #[cfg(target_os = "macos")]
         let friendly_name = match self.get_os_version().unwrap_or_default() {
-            f_n if f_n.starts_with("10.16") | f_n.starts_with("11.0") |  f_n.starts_with("11.1") | f_n.starts_with("11.2") => "Big Sur",
+            f_n if f_n.starts_with("10.16")
+                | f_n.starts_with("11.0")
+                | f_n.starts_with("11.1")
+                | f_n.starts_with("11.2") =>
+            {
+                "Big Sur"
+            }
             f_n if f_n.starts_with("10.15") => "Catalina",
             f_n if f_n.starts_with("10.14") => "Mojave",
             f_n if f_n.starts_with("10.13") => "High Sierra",
@@ -488,13 +494,16 @@ impl SystemExt for System {
         };
 
         #[cfg(target_os = "macos")]
-        let long_name = Some(format!("MacOS {} {}", self.get_os_version().unwrap_or_default(), friendly_name)); 
+        let long_name = Some(format!(
+            "MacOS {} {}",
+            self.get_os_version().unwrap_or_default(),
+            friendly_name
+        ));
 
         #[cfg(target_os = "ios")]
         let long_name = Some(format!("iOS {}", self.get_os_version().unwrap_or_default()));
 
         long_name
-        
     }
 
     fn get_host_name(&self) -> Option<String> {
@@ -636,7 +645,7 @@ fn get_system_info(value: c_int, default: Option<&str>) -> Option<String> {
     let mut mib: [c_int; 2] = [libc::CTL_KERN, value];
     let mut size = 0;
 
-    // Call first to get size 
+    // Call first to get size
     unsafe {
         libc::sysctl(
             mib.as_mut_ptr(),
@@ -646,13 +655,13 @@ fn get_system_info(value: c_int, default: Option<&str>) -> Option<String> {
             std::ptr::null_mut(),
             0,
         )
-    }; 
+    };
 
-    // exit early if we did not update the size 
+    // exit early if we did not update the size
     if size == 0 {
         default.map(|s| s.to_owned())
     } else {
-        // set the buffer to the correct size 
+        // set the buffer to the correct size
         let mut buf = vec![0_u8; size as usize];
 
         if unsafe {
@@ -664,7 +673,8 @@ fn get_system_info(value: c_int, default: Option<&str>) -> Option<String> {
                 std::ptr::null_mut(),
                 0,
             )
-        } == -1 {
+        } == -1
+        {
             // If command fails return default
             default.map(|s| s.to_owned())
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,6 +237,18 @@ mod test {
                 .is_empty());
         }
     }
+
+    #[test]
+    fn check_long_os_version() {
+        // We don't want to test on unknown systems.
+        if MIN_USERS > 0 {
+            let s = System::new();
+            assert!(!s
+                .get_long_os_version()
+                .expect("Failed to get host name")
+                .is_empty());
+        }
+    }
 }
 
 // Used to check that System is Send and Sync.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,12 +216,17 @@ mod test {
 
             assert!(!s
                 .get_kernel_version()
-                .expect("Failed to get system version")
+                .expect("Failed to get kernel version")
                 .is_empty());
 
             assert!(!s
                 .get_os_version()
-                .expect("Failed to get system version")
+                .expect("Failed to get os version")
+                .is_empty());
+
+            assert!(!s
+                .get_long_os_version()
+                .expect("Failed to get long OS version")
                 .is_empty());
         }
     }
@@ -233,18 +238,6 @@ mod test {
             let s = System::new();
             assert!(!s
                 .get_host_name()
-                .expect("Failed to get host name")
-                .is_empty());
-        }
-    }
-
-    #[test]
-    fn check_long_os_version() {
-        // We don't want to test on unknown systems.
-        if MIN_USERS > 0 {
-            let s = System::new();
-            assert!(!s
-                .get_long_os_version()
                 .expect("Failed to get host name")
                 .is_empty());
         }

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -492,20 +492,17 @@ impl SystemExt for System {
 
     fn get_long_os_version(&self) -> Option<String> {
         #[cfg(target_os = "android")]
-        let long_name = format!(
-            "Android {} {}",
+        let system_name = "Android";
+
+        #[cfg(not(target_os = "android"))]
+        let system_name = "Linux";
+
+        Some(format!(
+            "{} {} {}",
+            system_name,
             self.get_os_version().unwrap_or_default(),
             self.get_name().unwrap_or_default()
-        );
-
-        #[cfg(target_os = "linux")]
-        let long_name = format!(
-            "Linux {} {}",
-            self.get_os_version().unwrap_or_default(),
-            self.get_name().unwrap_or_default()
-        );
-
-        Some(long_name)
+        ))
     }
 
     fn get_host_name(&self) -> Option<String> {

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -492,10 +492,18 @@ impl SystemExt for System {
 
     fn get_long_os_version(&self) -> Option<String> {
         #[cfg(target_os = "android")]
-        let long_name = format!("Android {} {}", self.get_os_version().unwrap_or_default(), self.get_name().unwrap_or_default());
+        let long_name = format!(
+            "Android {} {}",
+            self.get_os_version().unwrap_or_default(),
+            self.get_name().unwrap_or_default()
+        );
 
         #[cfg(target_os = "linux")]
-        let long_name = format!("Linux {} {}", self.get_os_version().unwrap_or_default(), self.get_name().unwrap_or_default());
+        let long_name = format!(
+            "Linux {} {}",
+            self.get_os_version().unwrap_or_default(),
+            self.get_name().unwrap_or_default()
+        );
 
         Some(long_name)
     }

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -490,6 +490,16 @@ impl SystemExt for System {
         get_system_info(InfoType::Name)
     }
 
+    fn get_long_os_version(&self) -> Option<String> {
+        #[cfg(target_os = "android")]
+        let long_name = format!("Android {} {}", get_os_version(), get_name());
+
+        #[cfg(target_os = "linux")]
+        let long_name = format!("Linux {} {}", get_os_version(), get_name());
+
+        Some(long_name)
+    }
+
     fn get_host_name(&self) -> Option<String> {
         let hostname_max = unsafe { sysconf(_SC_HOST_NAME_MAX) };
         let mut buffer = vec![0_u8; hostname_max as usize];

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -980,7 +980,7 @@ pub trait SystemExt: Sized + Debug + Default {
     /// ```
     fn get_os_version(&self) -> Option<String>;
 
-    /// Returns the system long os version (e.g MacOS 11.2 BigSur).
+    /// Returns the system long os version (e.g "MacOS 11.2 BigSur").
     ///
     /// **Important**: this information is computed every time this function is called.
     ///

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -980,6 +980,18 @@ pub trait SystemExt: Sized + Debug + Default {
     /// ```
     fn get_os_version(&self) -> Option<String>;
 
+    /// Returns the system long os version (e.g MacOS 11.2 BigSur).
+    ///
+    /// **Important**: this information is computed every time this function is called.
+    ///
+    /// ```no_run
+    /// use sysinfo::{System, SystemExt};
+    ///
+    /// let s = System::new();
+    /// println!("Long OS Version: {:?}", s.get_long_os_version());
+    /// ```
+    fn get_long_os_version(&self) -> Option<String>;
+
     /// Returns the system hostname based off DNS
     ///
     /// **Important**: this information is computed every time this function is called.

--- a/src/unknown/system.rs
+++ b/src/unknown/system.rs
@@ -148,6 +148,10 @@ impl SystemExt for System {
         None
     }
 
+    fn get_long_os_version(&self) -> Option<String> {
+        None
+    }
+
     fn get_kernel_version(&self) -> Option<String> {
         None
     }

--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -402,6 +402,14 @@ impl SystemExt for System {
         Some("Windows".to_owned())
     }
 
+    fn get_long_os_version(&self) -> Option<String> {
+        get_reg_string_value(
+            HKEY_LOCAL_MACHINE,
+            "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
+            "ProductName",
+        )
+    }
+
     fn get_host_name(&self) -> Option<String> {
         get_dns_hostname()
     }
@@ -415,11 +423,19 @@ impl SystemExt for System {
     }
 
     fn get_os_version(&self) -> Option<String> {
-        get_reg_string_value(
+        let major = get_reg_value_u32(
             HKEY_LOCAL_MACHINE,
             "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
-            "ProductName",
-        )
+            "CurrentMajorVersionNumber",
+        );
+
+        let minor = get_reg_value_u32(
+            HKEY_LOCAL_MACHINE,
+            "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
+            "CurrentMinorVersionNumber",
+        ); 
+
+        Some(format!("{}.{}", u32::from_le_bytes(major.unwrap_or_default()), u32::from_le_bytes(minor.unwrap_or_default())))
     }
 }
 
@@ -524,6 +540,37 @@ fn get_reg_string_value(hkey: HKEY, path: &str, field_name: &str) -> Option<Stri
         s.pop();
     }
     Some(s)
+}
+
+fn get_reg_value_u32(hkey: HKEY, path: &str, field_name: &str) -> Option<[u8; 4]> {
+    let c_path = utf16_str(path);
+    let c_field_name = utf16_str(field_name);
+
+    let mut new_hkey: HKEY = std::ptr::null_mut();
+    if unsafe { RegOpenKeyExW(hkey, c_path.as_ptr(), 0, KEY_READ, &mut new_hkey) } != 0 {
+        return None;
+    }
+
+    let mut buf_len: DWORD = 4;
+    let mut buf_type: DWORD = 0;
+    let mut buf= [0u8; 4];
+    loop {
+        match unsafe {
+            RegQueryValueExW(
+                new_hkey,
+                c_field_name.as_ptr(),
+                std::ptr::null_mut(),
+                &mut buf_type,
+                buf.as_mut_ptr() as LPBYTE,
+                &mut buf_len,
+            ) as DWORD
+        } {
+            0 => break,
+            _ => return None,
+        }
+    }
+
+    Some(buf)
 }
 
 fn get_dns_hostname() -> Option<String> {

--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -433,9 +433,13 @@ impl SystemExt for System {
             HKEY_LOCAL_MACHINE,
             "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
             "CurrentMinorVersionNumber",
-        ); 
+        );
 
-        Some(format!("{}.{}", u32::from_le_bytes(major.unwrap_or_default()), u32::from_le_bytes(minor.unwrap_or_default())))
+        Some(format!(
+            "{}.{}",
+            u32::from_le_bytes(major.unwrap_or_default()),
+            u32::from_le_bytes(minor.unwrap_or_default())
+        ))
     }
 }
 
@@ -553,7 +557,7 @@ fn get_reg_value_u32(hkey: HKEY, path: &str, field_name: &str) -> Option<[u8; 4]
 
     let mut buf_len: DWORD = 4;
     let mut buf_type: DWORD = 0;
-    let mut buf= [0u8; 4];
+    let mut buf = [0u8; 4];
     loop {
         match unsafe {
             RegQueryValueExW(


### PR DESCRIPTION
When running `sysinfo` on Windows `get_os_version` was returning `Windows 10 Pro` which did not match the other OSes (e.g. MacOS returning `11.2` for the latest version). 

This MR adds the method `get_long_os_version()` which gives more detail to the OS version. 

Included in this MR is a better format for the Apple `get_system_info()` function that removed the unsafe `set_len()` in favor of getting the size from the initial system call and trimming the null bytes from the end of the string before returning.

For Windows `ProductName` was moved to the new `get_long_os_version()` (as it fit and was the inspiration for this MR) and for `get_os_version()` I added a way to get `u32` values from the Registry and use `CurrentMajorVersionNumber` and `CurrentMinorVersionNumber`.