### PR TITLE
Attempt to restrict `getpwent` results on MacOS to local users

### DIFF
--- a/src/apple/users.rs
+++ b/src/apple/users.rs
@@ -53,7 +53,7 @@ fn endswith(s1: *const c_char, s2: &[u8]) -> bool {
 
 fn users_list<F>(filter: F) -> Vec<User>
 where
-    F: Fn(*const c_char) -> bool,
+    F: Fn(*const c_char, u32) -> bool,
 {
     let mut users = Vec::new();
 
@@ -63,10 +63,12 @@ where
         if pw.is_null() {
             break;
         }
-        if !filter(unsafe { (*pw).pw_shell }) {
-            // This is not a "real" user.
+
+        if !filter(unsafe { (*pw).pw_shell}, unsafe { (*pw).pw_uid }) {
+            // This is not a "real" or "local" user.
             continue;
         }
+
         let groups = get_user_groups(unsafe { (*pw).pw_name }, unsafe { (*pw).pw_gid });
         let uid = unsafe { (*pw).pw_uid };
         let gid = unsafe { (*pw).pw_gid };
@@ -86,7 +88,7 @@ where
 }
 
 pub fn get_users_list() -> Vec<User> {
-    users_list(|shell| !endswith(shell, b"/false") && !endswith(shell, b"/uucico"))
+    users_list(|shell, uid| !endswith(shell, b"/false") && !endswith(shell, b"/uucico") && uid < 65536)
 }
 
 // This was the OSX-based solution. It provides enough information, but what a mess!

--- a/src/apple/users.rs
+++ b/src/apple/users.rs
@@ -64,7 +64,7 @@ where
             break;
         }
 
-        if !filter(unsafe { (*pw).pw_shell}, unsafe { (*pw).pw_uid }) {
+        if !filter(unsafe { (*pw).pw_shell }, unsafe { (*pw).pw_uid }) {
             // This is not a "real" or "local" user.
             continue;
         }
@@ -88,7 +88,9 @@ where
 }
 
 pub fn get_users_list() -> Vec<User> {
-    users_list(|shell, uid| !endswith(shell, b"/false") && !endswith(shell, b"/uucico") && uid < 65536)
+    users_list(|shell, uid| {
+        !endswith(shell, b"/false") && !endswith(shell, b"/uucico") && uid < 65536
+    })
 }
 
 // This was the OSX-based solution. It provides enough information, but what a mess!

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -211,7 +211,6 @@ impl System {
                         vendor_id.clone(),
                         brand.clone(),
                     ));
-                    i += 1;
                 } else {
                     parts.next(); // we don't want the name again
                     self.processors[i].set(
@@ -227,8 +226,8 @@ impl System {
                         parts.next().map(|v| to_u64(v)).unwrap_or(0),
                     );
                     self.processors[i].frequency = get_cpu_frequency(i);
-                    i += 1;
                 }
+                i += 1;
                 count += 1;
                 if let Some(limit) = limit {
                     if count >= limit {


### PR DESCRIPTION
* In local testing, all of the users external to the system came back with UIDs much larger that 65535.  I added to the filter this UID value as a max as it did restrict to local users only.

I'm not sure this value is universal for all `opendirectoryd` UID values, but it's a start.   Also, should this be made configurable?