### PR TITLE
Improve linux process user ID retrieval

### DIFF
--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -49,6 +49,14 @@ fn bench_refresh_processes(b: &mut test::Bencher) {
 }
 
 #[bench]
+fn bench_first_refresh_processes(b: &mut test::Bencher) {
+    b.iter(move || {
+        let mut s = sysinfo::System::new();
+        s.refresh_processes();
+    });
+}
+
+#[bench]
 fn bench_refresh_process(b: &mut test::Bencher) {
     let mut s = sysinfo::System::new();
 

--- a/src/linux/process.rs
+++ b/src/linux/process.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::fs::{self, File};
 use std::io::Read;
+use std::mem::MaybeUninit;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
@@ -88,9 +89,9 @@ pub struct Process {
     pub(crate) updated: bool,
     cpu_usage: f32,
     /// User id of the process owner.
-    pub uid: uid_t,
+    pub uid: Option<uid_t>,
     /// Group id of the process owner.
-    pub gid: gid_t,
+    pub gid: Option<gid_t>,
     pub(crate) status: ProcessStatus,
     /// Tasks run by this process.
     pub tasks: HashMap<Pid, Process>,
@@ -128,8 +129,8 @@ impl Process {
             start_time_without_boot_time,
             start_time: start_time_without_boot_time + info.boot_time,
             run_time: 0,
-            uid: 0,
-            gid: 0,
+            uid: None,
+            gid: None,
             status: ProcessStatus::Unknown(0),
             tasks: if pid.0 == 0 {
                 HashMap::with_capacity(1000)
@@ -377,11 +378,9 @@ pub(crate) fn _get_process_data(
 
     tmp.pop();
     tmp.push("status");
-    if let Ok(data) = get_all_data(&tmp, 16_385) {
-        if let Some((uid, gid)) = _get_uid_and_gid(data) {
-            p.uid = uid;
-            p.gid = gid;
-        }
+    if let Some((uid, gid)) = get_uid_and_gid(&tmp) {
+        p.uid = Some(uid);
+        p.gid = Some(gid);
     }
 
     if proc_list.pid.0 != 0 {
@@ -586,7 +585,23 @@ fn copy_from_file(entry: &Path) -> Vec<String> {
     }
 }
 
-fn _get_uid_and_gid(status_data: String) -> Option<(uid_t, gid_t)> {
+fn get_uid_and_gid(file_path: &Path) -> Option<(uid_t, gid_t)> {
+    use std::os::unix::ffi::OsStrExt;
+
+    unsafe {
+        let mut sstat: MaybeUninit<libc::stat> = MaybeUninit::uninit();
+
+        let mut file_path: Vec<u8> = file_path.as_os_str().as_bytes().to_vec();
+        file_path.push(0);
+        if libc::stat(file_path.as_ptr() as *const _, sstat.as_mut_ptr()) == 0 {
+            let sstat = sstat.assume_init();
+
+            return Some((sstat.st_uid, sstat.st_gid));
+        }
+    }
+
+    let status_data = get_all_data(&file_path, 16_385).ok()?;
+
     // We're only interested in the lines starting with Uid: and Gid:
     // here. From these lines, we're looking at the second entry to get
     // the effective u/gid.


### PR DESCRIPTION
With the bench it gives:

```
before:
test bench_first_refresh_processes ... bench:  20,298,159 ns/iter (+/- 1,598,495)

after:
test bench_first_refresh_processes ... bench:  17,830,218 ns/iter (+/- 1,214,291)
```