### PR TITLE
Rename ProcessStatus to_string method to as_str

### DIFF
--- a/src/apple/process.rs
+++ b/src/apple/process.rs
@@ -40,7 +40,7 @@ impl From<u32> for ProcessStatus {
 
 impl ProcessStatus {
     /// Used to display `ProcessStatus`.
-    pub fn to_string(&self) -> &str {
+    pub fn as_str(&self) -> &str {
         match *self {
             ProcessStatus::Idle => "Idle",
             ProcessStatus::Run => "Runnable",
@@ -54,7 +54,7 @@ impl ProcessStatus {
 
 impl fmt::Display for ProcessStatus {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.to_string())
+        f.write_str(self.as_str())
     }
 }
 

--- a/src/linux/process.rs
+++ b/src/linux/process.rs
@@ -73,7 +73,7 @@ impl From<char> for ProcessStatus {
 
 impl ProcessStatus {
     /// Used to display `ProcessStatus`.
-    pub fn to_string(&self) -> &str {
+    pub fn as_str(&self) -> &str {
         match *self {
             ProcessStatus::Idle => "Idle",
             ProcessStatus::Run => "Runnable",
@@ -92,7 +92,7 @@ impl ProcessStatus {
 
 impl fmt::Display for ProcessStatus {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.to_string())
+        f.write_str(self.as_str())
     }
 }
 

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -50,7 +50,7 @@ pub enum ProcessStatus {
 
 impl ProcessStatus {
     /// Used to display `ProcessStatus`.
-    pub fn to_string(&self) -> &str {
+    pub fn as_str(&self) -> &str {
         match *self {
             ProcessStatus::Run => "Runnable",
         }
@@ -59,7 +59,7 @@ impl ProcessStatus {
 
 impl fmt::Display for ProcessStatus {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.to_string())
+        f.write_str(self.as_str())
     }
 }
 


### PR DESCRIPTION
Since this is an API change, I'll need to make a big release.