### PR TITLE
divising the virtual memory by 1000 to get kb in Linux

### DIFF
--- a/src/apple/process.rs
+++ b/src/apple/process.rs
@@ -33,7 +33,7 @@ impl fmt::Display for ProcessStatus {
 }
 
 /// Enum describing the different status of a thread.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ThreadStatus {
     /// Thread is running normally.
     Running,

--- a/src/common.rs
+++ b/src/common.rs
@@ -419,7 +419,7 @@ impl<'a> IntoIterator for &'a Networks {
 ///     println!("{:?}: {:?}", disk.name(), disk.type_());
 /// }
 /// ```
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum DiskType {
     /// HDD type.
     HDD,
@@ -436,7 +436,7 @@ pub enum DiskType {
 ///
 /// If you want the list of the supported signals on the current system, use
 /// [`SystemExt::SUPPORTED_SIGNALS`][crate::SystemExt::SUPPORTED_SIGNALS].
-#[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Debug)]
 pub enum Signal {
     /// Hangup detected on controlling terminal or death of controlling process.
     Hangup,
@@ -682,7 +682,7 @@ impl UserExt for User {
 ///     );
 /// }
 /// ```
-#[derive(Debug, Default, Clone, Copy, PartialEq, PartialOrd)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd)]
 pub struct DiskUsage {
     /// Total number of written bytes.
     pub total_written_bytes: u64,
@@ -695,7 +695,7 @@ pub struct DiskUsage {
 }
 
 /// Enum describing the different status of a process.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ProcessStatus {
     /// ## Linux/FreeBSD
     ///

--- a/src/linux/disk.rs
+++ b/src/linux/disk.rs
@@ -18,7 +18,7 @@ macro_rules! cast {
 }
 
 #[doc = include_str!("../../md_doc/disk.md")]
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub struct Disk {
     type_: DiskType,
     device_name: OsString,

--- a/src/linux/process.rs
+++ b/src/linux/process.rs
@@ -457,7 +457,7 @@ fn update_time_and_memory(
             entry.memory -= parent_memory;
         }
         // vsz
-        entry.virtual_memory = u64::from_str(parts[22]).unwrap_or(0);
+        entry.virtual_memory = u64::from_str(parts[22]).unwrap_or(0) / 1_000;
         if entry.virtual_memory >= parent_virtual_memory {
             entry.virtual_memory -= parent_virtual_memory;
         }

--- a/src/linux/process.rs
+++ b/src/linux/process.rs
@@ -456,7 +456,8 @@ fn update_time_and_memory(
         if entry.memory >= parent_memory {
             entry.memory -= parent_memory;
         }
-        // vsz
+        // vsz correspond to the Virtual memory size in bytes. Divising by 1_000 gives us kb.
+        // see: https://man7.org/linux/man-pages/man5/proc.5.html
         entry.virtual_memory = u64::from_str(parts[22]).unwrap_or(0) / 1_000;
         if entry.virtual_memory >= parent_virtual_memory {
             entry.virtual_memory -= parent_virtual_memory;

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -700,7 +700,7 @@ fn to_u64(v: &[u8]) -> u64 {
     x
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 enum InfoType {
     /// The end-user friendly name of:
     /// - Android: The device model


### PR DESCRIPTION
It seems that divising the virtual memory by the `page_size_in_kb` is necessary to have `kb` and not `bytes` for the virtual_memory. 

Virtual memory and Residual memory do not share the same metric on my machine at the moment.