### PR TITLE
Lazily create query

### DIFF
--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -91,32 +91,35 @@ impl SystemExt for System {
             processors,
             components: Vec::new(),
             disks: Vec::with_capacity(2),
-            query: Query::new(),
+            query: None,
             networks: Networks::new(),
             boot_time: unsafe { boot_time() },
             users: Vec::new(),
         };
-        if let Some(ref mut query) = s.query {
-            add_english_counter(
-                r"\Processor(_Total)\% Processor Time".to_string(),
-                query,
-                get_key_used(&mut s.global_processor),
-                "tot_0".to_owned(),
-            );
-            for (pos, proc_) in s.processors.iter_mut().enumerate() {
-                add_english_counter(
-                    format!(r"\Processor({})\% Processor Time", pos),
-                    query,
-                    get_key_used(proc_),
-                    format!("{}_0", pos),
-                );
-            }
-        }
         s.refresh_specifics(refreshes);
         s
     }
 
     fn refresh_cpu(&mut self) {
+        if self.query.is_none() {
+            self.query = Query::new();
+            if let Some(ref mut query) = self.query {
+                add_english_counter(
+                    r"\Processor(_Total)\% Processor Time".to_string(),
+                    query,
+                    get_key_used(&mut self.global_processor),
+                    "tot_0".to_owned(),
+                );
+                for (pos, proc_) in self.processors.iter_mut().enumerate() {
+                    add_english_counter(
+                        format!(r"\Processor({})\% Processor Time", pos),
+                        query,
+                        get_key_used(proc_),
+                        format!("{}_0", pos),
+                    );
+                }
+            }
+        }
         if let Some(ref mut query) = self.query {
             query.refresh();
             let mut used_time = None;


### PR DESCRIPTION
This MR changes the windows backend to only create the `Query` (which calls PDH) when refreshing CPU usage.

Motivation: I'm working on a somewhat security-sensitive software, using `sysinfo` to get some information about running processes, their resource usage and so on. This software needs to be resilient against DLL hijacking attacks and other code injection techniques, even against administrators, for various reasons.

In this context, `PDH.dll` is somewhat problematic: it loads the Performance Counter DLLs (which may be registered by anyone) at runtime, which may be used to inject code in my program. Those DLLs are loaded as soon as `PdhAddEnglishCounter` are called.

My program doesn't need system CPU usage, and I don't request it as part of the `RefreshKind`, so building the query isn't useful in the first place. This commit moves the building of the `Query` (which calls `PdhAddEnglishCounter`) to the `refresh_cpu` function, ensuring that it is only created when actually used.