### PR TITLE
Add SUPPORTED_SIGNALS constant on SystemExt

### DIFF
--- a/src/apple/app_store/process.rs
+++ b/src/apple/app_store/process.rs
@@ -9,10 +9,6 @@ use crate::{DiskUsage, Pid, ProcessExt, ProcessStatus, Signal};
 pub struct Process;
 
 impl ProcessExt for Process {
-    fn kill(&self) -> bool {
-        false
-    }
-
     fn kill_with(&self, _signal: Signal) -> Option<bool> {
         None
     }

--- a/src/apple/macos/process.rs
+++ b/src/apple/macos/process.rs
@@ -151,47 +151,8 @@ impl Process {
 }
 
 impl ProcessExt for Process {
-    fn kill(&self) -> bool {
-        self.kill_with(Signal::Kill).unwrap()
-    }
-
     fn kill_with(&self, signal: Signal) -> Option<bool> {
-        let c_signal = match signal {
-            Signal::Hangup => libc::SIGHUP,
-            Signal::Interrupt => libc::SIGINT,
-            Signal::Quit => libc::SIGQUIT,
-            Signal::Illegal => libc::SIGILL,
-            Signal::Trap => libc::SIGTRAP,
-            Signal::Abort => libc::SIGABRT,
-            Signal::IOT => libc::SIGIOT,
-            Signal::Bus => libc::SIGBUS,
-            Signal::FloatingPointException => libc::SIGFPE,
-            Signal::Kill => libc::SIGKILL,
-            Signal::User1 => libc::SIGUSR1,
-            Signal::Segv => libc::SIGSEGV,
-            Signal::User2 => libc::SIGUSR2,
-            Signal::Pipe => libc::SIGPIPE,
-            Signal::Alarm => libc::SIGALRM,
-            Signal::Term => libc::SIGTERM,
-            Signal::Child => libc::SIGCHLD,
-            Signal::Continue => libc::SIGCONT,
-            Signal::Stop => libc::SIGSTOP,
-            Signal::TSTP => libc::SIGTSTP,
-            Signal::TTIN => libc::SIGTTIN,
-            Signal::TTOU => libc::SIGTTOU,
-            Signal::Urgent => libc::SIGURG,
-            Signal::XCPU => libc::SIGXCPU,
-            Signal::XFSZ => libc::SIGXFSZ,
-            Signal::VirtualAlarm => libc::SIGVTALRM,
-            Signal::Profiling => libc::SIGPROF,
-            Signal::Winch => libc::SIGWINCH,
-            Signal::IO => libc::SIGIO,
-            // SIGPOLL doesn't exist on apple targets but since it's an equivalent of SIGIO on unix,
-            // we simply use the SIGIO constant.
-            Signal::Poll => libc::SIGIO,
-            Signal::Power => return None,
-            Signal::Sys => libc::SIGSYS,
-        };
+        let c_signal = crate::sys::system::convert_signal(signal)?;
         unsafe { Some(kill(self.pid, c_signal) == 0) }
     }
 

--- a/src/apple/system.rs
+++ b/src/apple/system.rs
@@ -28,6 +28,50 @@ use libc::{
     vm_statistics64, _SC_PAGESIZE,
 };
 
+#[cfg(all(target_os = "macos", not(feature = "apple-sandbox")))]
+declare_signals! {
+    c_int,
+    Signal::Hangup => libc::SIGHUP,
+    Signal::Interrupt => libc::SIGINT,
+    Signal::Quit => libc::SIGQUIT,
+    Signal::Illegal => libc::SIGILL,
+    Signal::Trap => libc::SIGTRAP,
+    Signal::Abort => libc::SIGABRT,
+    Signal::IOT => libc::SIGIOT,
+    Signal::Bus => libc::SIGBUS,
+    Signal::FloatingPointException => libc::SIGFPE,
+    Signal::Kill => libc::SIGKILL,
+    Signal::User1 => libc::SIGUSR1,
+    Signal::Segv => libc::SIGSEGV,
+    Signal::User2 => libc::SIGUSR2,
+    Signal::Pipe => libc::SIGPIPE,
+    Signal::Alarm => libc::SIGALRM,
+    Signal::Term => libc::SIGTERM,
+    Signal::Child => libc::SIGCHLD,
+    Signal::Continue => libc::SIGCONT,
+    Signal::Stop => libc::SIGSTOP,
+    Signal::TSTP => libc::SIGTSTP,
+    Signal::TTIN => libc::SIGTTIN,
+    Signal::TTOU => libc::SIGTTOU,
+    Signal::Urgent => libc::SIGURG,
+    Signal::XCPU => libc::SIGXCPU,
+    Signal::XFSZ => libc::SIGXFSZ,
+    Signal::VirtualAlarm => libc::SIGVTALRM,
+    Signal::Profiling => libc::SIGPROF,
+    Signal::Winch => libc::SIGWINCH,
+    Signal::IO => libc::SIGIO,
+    // SIGPOLL doesn't exist on apple targets but since it's an equivalent of SIGIO on unix,
+    // we simply use the SIGIO constant.
+    Signal::Poll => libc::SIGIO,
+    Signal::Sys => libc::SIGSYS,
+    _ => None,
+}
+#[cfg(any(target_os = "ios", feature = "apple-sandbox"))]
+declare_signals! {
+    c_int,
+    _ => None,
+}
+
 #[doc = include_str!("../../md_doc/system.md")]
 pub struct System {
     process_list: HashMap<Pid, Process>,
@@ -122,6 +166,7 @@ fn get_now() -> u64 {
 
 impl SystemExt for System {
     const IS_SUPPORTED: bool = true;
+    const SUPPORTED_SIGNALS: &'static [Signal] = supported_signals();
 
     fn new_with_specifics(refreshes: RefreshKind) -> System {
         let port = unsafe { libc::mach_host_self() };

--- a/src/freebsd/process.rs
+++ b/src/freebsd/process.rs
@@ -66,44 +66,8 @@ pub struct Process {
 }
 
 impl ProcessExt for Process {
-    fn kill(&self) -> bool {
-        self.kill_with(Signal::Kill).unwrap()
-    }
-
     fn kill_with(&self, signal: Signal) -> Option<bool> {
-        let c_signal = match signal {
-            Signal::Hangup => libc::SIGHUP,
-            Signal::Interrupt => libc::SIGINT,
-            Signal::Quit => libc::SIGQUIT,
-            Signal::Illegal => libc::SIGILL,
-            Signal::Trap => libc::SIGTRAP,
-            Signal::Abort => libc::SIGABRT,
-            Signal::IOT => libc::SIGIOT,
-            Signal::Bus => libc::SIGBUS,
-            Signal::FloatingPointException => libc::SIGFPE,
-            Signal::Kill => libc::SIGKILL,
-            Signal::User1 => libc::SIGUSR1,
-            Signal::Segv => libc::SIGSEGV,
-            Signal::User2 => libc::SIGUSR2,
-            Signal::Pipe => libc::SIGPIPE,
-            Signal::Alarm => libc::SIGALRM,
-            Signal::Term => libc::SIGTERM,
-            Signal::Child => libc::SIGCHLD,
-            Signal::Continue => libc::SIGCONT,
-            Signal::Stop => libc::SIGSTOP,
-            Signal::TSTP => libc::SIGTSTP,
-            Signal::TTIN => libc::SIGTTIN,
-            Signal::TTOU => libc::SIGTTOU,
-            Signal::Urgent => libc::SIGURG,
-            Signal::XCPU => libc::SIGXCPU,
-            Signal::XFSZ => libc::SIGXFSZ,
-            Signal::VirtualAlarm => libc::SIGVTALRM,
-            Signal::Profiling => libc::SIGPROF,
-            Signal::Winch => libc::SIGWINCH,
-            Signal::IO => libc::SIGIO,
-            Signal::Sys => libc::SIGSYS,
-            Signal::Poll | Signal::Power => return None,
-        };
+        let c_signal = super::system::convert_signal(signal)?;
         unsafe { Some(libc::kill(self.pid, c_signal) == 0) }
     }
 

--- a/src/freebsd/process.rs
+++ b/src/freebsd/process.rs
@@ -201,7 +201,7 @@ pub(crate) unsafe fn get_process_data(
         ],
         &mut buffer,
     )
-    .unwrap_or_else(String::new);
+    .unwrap_or_default();
     // For some reason, it can return completely invalid path like `p\u{5}`. So we need to use
     // procstat to get around this problem.
     // let cwd = get_sys_value_str(

--- a/src/freebsd/system.rs
+++ b/src/freebsd/system.rs
@@ -19,6 +19,41 @@ use super::utils::{
 
 use libc::c_int;
 
+declare_signals! {
+    c_int,
+    Signal::Hangup => libc::SIGHUP,
+    Signal::Interrupt => libc::SIGINT,
+    Signal::Quit => libc::SIGQUIT,
+    Signal::Illegal => libc::SIGILL,
+    Signal::Trap => libc::SIGTRAP,
+    Signal::Abort => libc::SIGABRT,
+    Signal::IOT => libc::SIGIOT,
+    Signal::Bus => libc::SIGBUS,
+    Signal::FloatingPointException => libc::SIGFPE,
+    Signal::Kill => libc::SIGKILL,
+    Signal::User1 => libc::SIGUSR1,
+    Signal::Segv => libc::SIGSEGV,
+    Signal::User2 => libc::SIGUSR2,
+    Signal::Pipe => libc::SIGPIPE,
+    Signal::Alarm => libc::SIGALRM,
+    Signal::Term => libc::SIGTERM,
+    Signal::Child => libc::SIGCHLD,
+    Signal::Continue => libc::SIGCONT,
+    Signal::Stop => libc::SIGSTOP,
+    Signal::TSTP => libc::SIGTSTP,
+    Signal::TTIN => libc::SIGTTIN,
+    Signal::TTOU => libc::SIGTTOU,
+    Signal::Urgent => libc::SIGURG,
+    Signal::XCPU => libc::SIGXCPU,
+    Signal::XFSZ => libc::SIGXFSZ,
+    Signal::VirtualAlarm => libc::SIGVTALRM,
+    Signal::Profiling => libc::SIGPROF,
+    Signal::Winch => libc::SIGWINCH,
+    Signal::IO => libc::SIGIO,
+    Signal::Sys => libc::SIGSYS,
+    _ => None,
+}
+
 #[doc = include_str!("../../md_doc/system.md")]
 pub struct System {
     process_list: HashMap<Pid, Process>,
@@ -39,6 +74,7 @@ pub struct System {
 
 impl SystemExt for System {
     const IS_SUPPORTED: bool = true;
+    const SUPPORTED_SIGNALS: &'static [Signal] = supported_signals();
 
     fn new_with_specifics(refreshes: RefreshKind) -> System {
         let system_info = SystemInfo::new();

--- a/src/freebsd/system.rs
+++ b/src/freebsd/system.rs
@@ -419,7 +419,7 @@ impl System {
             // The name can be cut short because the `ki_comm` field size is limited,
             // which is why we prefer to get the name from the command line as much as
             // possible.
-            proc_.name = c_buf_to_string(&kproc.ki_comm).unwrap_or_else(String::new);
+            proc_.name = c_buf_to_string(&kproc.ki_comm).unwrap_or_default();
         }
         proc_.environ = from_cstr_array(libc::kvm_getenvv(kd, kproc, 0) as _);
         self.process_list.insert(proc_.pid, proc_);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,21 +9,8 @@
 #![allow(renamed_and_removed_lints)]
 #![allow(unknown_lints)]
 
-#[cfg(feature = "debug")]
-#[doc(hidden)]
-#[allow(unused)]
-macro_rules! sysinfo_debug {
-    ($($x:tt)*) => {{
-        eprintln!($($x)*);
-    }}
-}
-
-#[cfg(not(feature = "debug"))]
-#[doc(hidden)]
-#[allow(unused)]
-macro_rules! sysinfo_debug {
-    ($($x:tt)*) => {{}};
-}
+#[macro_use]
+mod macros;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "unknown-ci")] {

--- a/src/linux/process.rs
+++ b/src/linux/process.rs
@@ -139,45 +139,8 @@ impl Process {
 }
 
 impl ProcessExt for Process {
-    fn kill(&self) -> bool {
-        self.kill_with(Signal::Kill).unwrap()
-    }
-
     fn kill_with(&self, signal: Signal) -> Option<bool> {
-        let c_signal = match signal {
-            Signal::Hangup => libc::SIGHUP,
-            Signal::Interrupt => libc::SIGINT,
-            Signal::Quit => libc::SIGQUIT,
-            Signal::Illegal => libc::SIGILL,
-            Signal::Trap => libc::SIGTRAP,
-            Signal::Abort => libc::SIGABRT,
-            Signal::IOT => libc::SIGIOT,
-            Signal::Bus => libc::SIGBUS,
-            Signal::FloatingPointException => libc::SIGFPE,
-            Signal::Kill => libc::SIGKILL,
-            Signal::User1 => libc::SIGUSR1,
-            Signal::Segv => libc::SIGSEGV,
-            Signal::User2 => libc::SIGUSR2,
-            Signal::Pipe => libc::SIGPIPE,
-            Signal::Alarm => libc::SIGALRM,
-            Signal::Term => libc::SIGTERM,
-            Signal::Child => libc::SIGCHLD,
-            Signal::Continue => libc::SIGCONT,
-            Signal::Stop => libc::SIGSTOP,
-            Signal::TSTP => libc::SIGTSTP,
-            Signal::TTIN => libc::SIGTTIN,
-            Signal::TTOU => libc::SIGTTOU,
-            Signal::Urgent => libc::SIGURG,
-            Signal::XCPU => libc::SIGXCPU,
-            Signal::XFSZ => libc::SIGXFSZ,
-            Signal::VirtualAlarm => libc::SIGVTALRM,
-            Signal::Profiling => libc::SIGPROF,
-            Signal::Winch => libc::SIGWINCH,
-            Signal::IO => libc::SIGIO,
-            Signal::Poll => libc::SIGPOLL,
-            Signal::Power => libc::SIGPWR,
-            Signal::Sys => libc::SIGSYS,
-        };
+        let c_signal = super::system::convert_signal(signal)?;
         unsafe { Some(kill(self.pid, c_signal) == 0) }
     }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,58 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+#[cfg(feature = "debug")]
+#[doc(hidden)]
+#[allow(unused)]
+macro_rules! sysinfo_debug {
+    ($($x:tt)*) => {{
+        eprintln!($($x)*);
+    }}
+}
+
+#[cfg(not(feature = "debug"))]
+#[doc(hidden)]
+#[allow(unused)]
+macro_rules! sysinfo_debug {
+    ($($x:tt)*) => {{}};
+}
+
+macro_rules! declare_signals {
+    ($kind:ty, _ => None,) => (
+        use crate::Signal;
+
+        pub(crate) const fn supported_signals() -> &'static [Signal] {
+            &[]
+        }
+    );
+
+    ($kind:ty, $(Signal::$signal:ident => $map:expr,)+ _ => None,) => (
+        use crate::Signal;
+
+        pub(crate) const fn supported_signals() -> &'static [Signal] {
+            &[$(Signal::$signal,)*]
+        }
+
+        #[inline]
+        pub(crate) fn convert_signal(s: Signal) -> Option<$kind> {
+            match s {
+                $(Signal::$signal => Some($map),)*
+                _ => None,
+            }
+        }
+    );
+
+    ($kind:ty, $(Signal::$signal:ident => $map:expr,)+) => (
+        use crate::Signal;
+
+        pub(crate) const fn supported_signals() -> &'static [Signal] {
+            &[$(Signal::$signal,)*]
+        }
+
+        #[inline]
+        pub(crate) fn convert_signal(s: Signal) -> Option<$kind> {
+            match s {
+                $(Signal::$signal => Some($map),)*
+            }
+        }
+    )
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -124,10 +124,13 @@ pub trait DiskExt: Debug {
 
 /// Contains all the methods of the [`Process`][crate::Process] struct.
 pub trait ProcessExt: Debug {
-    /// Sends [`Signal::Kill`] to the process (which is the only signal supported on all platforms
-    /// by this crate).
+    /// Sends [`Signal::Kill`] to the process (which is the only signal supported on all supported
+    /// platforms by this crate).
     ///
     /// If you want to send another signal, take a look at [`ProcessExt::kill_with`].
+    ///
+    /// To get the list of the supported signals on this system, use
+    /// [`SystemExt::SUPPORTED_SIGNALS`].
     ///
     /// ```no_run
     /// use sysinfo::{ProcessExt, System, SystemExt};
@@ -137,13 +140,18 @@ pub trait ProcessExt: Debug {
     ///     process.kill();
     /// }
     /// ```
-    fn kill(&self) -> bool;
+    fn kill(&self) -> bool {
+        self.kill_with(Signal::Kill).unwrap_or(false)
+    }
 
     /// Sends the given `signal` to the process. If the signal doesn't exist on this platform,
     /// it'll do nothing and will return `None`. Otherwise it'll return if the signal was sent
     /// successfully.
     ///
     /// If you just want to kill the process, use [`ProcessExt::kill`] directly.
+    ///
+    /// To get the list of the supported signals on this system, use
+    /// [`SystemExt::SUPPORTED_SIGNALS`].
     ///
     /// ```no_run
     /// use sysinfo::{ProcessExt, Signal, System, SystemExt};
@@ -445,6 +453,16 @@ pub trait SystemExt: Sized + Debug + Default + Send + Sync {
     /// }
     /// ```
     const IS_SUPPORTED: bool;
+
+    /// Returns the list of the supported signals on this system (used by
+    /// [`ProcessExt::kill_with`]).
+    ///
+    /// ```
+    /// use sysinfo::{System, SystemExt};
+    ///
+    /// println!("supported signals: {:?}", System::SUPPORTED_SIGNALS);
+    /// ```
+    const SUPPORTED_SIGNALS: &'static [Signal];
 
     /// Creates a new [`System`] instance with nothing loaded except the processors list. If you
     /// want to load components, network interfaces or the disks, you'll have to use the

--- a/src/unknown/process.rs
+++ b/src/unknown/process.rs
@@ -19,10 +19,6 @@ pub struct Process {
 }
 
 impl ProcessExt for Process {
-    fn kill(&self) -> bool {
-        false
-    }
-
     fn kill_with(&self, _signal: Signal) -> Option<bool> {
         None
     }

--- a/src/unknown/system.rs
+++ b/src/unknown/system.rs
@@ -7,6 +7,11 @@ use crate::{
 
 use std::collections::HashMap;
 
+declare_signals! {
+    (),
+    _ => None,
+}
+
 #[doc = include_str!("../../md_doc/system.md")]
 pub struct System {
     processes_list: HashMap<Pid, Process>,
@@ -16,6 +21,7 @@ pub struct System {
 
 impl SystemExt for System {
     const IS_SUPPORTED: bool = false;
+    const SUPPORTED_SIGNALS: &'static [Signal] = supported_signals();
 
     fn new_with_specifics(_: RefreshKind) -> System {
         System {

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -347,21 +347,14 @@ impl Process {
 }
 
 impl ProcessExt for Process {
-    fn kill(&self) -> bool {
+    fn kill_with(&self, signal: Signal) -> Option<bool> {
+        let _c_signal = super::system::convert_signal(signal)?;
         let mut kill = process::Command::new("taskkill.exe");
-        kill.arg("/PID").arg(self.pid().to_string()).arg("/F");
+        kill.arg("/PID").arg(self.pid.to_string()).arg("/F");
         kill.creation_flags(CREATE_NO_WINDOW);
         match kill.output() {
-            Ok(o) => o.status.success(),
-            Err(_) => false,
-        }
-    }
-
-    fn kill_with(&self, signal: Signal) -> Option<bool> {
-        if signal == Signal::Kill {
-            Some(self.kill())
-        } else {
-            None
+            Ok(o) => Some(o.status.success()),
+            Err(_) => Some(false),
         }
     }
 

--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -39,6 +39,12 @@ use winapi::um::sysinfoapi::{
 use winapi::um::winnt::{HANDLE, KEY_READ};
 use winapi::um::winreg::{RegOpenKeyExW, RegQueryValueExW};
 
+declare_signals! {
+    (),
+    Signal::Kill => (),
+    _ => None,
+}
+
 #[doc = include_str!("../../md_doc/system.md")]
 pub struct System {
     process_list: HashMap<usize, Process>,
@@ -74,6 +80,7 @@ unsafe fn boot_time() -> u64 {
 
 impl SystemExt for System {
     const IS_SUPPORTED: bool = true;
+    const SUPPORTED_SIGNALS: &'static [Signal] = supported_signals();
 
     #[allow(non_snake_case)]
     fn new_with_specifics(refreshes: RefreshKind) -> System {

--- a/tests/code_checkers/headers.rs
+++ b/tests/code_checkers/headers.rs
@@ -1,38 +1,9 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use std::fs::{read_dir, File};
-use std::io::Read;
+use super::utils::show_error;
 use std::path::Path;
 
-fn read_dirs<P: AsRef<Path>>(dir: P, errors: &mut u32) {
-    for entry in read_dir(dir).expect("read_dir failed") {
-        let entry = entry.expect("entry failed");
-        let path = entry.path();
-        if path.is_dir() {
-            read_dirs(path, errors);
-        } else {
-            if !check_file_license(&path) {
-                *errors += 1;
-            }
-        }
-    }
-}
-
-fn read_file<P: AsRef<Path>>(p: P) -> String {
-    let mut f = File::open(p).expect("read_file::open failed");
-    let mut content =
-        String::with_capacity(f.metadata().map(|m| m.len() as usize + 1).unwrap_or(0));
-    f.read_to_string(&mut content)
-        .expect("read_file::read_to_end failed");
-    content
-}
-
-fn show_error(p: &Path, err: &str) {
-    eprintln!("=> [{}]: {}", p.display(), err);
-}
-
-fn check_file_license(p: &Path) -> bool {
-    let content = read_file(p);
+pub fn check_license_header(content: &str, p: &Path) -> bool {
     let mut lines = content.lines();
     let next = lines.next();
     let header = "// Take a look at the license at the top of the repository in the LICENSE file.";
@@ -70,13 +41,4 @@ fn check_file_license(p: &Path) -> bool {
             false
         }
     }
-}
-
-#[test]
-fn check_license_headers() {
-    let mut errors = 0;
-    for folder in ["src", "tests", "examples"] {
-        read_dirs(folder, &mut errors);
-    }
-    assert!(errors == 0);
 }

--- a/tests/code_checkers/headers.rs
+++ b/tests/code_checkers/headers.rs
@@ -1,9 +1,9 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use super::utils::show_error;
+use super::utils::{show_error, TestResult};
 use std::path::Path;
 
-pub fn check_license_header(content: &str, p: &Path) -> bool {
+pub fn check_license_header(content: &str, p: &Path) -> TestResult {
     let mut lines = content.lines();
     let next = lines.next();
     let header = "// Take a look at the license at the top of the repository in the LICENSE file.";
@@ -12,17 +12,26 @@ pub fn check_license_header(content: &str, p: &Path) -> bool {
         Some(s) if s == header => {
             let next = lines.next();
             match next {
-                Some("") => true,
+                Some("") => TestResult {
+                    nb_tests: 1,
+                    nb_errors: 0,
+                },
                 Some(s) => {
                     show_error(
                         p,
                         &format!("Expected empty line after license header, found `{}`", s),
                     );
-                    false
+                    TestResult {
+                        nb_tests: 1,
+                        nb_errors: 1,
+                    }
                 }
                 None => {
                     show_error(p, "This file should very likely not exist...");
-                    false
+                    TestResult {
+                        nb_tests: 1,
+                        nb_errors: 1,
+                    }
                 }
             }
         }
@@ -34,11 +43,17 @@ pub fn check_license_header(content: &str, p: &Path) -> bool {
                     header, s
                 ),
             );
-            false
+            TestResult {
+                nb_tests: 1,
+                nb_errors: 1,
+            }
         }
         None => {
             show_error(p, "This (empty?) file should very likely not exist...");
-            false
+            TestResult {
+                nb_tests: 1,
+                nb_errors: 1,
+            }
         }
     }
 }

--- a/tests/code_checkers/mod.rs
+++ b/tests/code_checkers/mod.rs
@@ -1,24 +1,25 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 mod headers;
+mod signals;
 mod utils;
 
 use std::path::Path;
+use utils::TestResult;
 
-const CHECKS: &[(fn(&str, &Path) -> bool, &[&str])] =
-    &[(headers::check_license_header, &["src", "tests", "examples"])];
+const CHECKS: &[(fn(&str, &Path) -> TestResult, &[&str])] = &[
+    (headers::check_license_header, &["src", "tests", "examples"]),
+    (signals::check_signals, &["src"]),
+];
 
-fn handle_tests(nb_errors: &mut usize, nb_run: &mut usize) {
+fn handle_tests(res: &mut [TestResult]) {
     utils::read_dirs(
         &["benches", "examples", "src", "tests"],
         &mut |p: &Path, c: &str| {
             if let Some(first) = p.iter().next().and_then(|first| first.to_str()) {
-                for (check, filter) in CHECKS {
+                for (pos, (check, filter)) in CHECKS.iter().enumerate() {
                     if filter.contains(&first) {
-                        *nb_run += 1;
-                        if !check(c, p) {
-                            *nb_errors += 1;
-                        }
+                        res[pos] += check(c, p);
                     }
                 }
             }
@@ -28,11 +29,19 @@ fn handle_tests(nb_errors: &mut usize, nb_run: &mut usize) {
 
 #[test]
 fn code_checks() {
-    let mut nb_errors = 0;
-    let mut nb_run = 0;
+    let mut res = Vec::new();
 
-    handle_tests(&mut nb_errors, &mut nb_run);
+    for _ in CHECKS {
+        res.push(TestResult {
+            nb_tests: 0,
+            nb_errors: 0,
+        });
+    }
 
-    assert_eq!(nb_errors, 0);
-    assert_ne!(nb_run, 0);
+    handle_tests(&mut res);
+
+    for r in res {
+        assert_eq!(r.nb_errors, 0);
+        assert_ne!(r.nb_tests, 0);
+    }
 }

--- a/tests/code_checkers/mod.rs
+++ b/tests/code_checkers/mod.rs
@@ -1,3 +1,38 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 mod headers;
+mod utils;
+
+use std::path::Path;
+
+const CHECKS: &[(fn(&str, &Path) -> bool, &[&str])] =
+    &[(headers::check_license_header, &["src", "tests", "examples"])];
+
+fn handle_tests(nb_errors: &mut usize, nb_run: &mut usize) {
+    utils::read_dirs(
+        &["benches", "examples", "src", "tests"],
+        &mut |p: &Path, c: &str| {
+            if let Some(first) = p.iter().next().and_then(|first| first.to_str()) {
+                for (check, filter) in CHECKS {
+                    if filter.contains(&first) {
+                        *nb_run += 1;
+                        if !check(c, p) {
+                            *nb_errors += 1;
+                        }
+                    }
+                }
+            }
+        },
+    );
+}
+
+#[test]
+fn code_checks() {
+    let mut nb_errors = 0;
+    let mut nb_run = 0;
+
+    handle_tests(&mut nb_errors, &mut nb_run);
+
+    assert_eq!(nb_errors, 0);
+    assert_ne!(nb_run, 0);
+}

--- a/tests/code_checkers/signals.rs
+++ b/tests/code_checkers/signals.rs
@@ -1,0 +1,67 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use super::utils::{show_error, TestResult};
+use std::path::Path;
+
+fn check_supported_signals_decl<'a>(lines: &mut impl Iterator<Item = &'a str>, p: &Path) -> usize {
+    for line in lines {
+        let trimmed = line.trim();
+        if trimmed.starts_with("const SUPPORTED_SIGNALS: &'static [Signal]") {
+            if trimmed != "const SUPPORTED_SIGNALS: &'static [Signal] = supported_signals();" {
+                show_error(
+                    p,
+                    "SystemExt::SUPPORTED_SIGNALS should be declared using `supported_signals()`",
+                );
+                return 1;
+            }
+            break;
+        }
+    }
+    0
+}
+
+fn check_kill_decl<'a>(lines: &mut impl Iterator<Item = &'a str>, p: &Path) -> usize {
+    let mut errors = 0;
+
+    while let Some(line) = lines.next() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("fn kill(") {
+            show_error(p, "`ProcessExt::kill` should not be reimplemented!");
+            errors += 1;
+        } else if trimmed.starts_with("fn kill_with(") {
+            if let Some(line) = lines.next() {
+                let trimmed = line.trim();
+                if (trimmed.starts_with("let ")
+                    && trimmed.ends_with("::system::convert_signal(signal)?;"))
+                    || trimmed == "None"
+                {
+                    continue;
+                } else {
+                    show_error(p, "`ProcessExt::kill_with` should use `convert_signal`");
+                    errors += 1;
+                }
+            }
+        }
+    }
+    errors
+}
+
+pub fn check_signals(content: &str, p: &Path) -> TestResult {
+    let mut lines = content.lines();
+    let mut res = TestResult {
+        nb_tests: 0,
+        nb_errors: 0,
+    };
+
+    while let Some(line) = lines.next() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("impl SystemExt for System {") {
+            res.nb_tests += 1;
+            res.nb_errors += check_supported_signals_decl(&mut lines, p);
+        } else if trimmed.starts_with("impl ProcessExt for Process {") {
+            res.nb_tests += 1;
+            res.nb_errors += check_kill_decl(&mut lines, p);
+        }
+    }
+    res
+}

--- a/tests/code_checkers/utils.rs
+++ b/tests/code_checkers/utils.rs
@@ -1,0 +1,37 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use std::fs::{self, File};
+use std::io::Read;
+use std::path::Path;
+
+pub fn read_dirs<P: AsRef<Path>, F: FnMut(&Path, &str)>(dirs: &[P], callback: &mut F) {
+    for dir in dirs {
+        read_dir(dir, callback);
+    }
+}
+
+fn read_dir<P: AsRef<Path>, F: FnMut(&Path, &str)>(dir: P, callback: &mut F) {
+    for entry in fs::read_dir(dir).expect("read_dir failed") {
+        let entry = entry.expect("entry failed");
+        let path = entry.path();
+        if path.is_dir() {
+            read_dir(path, callback);
+        } else {
+            let content = read_file(&path);
+            callback(&path, &content);
+        }
+    }
+}
+
+fn read_file<P: AsRef<Path>>(p: P) -> String {
+    let mut f = File::open(p).expect("read_file::open failed");
+    let mut content =
+        String::with_capacity(f.metadata().map(|m| m.len() as usize + 1).unwrap_or(0));
+    f.read_to_string(&mut content)
+        .expect("read_file::read_to_end failed");
+    content
+}
+
+pub fn show_error(p: &Path, err: &str) {
+    eprintln!("=> [{}]: {}", p.display(), err);
+}

--- a/tests/code_checkers/utils.rs
+++ b/tests/code_checkers/utils.rs
@@ -4,6 +4,18 @@ use std::fs::{self, File};
 use std::io::Read;
 use std::path::Path;
 
+pub struct TestResult {
+    pub nb_tests: usize,
+    pub nb_errors: usize,
+}
+
+impl std::ops::AddAssign for TestResult {
+    fn add_assign(&mut self, other: Self) {
+        self.nb_tests += other.nb_tests;
+        self.nb_errors += other.nb_errors;
+    }
+}
+
 pub fn read_dirs<P: AsRef<Path>, F: FnMut(&Path, &str)>(dirs: &[P], callback: &mut F) {
     for dir in dirs {
         read_dir(dir, callback);


### PR DESCRIPTION
Remains to be done: add a `#[test]` which checks how `kill_with` and `SUPPORTED_SIGNALS` are declared.