### PR TITLE
Add `/etc/lsb-release` fallback when calculating OS version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ libc = "^0.2.92"
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 core-foundation-sys = "0.8"
 
+[target.'cfg(all(target_os = "linux", not(target_os = "android")))'.dev-dependencies]
+tempfile = "3.2"
+
 [lib]
 name = "sysinfo"
 crate_type = ["rlib", "cdylib"]


### PR DESCRIPTION
Take over of #452. Original PR explanations:

Per [os-release](https://www.linux.org/docs/man5/os-release.html), the VERSION_ID field is not required.
This adds a fallback using `/etc/lsb-release` for systems that do not have a VERSION_ID in the `/etc/os-release` file (such as my Manjaro dist).

Updated the `get_system_info` function to take a `BufRead` to make testing this fallback possible.