### PR TITLE
Ensure there's a value in linux `global_processor`

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -201,7 +201,11 @@ fn interpret_input(input: &str, sys: &mut System) -> bool {
             }
         }
         "frequency" => {
-            writeln!(&mut io::stdout(), "{} MHz", sys.processors()[0].frequency());
+            writeln!(
+                &mut io::stdout(),
+                "{} MHz",
+                sys.global_processor_info().frequency()
+            );
         }
         "vendor_id" => {
             writeln!(

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -224,6 +224,14 @@ impl System {
                     );
                     self.processors[i].frequency = get_cpu_frequency(i);
                 }
+
+                self.global_processor.frequency = self
+                    .processors
+                    .iter()
+                    .map(|p| p.frequency)
+                    .max()
+                    .unwrap_or(0);
+
                 i += 1;
                 count += 1;
                 if let Some(limit) = limit {


### PR DESCRIPTION
Currently, there is no frequency set for `global_processor` for linux.
This results in my project [sysit](https://github.com/crodjer/sysit) rendering `0` for CPU Frequency on my Raspberry Pi.
<img width="500" alt="Screenshot 2021-06-26 at 23 14 50" src="https://user-images.githubusercontent.com/343499/123521458-658bbe80-d6d4-11eb-9379-1c13399393d9.png">

I couldn't find the best heuristic to use for global processor
frequency. So using `max` to signify currently the most interesting core.

