### PR TITLE
Fix bug in linux's refresh_process()

### DIFF
--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -347,7 +347,7 @@ impl SystemExt for System {
         ) {
             Ok((Some(p), pid)) => {
                 self.process_list.tasks.insert(pid, p);
-                false
+                true
             }
             Ok(_) => true,
             Err(_) => false,


### PR DESCRIPTION
refresh_process(pid) is called for the first time, the linux implementation returns false when a process is not cached which is incorrect.

compare that with the mac and windows version which returns true.

windows: https://github.com/GuillaumeGomez/sysinfo/blob/58b31e3a5d2821fb0483125220331b3afab5cd11/src/windows/system.rs#L190
mac: https://github.com/GuillaumeGomez/sysinfo/blob/58b31e3a5d2821fb0483125220331b3afab5cd11/src/apple/system.rs#L326
linux: https://github.com/GuillaumeGomez/sysinfo/blob/c3f76b74a614cc8de552c306dc9a00f35977994e/src/linux/system.rs#L351