### PR TITLE
Make Pid newtype public for getting raw OS pid

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -38,7 +38,8 @@ macro_rules! pid_decl {
     ($typ:ty) => {
         #[doc = include_str!("../md_doc/pid.md")]
         #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-        pub struct Pid(pub(crate) $typ);
+        #[repr(transparent)]
+        pub struct Pid(pub $typ);
 
         impl From<$typ> for Pid {
             fn from(v: $typ) -> Self {

--- a/src/common.rs
+++ b/src/common.rs
@@ -46,6 +46,11 @@ macro_rules! pid_decl {
                 Self(v)
             }
         }
+        impl Into<$typ> for Pid {
+            fn into(self) -> $typ {
+                self.0
+            }
+        }
         impl PidExt<$typ> for Pid {
             fn as_u32(self) -> u32 {
                 self.0 as u32

--- a/src/common.rs
+++ b/src/common.rs
@@ -39,7 +39,7 @@ macro_rules! pid_decl {
         #[doc = include_str!("../md_doc/pid.md")]
         #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
         #[repr(transparent)]
-        pub struct Pid(pub $typ);
+        pub struct Pid(pub(crate) $typ);
 
         impl From<$typ> for Pid {
             fn from(v: $typ) -> Self {


### PR DESCRIPTION
sysinfo provides a way of getting process(es) by name and other useful utility functions. But, to do anything useful with the Pid, like calling OS functions on it, one must get the raw OS representation of the Pid.

This PR will allow users of the crate to access the newtype field or transmute it soundly.