### PR TITLE
Improve network code

### DIFF
--- a/src/linux/network.rs
+++ b/src/linux/network.rs
@@ -122,8 +122,8 @@ fn refresh_networks_list_from_sysfs(
             };
         }
 
-        // Remove interfaces that are gone
-        interfaces.retain(|_n, d| d.updated);
+        // Remove interfaces which are gone.
+        interfaces.retain(|_, d| d.updated);
     }
 }
 


### PR DESCRIPTION
Fixes #483.

Mac was using the same logic as linux so I just cleaned it up a bit.

Windows however was using another strategy: it was filling a `HashSet` with the interfaces' key and removed them when it updated one. Then at the end, it removed all the interfaces which still had their key in the `HashSet` at the end. It was really not great because it meant that we duplicated the keys for all interfaces.