### PR TITLE
Adding network usage information

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -169,6 +169,7 @@ assert_eq!(r.", stringify!($name), "(), false);
 pub struct ProcessRefreshKind {
     cpu: bool,
     disk_usage: bool,
+    network_usage: bool,
 }
 
 impl ProcessRefreshKind {
@@ -195,11 +196,13 @@ impl ProcessRefreshKind {
     ///
     /// assert_eq!(r.cpu(), true);
     /// assert_eq!(r.disk_usage(), true);
+    /// assert_eq!(r.network_usage(), true);
     /// ```
     pub fn everything() -> Self {
         Self {
             cpu: true,
             disk_usage: true,
+            network_usage: true,
         }
     }
 
@@ -209,6 +212,12 @@ impl ProcessRefreshKind {
         disk_usage,
         with_disk_usage,
         without_disk_usage
+    );
+    impl_get_set!(
+        ProcessRefreshKind,
+        network_usage,
+        with_network_usage,
+        without_network_usage
     );
 }
 
@@ -692,6 +701,40 @@ pub struct DiskUsage {
     pub total_read_bytes: u64,
     /// Number of read bytes since the last refresh.
     pub read_bytes: u64,
+}
+
+/// Type containing received and trasmitted bytes on all interface.
+///
+/// It is returned by [`ProcessExt::network_usage`][crate::ProcessExt::network_usage].
+///
+/// ```no_run
+/// use sysinfo::{ProcessExt, System, SystemExt};
+///
+/// let s = System::new_all();
+/// for (pid, process) in s.processes() {
+///     let network_usage = process.network_usage();
+///     println!("[{}] received bytes   : new/total => {}/{} B",
+///         pid,
+///         network_usage.received_bytes,
+///         network_usage.total_received_bytes,
+///     );
+///     println!("[{}] transmitted bytes: new/total => {}/{} B",
+///         pid,
+///         network_usage.transmitted_bytes,
+///         network_usage.total_transmitted_bytes,
+///     );
+/// }
+/// ```
+#[derive(Debug, Default, Clone, Copy, PartialEq, PartialOrd)]
+pub struct NetworkUsage {
+    /// Total number of transmit bytes.
+    pub total_transmitted_bytes: u64,
+    /// Number of transmit bytes since the last refresh.
+    pub transmitted_bytes: u64,
+    /// Total number of receive bytes.
+    pub total_received_bytes: u64,
+    /// Number of receive bytes since the last refresh.
+    pub received_bytes: u64,
 }
 
 /// Enum describing the different status of a process.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ cfg_if::cfg_if! {
 }
 
 pub use common::{
-    get_current_pid, DiskType, DiskUsage, Gid, LoadAvg, NetworksIter, Pid, PidExt,
+    get_current_pid, DiskType, DiskUsage, Gid, LoadAvg, NetworkUsage, NetworksIter, Pid, PidExt,
     ProcessRefreshKind, ProcessStatus, RefreshKind, Signal, Uid, User,
 };
 pub use sys::{Component, Disk, NetworkData, Networks, Process, Processor, System};

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -5,8 +5,8 @@ use crate::{
     sys::{Component, Disk, Networks, Process, Processor},
 };
 use crate::{
-    DiskType, DiskUsage, LoadAvg, NetworksIter, Pid, ProcessRefreshKind, ProcessStatus,
-    RefreshKind, Signal, User,
+    DiskType, DiskUsage, LoadAvg, NetworkUsage, NetworksIter, Pid, ProcessRefreshKind,
+    ProcessStatus, RefreshKind, Signal, User,
 };
 
 use std::collections::HashMap;
@@ -370,6 +370,28 @@ pub trait ProcessExt: Debug {
     /// }
     /// ```
     fn disk_usage(&self) -> DiskUsage;
+
+    /// Returns number of bytes received and transmitted to all network.
+    ///
+    /// ⚠️ This is currently only implemented on linux.
+    ///
+    /// ```no_run
+    /// use sysinfo::{Pid, ProcessExt, System, SystemExt};
+    ///
+    /// let s = System::new();
+    /// if let Some(process) = s.process(Pid::from(1337)) {
+    ///     let network_usage = process.network_usage();
+    ///     println!("received bytes   : new/total => {}/{}",
+    ///         network_usage.received_bytes,
+    ///         network_usage.total_received_bytes,
+    ///     );
+    ///     println!("transmitted bytes: new/total => {}/{}",
+    ///         network_usage.transmitted_bytes,
+    ///         network_usage.total_transmitted_bytes,
+    ///     );
+    /// }
+    /// ```
+    fn network_usage(&self) -> NetworkUsage;
 }
 
 /// Contains all the methods of the [`Processor`][crate::Processor] struct.


### PR DESCRIPTION
This PR implements the fetching of network information for linux process using the `proc/{pid}/net/dev/`information and summing up all bytes transmitted and received. 

Knowing that this is not implemented for all OSes, this PR is not intended to be merged and only serves as a reference for those who need network information. 

