### PR TITLE
Option to keep fewer files open when querying processes

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -107,6 +107,7 @@ assert_eq!(r.", stringify!($name), "(), false);
 pub struct ProcessRefreshKind {
     cpu: bool,
     disk_usage: bool,
+    multiple_refreshes: bool,
 }
 
 impl ProcessRefreshKind {
@@ -119,6 +120,7 @@ impl ProcessRefreshKind {
     ///
     /// assert_eq!(r.cpu(), false);
     /// assert_eq!(r.disk_usage(), false);
+    /// assert_eq!(r.multiple_refreshes(), false);
     /// ```
     pub fn new() -> Self {
         Self::default()
@@ -133,11 +135,13 @@ impl ProcessRefreshKind {
     ///
     /// assert_eq!(r.cpu(), true);
     /// assert_eq!(r.disk_usage(), true);
+    /// assert_eq!(r.multiple_refreshes(), true);
     /// ```
     pub fn everything() -> Self {
         Self {
             cpu: true,
             disk_usage: true,
+            multiple_refreshes: true,
         }
     }
 
@@ -147,6 +151,12 @@ impl ProcessRefreshKind {
         disk_usage,
         with_disk_usage,
         without_disk_usage
+    );
+    impl_get_set!(
+        ProcessRefreshKind,
+        multiple_refreshes,
+        expect_multiple_refreshes,
+        no_multiple_refreshes
     );
 }
 


### PR DESCRIPTION
On Linux refreshing the process information will keep the stat file
of every process open, anticipating future refreshes.

Add the `multiple_refreshes` flag to `ProcessRefreshKind` to indicate
that only a single/initial refresh is expected. Set/unset with
`expect_multiple_refreshes()` / `no_multiple_refreshes()`.

This also speeds up sysinfo when it runs on a second thread, in
which case due to a Linux kernel bug syscalls seem to get slower
the more open files a process has.

----------
With this a simple query like the following takes ~50ms on the main and another thread, instead of 4x as long in the second case.

```rust
{
  let mut s = sysinfo::System::new();
  s.refresh_processes_specifics(sysinfo::ProcessRefreshKind::new());
}
```

Closes #638, also see  [dandavison/delta/#845](https://github.com/dandavison/delta/pull/845)