### PR TITLE
Fix KB conversion for memory in Windows

### DIFF
--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -172,8 +172,8 @@ impl SystemExt for System {
                     * perf_info
                         .CommitTotal
                         .saturating_sub(perf_info.PhysicalTotal);
-                self.swap_total = (swap_total / 1000) as u64;
-                self.swap_used = (swap_used / 1000) as u64;
+                self.swap_total = (swap_total / 1024) as u64;
+                self.swap_used = (swap_used / 1024) as u64;
             }
         }
     }

--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -158,8 +158,8 @@ impl SystemExt for System {
             let mut mem_info: MEMORYSTATUSEX = zeroed();
             mem_info.dwLength = size_of::<MEMORYSTATUSEX>() as u32;
             GlobalMemoryStatusEx(&mut mem_info);
-            self.mem_total = auto_cast!(mem_info.ullTotalPhys, u64) / 1_000;
-            self.mem_available = auto_cast!(mem_info.ullAvailPhys, u64) / 1_000;
+            self.mem_total = auto_cast!(mem_info.ullTotalPhys, u64) / 1_024;
+            self.mem_available = auto_cast!(mem_info.ullAvailPhys, u64) / 1_024;
             let mut perf_info: PERFORMANCE_INFORMATION = zeroed();
             if GetPerformanceInfo(&mut perf_info, size_of::<PERFORMANCE_INFORMATION>() as u32)
                 == TRUE


### PR DESCRIPTION
Fix to divide the bytes output from the  GlobalMemoryStatusEx(&mut mem_info) function by 1024 to get the correct KB usage for the system.
