### PR TITLE
Fix underflow for windows run_time computation

### DIFF
--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -332,7 +332,7 @@ impl Process {
         if refresh_kind.disk_usage() {
             update_disk_usage(self);
         }
-        self.run_time = now.checked_sub(self.start_time()).unwrap_or(0);
+        self.run_time = now.saturating_sub(self.start_time());
         self.updated = true;
     }
 }

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -332,7 +332,7 @@ impl Process {
         if refresh_kind.disk_usage() {
             update_disk_usage(self);
         }
-        self.run_time = now - self.start_time();
+        self.run_time = now.checked_sub(self.start_time()).unwrap_or(0);
         self.updated = true;
     }
 }


### PR DESCRIPTION
Fixes #716 

Also worth considering if `1` would be a better default than `0`