### PR TITLE
c_interface: Fix compiling of the C interface

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -138,3 +138,14 @@ jobs:
         if: matrix.os == 'macos-latest'
         env:
           RUST_BACKTRACE: full
+
+  c_interface:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: cargo build --features=c-interface

--- a/src/c_interface.rs
+++ b/src/c_interface.rs
@@ -4,10 +4,10 @@
 // Copyright (c) 2017 Guillaume Gomez
 //
 
+use crate::{NetworkExt, NetworksExt, Process, ProcessExt, ProcessorExt, System, SystemExt};
 use libc::{self, c_char, c_float, c_uint, c_void, pid_t, size_t};
 use std::borrow::BorrowMut;
 use std::ffi::CString;
-use {NetworkExt, NetworksExt, Process, ProcessExt, ProcessorExt, System, SystemExt};
 
 /// Equivalent of [`System`][crate::System] struct.
 pub type CSystem = *mut c_void;


### PR DESCRIPTION
```
[dvaneeden@dve-carbon sysinfo]$ git status
On branch master
Your branch is up to date with 'origin/master'.

nothing to commit, working tree clean
[dvaneeden@dve-carbon sysinfo]$ git describe --always
8165447
[dvaneeden@dve-carbon sysinfo]$ make
Compiling in debug mode
cargo build --features=c-interface
   Compiling sysinfo v0.17.2 (/home/dvaneeden/dev/sysinfo)
error[E0432]: unresolved imports `NetworkExt`, `NetworksExt`, `Process`, `ProcessExt`, `ProcessorExt`, `System`, `SystemExt`
  --> src/c_interface.rs:10:6
   |
10 | use {NetworkExt, NetworksExt, Process, ProcessExt, ProcessorExt, System, SystemExt};
   |      ^^^^^^^^^^  ^^^^^^^^^^^  ^^^^^^^  ^^^^^^^^^^  ^^^^^^^^^^^^  ^^^^^^  ^^^^^^^^^ no external crate `SystemExt`
   |      |           |            |        |           |             |
   |      |           |            |        |           |             no external crate `System`
   |      |           |            |        |           no external crate `ProcessorExt`
   |      |           |            |        no external crate `ProcessExt`
   |      |           |            no external crate `Process`
   |      |           no external crate `NetworksExt`
   |      no external crate `NetworkExt`

warning: unused import: `std::borrow::BorrowMut`
 --> src/c_interface.rs:8:5
  |
8 | use std::borrow::BorrowMut;
  |     ^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

error: aborting due to previous error; 1 warning emitted

For more information about this error, try `rustc --explain E0432`.
error: could not compile `sysinfo`

To learn more, run the command again with --verbose.
make: *** [Makefile:30: simple] Error 101
```