### PR TITLE
Use Wrapping on the stat numbers due to a potential overflow in the following mutliplications

### DIFF
--- a/src/linux/disk.rs
+++ b/src/linux/disk.rs
@@ -11,6 +11,7 @@ use libc::statvfs;
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::mem;
+use std::num::Wrapping;
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 
@@ -89,8 +90,11 @@ fn new_disk(
     unsafe {
         let mut stat: statvfs = mem::zeroed();
         if statvfs(mount_point_cpath.as_ptr() as *const _, &mut stat) == 0 {
-            total = cast!(stat.f_bsize) * cast!(stat.f_blocks);
-            available = cast!(stat.f_bsize) * cast!(stat.f_bavail);
+            let bsize = Wrapping(cast!(stat.f_bsize));
+            let blocks = Wrapping(cast!(stat.f_blocks));
+            let bavail = Wrapping(cast!(stat.f_bavail));
+            total = (bsize * blocks).0;
+            available = (bsize * bavail).0;
         }
     }
     if total == 0 {


### PR DESCRIPTION
I do not use this crate directly but I use the vergen crate in my build scripts. Unfortunately, on some my machines I fail to compile those scripts in the debug configuration (in release it is all fine) because for some unclear reason I got ```stat.f_bsize == 4096``` and ```stat.f_blocks == 4503599627370719``` and then the following multiplication gives an overflow. This PR solves this problem for me.