### PR TITLE
Add `/etc/lsb-release` fallback when calculating OS version

### DIFF
--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -552,7 +552,7 @@ impl SystemExt for System {
             if #[cfg(not(target_os = "android"))] {
                 get_system_info(InfoType::OsVersion, Some(BufReader::new(File::open("/etc/os-release").ok()?)))
             } else {
-                get_system_info(InfoType::OsVersion, None)
+                get_system_info::<BufRead<File>>(InfoType::OsVersion, None)
             }
         }
     }

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -10,6 +10,7 @@ use crate::sys::process::*;
 use crate::sys::processor::*;
 use crate::{Disk, LoadAvg, Networks, Pid, ProcessExt, RefreshKind, SystemExt, User};
 
+use cfg_if::cfg_if;
 use libc::{self, c_char, gid_t, sysconf, uid_t, _SC_CLK_TCK, _SC_HOST_NAME_MAX, _SC_PAGESIZE};
 use std::cell::UnsafeCell;
 use std::collections::HashMap;
@@ -490,8 +491,13 @@ impl SystemExt for System {
     }
 
     fn get_name(&self) -> Option<String> {
-        let buf = BufReader::new(File::open("/etc/os-release").ok()?);
-        get_system_info(InfoType::Name, Some(buf))
+        cfg_if! {
+            if #[cfg(not(target_os = "android"))] {
+                get_system_info(InfoType::Name, Some(BufReader::new(File::open("/etc/os-release").ok()?)))
+            } else {
+                get_system_info(InfoType::Name, None)
+            }
+        }
     }
 
     fn get_long_os_version(&self) -> Option<String> {
@@ -544,8 +550,13 @@ impl SystemExt for System {
     }
 
     fn get_os_version(&self) -> Option<String> {
-        let buf = BufReader::new(File::open("/etc/os-release").ok()?);
-        get_system_info(InfoType::OsVersion, Some(buf))
+        cfg_if! {
+            if #[cfg(not(target_os = "android"))] {
+                get_system_info(InfoType::OsVersion, Some(BufReader::new(File::open("/etc/os-release").ok()?)))
+            } else {
+                get_system_info(InfoType::OsVersion, None)
+            }
+        }
     }
 }
 

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -552,7 +552,7 @@ impl SystemExt for System {
             if #[cfg(not(target_os = "android"))] {
                 get_system_info(InfoType::OsVersion, Some(BufReader::new(File::open("/etc/os-release").ok()?)))
             } else {
-                get_system_info::<BufRead<File>>(InfoType::OsVersion, None)
+                get_system_info::<BufReader<File>>(InfoType::OsVersion, None)
             }
         }
     }

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -493,7 +493,7 @@ impl SystemExt for System {
             if #[cfg(not(target_os = "android"))] {
                 get_system_info(InfoType::Name, Some(BufReader::new(File::open("/etc/os-release").ok()?)))
             } else {
-                get_system_info(InfoType::Name, None)
+                get_system_info::<BufReader<File>>(InfoType::Name, None)
             }
         }
     }

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -837,10 +837,7 @@ where
 }
 
 #[cfg(target_os = "android")]
-fn get_system_info<T>(info: InfoType) -> Option<String>
-where
-    T: BufRead,
-{
+fn get_system_info(info: InfoType) -> Option<String> {
     use libc::c_int;
 
     // https://android.googlesource.com/platform/bionic/+/refs/heads/master/libc/include/sys/system_properties.h#41


### PR DESCRIPTION
Per [os-release](https://www.linux.org/docs/man5/os-release.html), the VERSION_ID field is not required.
This adds a fallback using `/etc/lsb-release` for systems that do not have a VERSION_ID in the `/etc/os-release` file (such as my Manjaro dist).

Updated the `get_system_info` function to take a `BufRead` to make testing this fallback possible.