### PR TITLE
Linux: Cleanup removed interfaces in refresh_networks_list (fixes #479)

### DIFF
--- a/src/linux/network.rs
+++ b/src/linux/network.rs
@@ -123,14 +123,7 @@ fn refresh_networks_list_from_sysfs(
         }
 
         // Remove interfaces that are gone
-        for name in interfaces
-            .iter()
-            .filter(|(_n, s)| !s.updated)
-            .map(|(n, _s)| n.to_owned())
-            .collect::<Vec<_>>()
-        {
-            interfaces.remove(&name);
-        }
+        interfaces.retain(|_n, d| d.updated);
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/GuillaumeGomez/sysinfo/issues/479

This removes interfaces that are not longer present in `refresh_networks_list` for Linux, before doing a second pass to update stats or add new interfaces.

I wanted to use `drain_filter` but this is a nightly only API for now.