### PR TITLE
Add support for getting process current working directory on macOS

### DIFF
--- a/src/apple/macos/ffi.rs
+++ b/src/apple/macos/ffi.rs
@@ -14,6 +14,57 @@ use libc::{c_int, mach_port_t, size_t};
 
 pub(crate) use crate::sys::ffi::*;
 
+pub const MAXPATHLEN: usize = libc::PATH_MAX as usize;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct vinfo_stat {
+    pub vst_dev: u32,
+    pub vst_mode: u16,
+    pub vst_nlink: u16,
+    pub vst_ino: u64,
+    pub vst_uid: libc::uid_t,
+    pub vst_gid: libc::gid_t,
+    pub vst_atime: i64,
+    pub vst_atimensec: i64,
+    pub vst_mtime: i64,
+    pub vst_mtimensec: i64,
+    pub vst_ctime: i64,
+    pub vst_ctimensec: i64,
+    pub vst_birthtime: i64,
+    pub vst_birthtimensec: i64,
+    pub vst_size: libc::off_t,
+    pub vst_blocks: i64,
+    pub vst_blksize: i32,
+    pub vst_flags: u32,
+    pub vst_gen: u32,
+    pub vst_rdev: u32,
+    pub vst_qspare: [i64; 2],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct vnode_info {
+    pub vi_stat: vinfo_stat,
+    pub vi_type: libc::c_int,
+    pub vi_fsid: libc::fsid_t,
+    pub vi_pad: libc::c_int,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct vnode_info_path {
+    pub vip_vi: vnode_info,
+    pub vip_path: [libc::c_char; MAXPATHLEN],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct proc_vnodepathinfo {
+    pub pvi_cdir: vnode_info_path,
+    pub pvi_rdir: vnode_info_path,
+}
+
 #[cfg(not(feature = "apple-sandbox"))]
 extern "C" {
     pub fn mach_absolute_time() -> u64;
@@ -175,6 +226,7 @@ mod io_service {
     pub const KIO_RETURN_SUCCESS: i32 = 0;
 
     pub const PROC_PIDTBSDINFO: c_int = 3;
+    pub const PROC_PIDVNODEPATHINFO: c_int = 9;
     pub const PROC_PIDPATHINFO_MAXSIZE: u32 = 4096;
 }
 

--- a/src/apple/macos/process.rs
+++ b/src/apple/macos/process.rs
@@ -64,7 +64,7 @@ impl Process {
             cmd: Vec::new(),
             environ: Vec::new(),
             exe,
-            cwd: cwd,
+            cwd,
             root: PathBuf::new(),
             memory: 0,
             virtual_memory: 0,
@@ -105,7 +105,7 @@ impl Process {
             cmd,
             environ,
             exe,
-            cwd: cwd,
+            cwd,
             root,
             memory: 0,
             virtual_memory: 0,
@@ -393,11 +393,10 @@ pub(crate) fn update_process(
         let cwd = if result > 0 {
             let buffer = vnodepathinfo.pvi_cdir.vip_path;
             let buffer = CStr::from_ptr(buffer.as_ptr());
-            buffer.to_str().unwrap_or("").to_owned()
+            buffer.to_str().map(PathBuf::from).unwrap_or_else(|_| PathBuf::new())
         } else {
-            "".to_owned()
+            PathBuf::new()
         };
-        let cwd = PathBuf::from(cwd);
 
         let mut info = mem::zeroed::<libc::proc_bsdinfo>();
         if ffi::proc_pidinfo(

--- a/src/apple/macos/process.rs
+++ b/src/apple/macos/process.rs
@@ -393,7 +393,10 @@ pub(crate) fn update_process(
         let cwd = if result > 0 {
             let buffer = vnodepathinfo.pvi_cdir.vip_path;
             let buffer = CStr::from_ptr(buffer.as_ptr());
-            buffer.to_str().map(PathBuf::from).unwrap_or_else(|_| PathBuf::new())
+            buffer
+                .to_str()
+                .map(PathBuf::from)
+                .unwrap_or_else(|_| PathBuf::new())
         } else {
             PathBuf::new()
         };

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -25,10 +25,9 @@ fn test_process() {
 
 #[test]
 #[cfg(not(windows))]
-fn test_process_info() {
+fn test_process_cwd() {
     let p = std::process::Command::new("sleep")
         .arg("3")
-        .current_dir("/bin")
         .spawn()
         .unwrap();
     let pid = p.id() as sysinfo::Pid;
@@ -45,8 +44,10 @@ fn test_process_info() {
 
     if let Some(p) = p {
         assert_eq!(p.pid(), pid);
-        assert_eq!(p.cwd().to_str().unwrap(), "/bin");
-        println!("{:?}", p);
+        assert_eq!(
+            p.cwd().to_str().unwrap(),
+            std::env::current_dir().unwrap().to_str().unwrap()
+        );
     } else {
         assert!(false);
     }


### PR DESCRIPTION
Hello!

Please take a look to this small pull request to add support for `process.cwd()` on macOS. If you have any suggestions about the code, please don't hesitate to ask and I will change it.

This uses the `proc_pidinfo` macOS system call to get information about a running process. It uses the PROC_PIDVNODEPATHINFO to get vnode information which contains the current working directory of the project.

Thanks!