### PR TITLE
Impl From<Pid> for usize

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -46,12 +46,9 @@ macro_rules! pid_decl {
                 Self(v)
             }
         }
-        #[allow(clippy::from_over_into)]
-        // This Into implementation is required otherwise it seems you can't do `pid.into()`
-        // for some reasons...
-        impl Into<$typ> for Pid {
-            fn into(self) -> $typ {
-                self.0
+        impl From<Pid> for $typ {
+            fn from(v: Pid) -> Self {
+                v.0
             }
         }
         impl PidExt<$typ> for Pid {


### PR DESCRIPTION
This is a backward-compatible change, as there is a blanket `impl<FROM, TO> Into<TO> for FROM where TO: From<FROM>` in the standard library.

This shouldn't cause any issue as far as I can tell. The comment seems to indicate some sort of issue without pointing to any test or issue.

Having a From implementation makes it easier to use in a more complex conversion, e.g. `usize::from(pid) as u32`. With the current code, this must be written as `Into::<usize>::into(pid) as u32`, which is much more verbose.