### PR TITLE
Fix cpu.get_brand() returning empty string on M1

### DIFF
--- a/src/apple/processor.rs
+++ b/src/apple/processor.rs
@@ -242,7 +242,7 @@ fn get_sysctl_str(s: &[u8]) -> String {
 
 pub fn get_vendor_id_and_brand() -> (String, String) {
     (
-        get_sysctl_str(b"machdep.cpu.brand_string\0"),
         get_sysctl_str(b"machdep.cpu.vendor\0"),
+        get_sysctl_str(b"machdep.cpu.brand_string\0"),
     )
 }

--- a/src/apple/processor.rs
+++ b/src/apple/processor.rs
@@ -241,8 +241,11 @@ fn get_sysctl_str(s: &[u8]) -> String {
 }
 
 pub fn get_vendor_id_and_brand() -> (String, String) {
-    (
-        get_sysctl_str(b"machdep.cpu.vendor\0"),
-        get_sysctl_str(b"machdep.cpu.brand_string\0"),
-    )
+    // On apple M1, `sysctl machdep.cpu.vendor` returns "", so fallback to "Apple" if the result is empty
+    let mut vendor = get_sysctl_str(b"machdep.cpu.vendor\0");
+    if vendor.is_empty() {
+        vendor = "Apple".to_string();
+    }
+
+    (vendor, get_sysctl_str(b"machdep.cpu.brand_string\0"))
 }


### PR DESCRIPTION
Closes #496 

This patch fixes the bug where on Apple M1 machines, calling `cpu.get_brand()` returns an empty string.

It looks like the real source of this bug was that `get_vendor_id_and_brand()` was returning `(brand_string, vendor_id)` when the result would be stored as `(vendor_id, brand)`. Just reversing the result tuple to match the function name fixed the issue.

It looks like this function is only being called in this file anyway, so shouldn't affect anyone else.