### PR TITLE
macos: Check for and remove trailing nulls from sysctl strings

### DIFF
--- a/src/apple/processor.rs
+++ b/src/apple/processor.rs
@@ -230,6 +230,9 @@ fn get_sysctl_str(s: &[u8]) -> String {
         unsafe {
             buf.set_len(len);
         }
+        while buf.last() == Some(&b'\0') {
+            buf.pop();
+        }
         String::from_utf8(buf).unwrap_or_else(|_| String::new())
     } else {
         String::new()

--- a/tests/processor.rs
+++ b/tests/processor.rs
@@ -9,12 +9,18 @@
 
 #[test]
 fn test_processor() {
-    use sysinfo::SystemExt;
+    use sysinfo::{ProcessorExt, SystemExt};
 
     let s = sysinfo::System::new();
     assert!(!s.get_processors().is_empty());
     let s = sysinfo::System::new_all();
     assert!(!s.get_processors().is_empty());
+
+    assert!(s.get_processors()[0]
+        .get_brand()
+        .chars()
+        .find(|c| *c == '\0')
+        .is_none())
 }
 
 #[test]


### PR DESCRIPTION
In particular, the brand string was showing up with a trailing null for me on
my 2019 MacBook Pro, and the test that I added does fail if you remove the
check that I added.