### PR TITLE
macOS: Fix disks missing due to incorrect CFStringGetStringPtr usage

### DIFF
--- a/src/apple/macos/disk.rs
+++ b/src/apple/macos/disk.rs
@@ -118,18 +118,24 @@ unsafe fn get_str_value(dict: CFDictionaryRef, key: &[u8]) -> Option<String> {
         let len_utf16 = cfs::CFStringGetLength(v);
         let len_bytes = len_utf16 as usize * 2; // Two bytes per UTF-16 codepoint.
 
-        let mut buf = vec![0; len_bytes];
-        let success = cfs::CFStringGetCString(
-            v,
-            buf.as_mut_ptr(),
-            len_bytes as _,
-            cfs::kCFStringEncodingUTF8,
-        );
+        let v_ptr = cfs::CFStringGetCStringPtr(v, cfs::kCFStringEncodingUTF8);
+        if v_ptr.is_null() {
+            // Fallback on CFStringGetString to read the underlying bytes from the CFString.
+            let mut buf = vec![0; len_bytes];
+            let success = cfs::CFStringGetCString(
+                v,
+                buf.as_mut_ptr(),
+                len_bytes as _,
+                cfs::kCFStringEncodingUTF8,
+            );
 
-        if success != 0 {
-            utils::vec_to_rust(buf)
+            if success != 0 {
+                utils::vec_to_rust(buf)
+            } else {
+                None
+            }
         } else {
-            None
+            utils::cstr_to_rust_with_size(v_ptr, Some(len_bytes))
         }
     })
 }

--- a/src/apple/utils.rs
+++ b/src/apple/utils.rs
@@ -27,3 +27,12 @@ pub(crate) fn cstr_to_rust_with_size(c: *const c_char, size: Option<usize>) -> O
         String::from_utf8(s).ok()
     }
 }
+
+pub(crate) fn vec_to_rust(buf: Vec<i8>) -> Option<String> {
+    String::from_utf8(
+        buf.into_iter()
+            .flat_map(|b| if b > 0 { Some(b as u8) } else { None })
+            .collect(),
+    )
+    .ok()
+}


### PR DESCRIPTION
With 0.23.7 (more specifically, with [this change](https://github.com/GuillaumeGomez/sysinfo/pull/714)), I noticed a behavior change in one of my applications where the system disk would not be found by `sysinfo` anymore. The only disk I'd find with `list_disks` was `iSCPreboot`, with a capacity of ~500mb.

By comparing with 0.23.6, I noticed that my application previously relied on the SSV (`com.apple.os.update-[...]`), which is a snapshot volume and is now excluded from detected disks with 0.23.7.

![big sur boot disk structure](https://eclecticlightdotcom.files.wordpress.com/2021/01/bootdiskstructurebigsur.jpg?w=940)

I understood why my snapshot was being excluded, but I didn't understand why my other disks weren't detected, so I dug around and found that my disks were found by `getfsstat` but were subsequently excluded by `get_str_value` because they allegedly did not have a value for the `DAMediaName` property.

By digging around some more, I found the culprit in the [CFStringGetCStringPtr documentation](https://developer.apple.com/documentation/corefoundation/1542133-cfstringgetcstringptr):
> ## Return Value
> A pointer to a C string or NULL if the internal storage of theString does not allow this to be returned efficiently.

> This function either returns the requested pointer immediately, with no memory allocations and no copying, in constant time, or returns NULL. If the latter is the result, call an alternative function such as the [CFStringGetCString(_:_:_:_:)](https://developer.apple.com/documentation/corefoundation/1542721-cfstringgetcstring) function to extract the characters.

> Whether or not this function returns a valid pointer or NULL depends on many factors, all of which depend on how the string was created and its properties. In addition, the function result might change between different releases and on different platforms. So do not count on receiving a non-NULL result from this function under any circumstances.

This PR changes `get_str_value` so that it adequately falls back on `CFStringGetCString` when a fast return is not available from `CFStringGetCStringPtr`. On my machine this does return all volumes for which the `MNT_ROOTFS` flag is set.