### PR TITLE
changes to linux kernel information functions

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -379,11 +379,11 @@ fn interpret_input(input: &str, sys: &mut System) -> bool {
             writeln!(
                 &mut io::stdout(),
                 "System name:           {}\n\
-                System kernel version: {}\n\
+                System kernel release: {}\n\
                 System OS version:     {}\n\
                 System host name:      {}",
                 sys.name().unwrap_or_else(|| "<unknown>".to_owned()),
-                sys.kernel_version()
+                sys.kernel_release()
                     .unwrap_or_else(|| "<unknown>".to_owned()),
                 sys.os_version().unwrap_or_else(|| "<unknown>".to_owned()),
                 sys.host_name().unwrap_or_else(|| "<unknown>".to_owned()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,6 +256,11 @@ mod test {
                 .expect("Failed to get kernel version")
                 .is_empty());
 
+            assert!(!s
+                    .kernel_release()
+                    .expect("Failed to get kernel version")
+                    .is_empty());
+
             assert!(!s.os_version().expect("Failed to get os version").is_empty());
 
             assert!(!s

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -540,7 +540,7 @@ impl SystemExt for System {
         }
     }
 
-    fn kernel_version(&self) -> Option<String> {
+    fn kernel_release(&self) -> Option<String> {
         let mut raw = std::mem::MaybeUninit::<libc::utsname>::zeroed();
 
         if unsafe { libc::uname(raw.as_mut_ptr()) } == 0 {
@@ -558,7 +558,21 @@ impl SystemExt for System {
             None
         }
     }
-
+    fn kernel_version(&self) -> Option<[usize; 3]> {
+        let release = self.kernel_release()?;
+        let mut chars = release.chars();
+        let mut ver = Vec::new();
+        for _ in 0..3 {
+            let mut cache: usize = 0;
+            while let Some(x) = chars.next().unwrap().to_digit(10) {
+                cache *= 10;
+                cache += x as usize;
+            }
+            ver.push(cache);
+        }
+        //    major   minor   patch
+        Some([ver[0], ver[1], ver[2]])
+    }
     #[cfg(not(target_os = "android"))]
     fn os_version(&self) -> Option<String> {
         get_system_info_linux(

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -558,6 +558,16 @@ impl SystemExt for System {
             None
         }
     }
+
+    fn kernel_name(&self) -> Option<String> {
+        let release = self.kernel_release()?;
+        let mut chars = release.chars();
+        for _ in 0..3 {
+            while let Some(_) = chars.next().unwrap().to_digit(10) {}
+        }
+        Some(chars.as_str().to_string())
+    }
+
     fn kernel_version(&self) -> Option<[usize; 3]> {
         let release = self.kernel_release()?;
         let mut chars = release.chars();
@@ -573,6 +583,7 @@ impl SystemExt for System {
         //    major   minor   patch
         Some([ver[0], ver[1], ver[2]])
     }
+
     #[cfg(not(target_os = "android"))]
     fn os_version(&self) -> Option<String> {
         get_system_info_linux(

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1002,6 +1002,18 @@ pub trait SystemExt: Sized + Debug + Default {
     /// ```
     fn name(&self) -> Option<String>;
 
+    /// Returns the system's kernel release.
+    ///
+    /// **Important**: this information is computed every time this function is called.
+    ///
+    /// ```no_run
+    /// use sysinfo::{System, SystemExt};
+    ///
+    /// let s = System::new();
+    /// println!("kernel release: {:?}", s.kernel_release());
+    /// ```
+    fn kernel_release(&self)-> Option<String>;
+
     /// Returns the system's kernel version.
     ///
     /// **Important**: this information is computed every time this function is called.
@@ -1012,7 +1024,7 @@ pub trait SystemExt: Sized + Debug + Default {
     /// let s = System::new();
     /// println!("kernel version: {:?}", s.kernel_version());
     /// ```
-    fn kernel_version(&self) -> Option<String>;
+    fn kernel_version(&self) -> Option<[usize; 3]>;
 
     /// Returns the system version (e.g. for MacOS this will return 11.1 rather than the kernel version).
     ///

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1014,6 +1014,18 @@ pub trait SystemExt: Sized + Debug + Default {
     /// ```
     fn kernel_release(&self)-> Option<String>;
 
+    /// Returns the system's kernel name.
+    ///
+    /// **Important**: this information is computed every time this function is called.
+    ///
+    /// ```no_run
+    /// use sysinfo::{System, SystemExt};
+    ///
+    /// let s = System::new();
+    /// println!("kernel release: {:?}", s.kernel_name());
+    /// ```
+    fn kernel_name(&self)-> Option<String>;
+
     /// Returns the system's kernel version.
     ///
     /// **Important**: this information is computed every time this function is called.


### PR DESCRIPTION
The actual `kernel_version()` function returns the kernel release, I moved it to another function and made it return just the kernel version. I also added a function for getting the kernel name. Now, in a Linux system like mine:
  * `kernel_release()` returns `5.13.13-hardened`.
  * `kernel_version()` returns `[5,13,13]`.
  * `kernel_name()` returns `hardened`.