### PR TITLE
Initial FreeBSD support

### DIFF
--- a/ADDING_NEW_PLATFORMS.md
+++ b/ADDING_NEW_PLATFORMS.md
@@ -1,0 +1,8 @@
+To get the `target_os` etc:
+```
+rustc --print cfg
+```
+
+In `src/lib.rs` add the matching based on the `cfg` data.
+
+Create `src/<new_platform>`. 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ core-foundation-sys = "0.8"
 [target.'cfg(all(target_os = "linux", not(target_os = "android")))'.dev-dependencies]
 tempfile = "3.2"
 
+[target.'cfg(target_os = "freebsd")'.dependencies]
+sysctl = "0.4.1"
+
 [lib]
 name = "sysinfo"
 crate_type = ["rlib", "cdylib"]

--- a/src/freebsd/component.rs
+++ b/src/freebsd/component.rs
@@ -1,0 +1,30 @@
+//
+// Sysinfo
+//
+// Copyright (c) 2021 Guillaume Gomez
+//
+
+use crate::ComponentExt;
+
+/// Dummy struct representing a component.
+pub struct Component;
+
+impl ComponentExt for Component {
+    fn get_temperature(&self) -> f32 {
+        0.0
+    }
+
+    fn get_max(&self) -> f32 {
+        0.0
+    }
+
+    fn get_critical(&self) -> Option<f32> {
+        None
+    }
+
+    fn get_label(&self) -> &str {
+        ""
+    }
+
+    fn refresh(&mut self) {}
+}

--- a/src/freebsd/disk.rs
+++ b/src/freebsd/disk.rs
@@ -1,0 +1,44 @@
+//
+// Sysinfo
+//
+// Copyright (c) 2021 Guillaume Gomez
+//
+
+use crate::DiskExt;
+use crate::DiskType;
+
+use std::ffi::OsStr;
+use std::path::Path;
+
+/// Struct containing a disk information.
+pub struct Disk {}
+
+impl DiskExt for Disk {
+    fn get_type(&self) -> DiskType {
+        unreachable!()
+    }
+
+    fn get_name(&self) -> &OsStr {
+        unreachable!()
+    }
+
+    fn get_file_system(&self) -> &[u8] {
+        &[]
+    }
+
+    fn get_mount_point(&self) -> &Path {
+        Path::new("")
+    }
+
+    fn get_total_space(&self) -> u64 {
+        0
+    }
+
+    fn get_available_space(&self) -> u64 {
+        0
+    }
+
+    fn refresh(&mut self) -> bool {
+        true
+    }
+}

--- a/src/freebsd/mod.rs
+++ b/src/freebsd/mod.rs
@@ -1,0 +1,19 @@
+//
+// Sysinfo
+//
+// Copyright (c) 2021 Guillaume Gomez
+//
+
+pub mod component;
+pub mod disk;
+pub mod network;
+pub mod process;
+pub mod processor;
+pub mod system;
+
+pub use self::component::Component;
+pub use self::disk::Disk;
+pub use self::network::{NetworkData, Networks};
+pub use self::process::{Process, ProcessStatus};
+pub use self::processor::Processor;
+pub use self::system::System;

--- a/src/freebsd/network.rs
+++ b/src/freebsd/network.rs
@@ -1,0 +1,92 @@
+//
+// Sysinfo
+//
+// Copyright (c) 2021 Guillaume Gomez
+//
+
+use std::collections::HashMap;
+
+use crate::{NetworkExt, NetworksExt, NetworksIter};
+
+/// Network interfaces.
+///
+/// ```no_run
+/// use sysinfo::{NetworksExt, System, SystemExt};
+///
+/// let s = System::new_all();
+/// let networks = s.get_networks();
+/// ```
+pub struct Networks {
+    interfaces: HashMap<String, NetworkData>,
+}
+
+impl Networks {
+    pub(crate) fn new() -> Networks {
+        Networks {
+            interfaces: HashMap::new(),
+        }
+    }
+}
+
+impl NetworksExt for Networks {
+    fn iter<'a>(&'a self) -> NetworksIter<'a> {
+        NetworksIter::new(self.interfaces.iter())
+    }
+
+    fn refresh_networks_list(&mut self) {}
+
+    fn refresh(&mut self) {}
+}
+
+/// Contains network information.
+pub struct NetworkData;
+
+impl NetworkExt for NetworkData {
+    fn get_received(&self) -> u64 {
+        0
+    }
+
+    fn get_total_received(&self) -> u64 {
+        0
+    }
+
+    fn get_transmitted(&self) -> u64 {
+        0
+    }
+
+    fn get_total_transmitted(&self) -> u64 {
+        0
+    }
+
+    fn get_packets_received(&self) -> u64 {
+        0
+    }
+
+    fn get_total_packets_received(&self) -> u64 {
+        0
+    }
+
+    fn get_packets_transmitted(&self) -> u64 {
+        0
+    }
+
+    fn get_total_packets_transmitted(&self) -> u64 {
+        0
+    }
+
+    fn get_errors_on_received(&self) -> u64 {
+        0
+    }
+
+    fn get_total_errors_on_received(&self) -> u64 {
+        0
+    }
+
+    fn get_errors_on_transmitted(&self) -> u64 {
+        0
+    }
+
+    fn get_total_errors_on_transmitted(&self) -> u64 {
+        0
+    }
+}

--- a/src/freebsd/process.rs
+++ b/src/freebsd/process.rs
@@ -1,0 +1,86 @@
+//
+// Sysinfo
+//
+// Copyright (c) 2021 Guillaume Gomez
+//
+
+use crate::{DiskUsage, Pid, ProcessExt, Signal};
+
+use std::path::Path;
+
+/// Enum describing the different status of a process.
+#[derive(Clone, Copy, Debug)]
+pub struct ProcessStatus;
+
+/// Struct containing a process' information.
+#[derive(Clone)]
+pub struct Process {
+    pid: Pid,
+    parent: Option<Pid>,
+}
+
+impl ProcessExt for Process {
+    fn new(pid: Pid, parent: Option<Pid>, _start_time: u64) -> Process {
+        Process { pid, parent }
+    }
+
+    fn kill(&self, _signal: Signal) -> bool {
+        false
+    }
+
+    fn name(&self) -> &str {
+        ""
+    }
+
+    fn cmd(&self) -> &[String] {
+        &[]
+    }
+
+    fn exe(&self) -> &Path {
+        &Path::new("")
+    }
+
+    fn pid(&self) -> Pid {
+        self.pid
+    }
+
+    fn environ(&self) -> &[String] {
+        &[]
+    }
+
+    fn cwd(&self) -> &Path {
+        &Path::new("")
+    }
+
+    fn root(&self) -> &Path {
+        &Path::new("")
+    }
+
+    fn memory(&self) -> u64 {
+        0
+    }
+
+    fn virtual_memory(&self) -> u64 {
+        0
+    }
+
+    fn parent(&self) -> Option<Pid> {
+        self.parent
+    }
+
+    fn status(&self) -> ProcessStatus {
+        ProcessStatus
+    }
+
+    fn start_time(&self) -> u64 {
+        0
+    }
+
+    fn cpu_usage(&self) -> f32 {
+        0.0
+    }
+
+    fn disk_usage(&self) -> DiskUsage {
+        DiskUsage::default()
+    }
+}

--- a/src/freebsd/processor.rs
+++ b/src/freebsd/processor.rs
@@ -1,0 +1,38 @@
+//
+// Sysinfo
+//
+// Copyright (c) 2021 Guillaume Gomez
+//
+
+use crate::ProcessorExt;
+
+/// Dummy struct that represents a processor.
+pub struct Processor {}
+
+impl Processor {
+    pub(crate) fn new() -> Processor {
+        Processor {}
+    }
+}
+
+impl ProcessorExt for Processor {
+    fn get_cpu_usage(&self) -> f32 {
+        0.0
+    }
+
+    fn get_name(&self) -> &str {
+        ""
+    }
+
+    fn get_frequency(&self) -> u64 {
+        0
+    }
+
+    fn get_vendor_id(&self) -> &str {
+        ""
+    }
+
+    fn get_brand(&self) -> &str {
+        ""
+    }
+}

--- a/src/freebsd/system.rs
+++ b/src/freebsd/system.rs
@@ -1,0 +1,176 @@
+//
+// Sysinfo
+//
+// Copyright (c) 2021 Guillaume Gomez
+//
+
+use crate::sys::component::Component;
+use crate::sys::process::*;
+use crate::sys::processor::*;
+use crate::sys::Disk;
+use crate::sys::Networks;
+use crate::{LoadAvg, Pid, User, RefreshKind, SystemExt};
+use sysctl::Sysctl;
+
+use std::collections::HashMap;
+
+/// Structs containing system's information.
+pub struct System {
+    processes_list: HashMap<Pid, Process>,
+    networks: Networks,
+    global_processor: Processor,
+}
+
+impl SystemExt for System {
+    fn new_with_specifics(_: RefreshKind) -> System {
+        System {
+            processes_list: Default::default(),
+            networks: Networks::new(),
+            global_processor: Processor::new(),
+        }
+    }
+
+    fn refresh_memory(&mut self) {}
+
+    fn refresh_cpu(&mut self) {}
+
+    fn refresh_components_list(&mut self) {}
+
+    fn refresh_processes(&mut self) {}
+
+    fn refresh_process(&mut self, _pid: Pid) -> bool {
+        false
+    }
+
+    fn refresh_disks_list(&mut self) {}
+
+    fn refresh_users_list(&mut self) {}
+
+    // COMMON PART
+    //
+    // Need to be moved into a "common" file to avoid duplication.
+
+    fn get_processes(&self) -> &HashMap<Pid, Process> {
+        &self.processes_list
+    }
+
+    fn get_process(&self, _pid: Pid) -> Option<&Process> {
+        None
+    }
+
+    fn get_networks(&self) -> &Networks {
+        &self.networks
+    }
+
+    fn get_networks_mut(&mut self) -> &mut Networks {
+        &mut self.networks
+    }
+
+    fn get_global_processor_info(&self) -> &Processor {
+        &self.global_processor
+    }
+
+    fn get_processors(&self) -> &[Processor] {
+        &[]
+    }
+
+    fn get_physical_core_count(&self) -> Option<usize> {
+        None
+    }
+
+    fn get_total_memory(&self) -> u64 {
+        0
+    }
+
+    fn get_free_memory(&self) -> u64 {
+        0
+    }
+
+    fn get_available_memory(&self) -> u64 {
+        0
+    }
+
+    fn get_used_memory(&self) -> u64 {
+        0
+    }
+
+    fn get_total_swap(&self) -> u64 {
+        0
+    }
+
+    fn get_free_swap(&self) -> u64 {
+        0
+    }
+
+    fn get_used_swap(&self) -> u64 {
+        0
+    }
+
+    fn get_components(&self) -> &[Component] {
+        &[]
+    }
+
+    fn get_components_mut(&mut self) -> &mut [Component] {
+        &mut []
+    }
+
+    fn get_disks(&self) -> &[Disk] {
+        &[]
+    }
+
+    fn get_disks_mut(&mut self) -> &mut [Disk] {
+        &mut []
+    }
+
+    fn get_uptime(&self) -> u64 {
+        0
+    }
+
+    fn get_boot_time(&self) -> u64 {
+        0
+    }
+
+    fn get_load_average(&self) -> LoadAvg {
+        LoadAvg {
+            one: 0.,
+            five: 0.,
+            fifteen: 0.,
+        }
+    }
+
+    fn get_users(&self) -> &[User] {
+        &[]
+    }
+
+    fn get_name(&self) -> Option<String> {
+        Some("FreeBSD".to_owned())
+    }
+
+    fn get_long_os_version(&self) -> Option<String> {
+        None
+    }
+
+    fn get_kernel_version(&self) -> Option<String> {
+        let ctl = sysctl::Ctl::new("kern.version").unwrap();
+        let osver = ctl.value().unwrap();
+        Some(osver.to_string())
+    }
+
+    fn get_os_version(&self) -> Option<String> {
+        let ctl = sysctl::Ctl::new("kern.osrelease").unwrap();
+        let osrel = ctl.value().unwrap();
+        Some(osrel.to_string())
+    }
+
+    fn get_host_name(&self) -> Option<String> {
+        let ctl = sysctl::Ctl::new("kern.hostname").unwrap();
+        let hostname = ctl.value().unwrap();
+        Some(hostname.to_string())
+    }
+}
+
+impl Default for System {
+    fn default() -> System {
+        System::new()
+    }
+}

--- a/src/freebsd/users.rs
+++ b/src/freebsd/users.rs
@@ -1,0 +1,99 @@
+//
+// Sysinfo
+//
+// Copyright (c) 2021 Guillaume Gomez
+//
+
+use crate::{
+    common::{Gid, Uid},
+    User,
+};
+
+use libc::{getgrgid, getgrouplist};
+use std::fs::File;
+use std::io::Read;
+
+pub fn get_users_list() -> Vec<User> {
+    let mut s = String::new();
+    let mut ngroups = 100;
+    let mut groups = vec![0; ngroups as usize];
+
+    let _ = File::open("/etc/passwd").and_then(|mut f| f.read_to_string(&mut s));
+    s.lines()
+        .filter_map(|line| {
+            let mut parts = line.split(':');
+            if let Some(username) = parts.next() {
+                let mut parts = parts.skip(1);
+                // Skip the user if the uid cannot be parsed correctly
+                if let Some(uid) = parts.next().and_then(parse_id) {
+                    if let Some(group_id) = parts.next().and_then(parse_id) {
+                        if let Some(command) = parts.last() {
+                            if command.is_empty()
+                                || command.ends_with("/false")
+                                || command.ends_with("/nologin")
+                            {
+                                // We don't want "fake" users so in case the user command is "bad", we
+                                // ignore this user.
+                                return None;
+                            }
+                            let mut c_user = username.as_bytes().to_vec();
+                            c_user.push(0);
+                            loop {
+                                let mut current = ngroups;
+                                if unsafe {
+                                    getgrouplist(
+                                        c_user.as_ptr() as *const _,
+                                        group_id,
+                                        groups.as_mut_ptr(),
+                                        &mut current,
+                                    )
+                                } == -1
+                                {
+                                    if current > ngroups {
+                                        groups.resize(current as _, 0);
+                                        ngroups = current;
+                                        continue;
+                                    }
+                                    // It really failed, let's move on...
+                                    return None;
+                                }
+                                // Let's get all the group names!
+                                return Some(User {
+                                    uid: Uid(uid),
+                                    gid: Gid(group_id),
+                                    name: username.to_owned(),
+                                    groups: groups[..current as usize]
+                                        .iter()
+                                        .filter_map(|id| {
+                                            let g = unsafe { getgrgid(*id as _) };
+                                            if g.is_null() {
+                                                return None;
+                                            }
+                                            let mut group_name = Vec::new();
+                                            let c_group_name = unsafe { (*g).gr_name };
+                                            let mut x = 0;
+                                            loop {
+                                                let c = unsafe { *c_group_name.offset(x) };
+                                                if c == 0 {
+                                                    break;
+                                                }
+                                                group_name.push(c as u8);
+                                                x += 1;
+                                            }
+                                            String::from_utf8(group_name).ok()
+                                        })
+                                        .collect(),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+            None
+        })
+        .collect()
+}
+
+fn parse_id(id: &str) -> Option<u32> {
+    id.parse::<u32>().ok()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,12 @@ cfg_if::cfg_if! {
 
         #[cfg(test)]
         const MIN_USERS: usize = 1;
+    } else if #[cfg(target_os = "freebsd")] {
+        mod freebsd;
+        use freebsd as sys;
+
+        #[cfg(test)]
+        const MIN_USERS: usize = 1;
     } else {
         mod unknown;
         use unknown as sys;


### PR DESCRIPTION
https://github.com/GuillaumeGomez/sysinfo/issues/433

- Recognizes FreeBSD based on cfg data
- Only a few of the functions are implemented yet.

As you may recognize this is mostly based on `unknown`, but with things like
```
use crate::DiskExt;
```
instead of
```
use DiskExt;
```
I'm not sure why that's needed but without this it was failing to build with errors like this:
```
$ cargo b
   Compiling sysinfo v0.17.2 (/usr/home/dvaneeden/sysinfo)
error[E0432]: unresolved import `ComponentExt`
 --> src/unknown/component.rs:7:5
  |
7 | use ComponentExt;
  |     ^^^^^^^^^^^^ no external crate `ComponentExt`
```
This error happens on an unmodified master branch as well as you can see here. 