### PR TITLE
Attempt to open Windows process with limited access if elevated access fails

### DIFF
--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -48,8 +48,8 @@ use winapi::um::securitybaseapi::GetTokenInformation;
 use winapi::um::winbase::{GetProcessIoCounters, CREATE_NO_WINDOW};
 use winapi::um::winnt::{
     TokenUser, HANDLE, HEAP_ZERO_MEMORY, IO_COUNTERS, MEMORY_BASIC_INFORMATION,
-    PROCESS_QUERY_INFORMATION, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_VM_READ, RTL_OSVERSIONINFOEXW, TOKEN_QUERY, TOKEN_USER,
-    ULARGE_INTEGER,
+    PROCESS_QUERY_INFORMATION, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_VM_READ,
+    RTL_OSVERSIONINFOEXW, TOKEN_QUERY, TOKEN_USER, ULARGE_INTEGER,
 };
 
 impl fmt::Display for ProcessStatus {
@@ -66,14 +66,18 @@ fn get_process_handler(pid: Pid) -> Option<HandleWrapper> {
         return None;
     }
     let options = PROCESS_QUERY_INFORMATION | PROCESS_VM_READ;
-    
-    HandleWrapper::new(unsafe{ OpenProcess(options, FALSE, pid.0 as DWORD) } )
+
+    HandleWrapper::new(unsafe { OpenProcess(options, FALSE, pid.0 as DWORD) })
         .or_else(|| {
-            sysinfo_debug!("OpenProcess failed, error: {:?}", unsafe{ GetLastError() });
-            HandleWrapper::new(unsafe{ OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid.0 as DWORD) } )
+            sysinfo_debug!("OpenProcess failed, error: {:?}", unsafe { GetLastError() });
+            HandleWrapper::new(unsafe {
+                OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid.0 as DWORD)
+            })
         })
         .or_else(|| {
-            sysinfo_debug!("OpenProcess limited failed, error: {:?}", unsafe{ GetLastError() });
+            sysinfo_debug!("OpenProcess limited failed, error: {:?}", unsafe {
+                GetLastError()
+            });
             None
         })
 }

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -48,7 +48,7 @@ use winapi::um::securitybaseapi::GetTokenInformation;
 use winapi::um::winbase::{GetProcessIoCounters, CREATE_NO_WINDOW};
 use winapi::um::winnt::{
     TokenUser, HANDLE, HEAP_ZERO_MEMORY, IO_COUNTERS, MEMORY_BASIC_INFORMATION,
-    PROCESS_QUERY_INFORMATION, PROCESS_VM_READ, RTL_OSVERSIONINFOEXW, TOKEN_QUERY, TOKEN_USER,
+    PROCESS_QUERY_INFORMATION, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_VM_READ, RTL_OSVERSIONINFOEXW, TOKEN_QUERY, TOKEN_USER,
     ULARGE_INTEGER,
 };
 
@@ -66,8 +66,16 @@ fn get_process_handler(pid: Pid) -> Option<HandleWrapper> {
         return None;
     }
     let options = PROCESS_QUERY_INFORMATION | PROCESS_VM_READ;
-
-    unsafe { HandleWrapper::new(OpenProcess(options, FALSE, pid.0 as DWORD)) }
+    
+    HandleWrapper::new(unsafe{ OpenProcess(options, FALSE, pid.0 as DWORD) } )
+        .or_else(|| {
+            sysinfo_debug!("OpenProcess failed, error: {:?}", unsafe{ GetLastError() });
+            HandleWrapper::new(unsafe{ OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid.0 as DWORD) } )
+        })
+        .or_else(|| {
+            sysinfo_debug!("OpenProcess limited failed, error: {:?}", unsafe{ GetLastError() });
+            None
+        })
 }
 
 unsafe fn get_process_user_id(


### PR DESCRIPTION
Fixes #771

If opening a process with PROCESS_QUERY_INFORMATION | PROCESS_VM_READ fails the code reverts to using PROCESS_QUERY_LIMITED_INFORMATION. Certain fields may not be available in this case(such as process params) but this is already the case when using refresh_processes().