### PR TITLE
Basic GPU support

### DIFF
--- a/md_doc/gpu.md
+++ b/md_doc/gpu.md
@@ -1,0 +1,1 @@
+Struct containing a GPU information.

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,8 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use crate::{
-    Component, ComponentExt, Cpu, CpuExt, Disk, DiskExt, NetworkData, NetworkExt, Networks,
-    NetworksExt, Process, ProcessExt, System, SystemExt,
+    Component, ComponentExt, Cpu, CpuExt, Disk, DiskExt, Gpu, GpuExt, NetworkData, NetworkExt,
+    Networks, NetworksExt, Process, ProcessExt, System, SystemExt,
 };
 
 use std::fmt;
@@ -33,6 +33,7 @@ impl fmt::Debug for System {
             .field("nb processes", &self.processes().len())
             .field("nb disks", &self.disks().len())
             .field("nb components", &self.components().len())
+            .field("nb GPUs", &self.gpus().len())
             .finish()
     }
 }
@@ -127,6 +128,21 @@ impl fmt::Debug for NetworkData {
             .field("total errors income", &self.total_errors_on_received())
             .field("errors outcome", &self.errors_on_transmitted())
             .field("total errors outcome", &self.total_errors_on_transmitted())
+            .finish()
+    }
+}
+
+impl fmt::Debug for Gpu {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GPU")
+            .field("name", &self.name())
+            .field("gpu usage", &self.gpu_usage())
+            .field("vendor ID", &self.vendor_id())
+            .field("brand", &self.brand())
+            .field("vram used", &self.vram_used())
+            .field("vram total", &self.vram_total())
+            .field("freq", &self.freq())
+            .field("max freq", &self.freq_max())
             .finish()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,9 +62,9 @@ pub use common::{
     get_current_pid, CpuRefreshKind, DiskType, DiskUsage, Gid, LoadAvg, NetworksIter, Pid, PidExt,
     ProcessRefreshKind, ProcessStatus, RefreshKind, Signal, Uid, User,
 };
-pub use sys::{Component, Cpu, Disk, NetworkData, Networks, Process, System};
+pub use sys::{Component, Cpu, Disk, Gpu, NetworkData, Networks, Process, System};
 pub use traits::{
-    ComponentExt, CpuExt, DiskExt, NetworkExt, NetworksExt, ProcessExt, SystemExt, UserExt,
+    ComponentExt, CpuExt, DiskExt, GpuExt, NetworkExt, NetworksExt, ProcessExt, SystemExt, UserExt,
 };
 
 #[cfg(feature = "c-interface")]

--- a/src/linux/gpu.rs
+++ b/src/linux/gpu.rs
@@ -118,8 +118,8 @@ impl Gpu {
         let gpu = Gpu {
             name,
             gpu_usage: Some(gpu_usage),
-            vram_used: Some(vram_used / 1024),
-            vram_total: Some(vram_total / 1024),
+            vram_used: Some(vram_used / 1000),
+            vram_total: Some(vram_total / 1000),
             freq: None,
             freq_max: None,
             vendor_id,

--- a/src/linux/gpu.rs
+++ b/src/linux/gpu.rs
@@ -105,8 +105,49 @@ impl Gpu {
         Some(gpu)
     }
 
-    fn get_amd_gpu_info(_path: &Path) -> Option<Self> {
-        None
+    fn get_amd_gpu_info(path: &Path) -> Option<Self> {
+        let vendor_id = String::from("AMD");
+        let name: String = path.file_name().unwrap().to_str().unwrap().to_string();
+
+        let gpu_usage: f32 = match File::open(path.join("device/gpu_busy_percent")) {
+            Ok(mut f) => {
+                let mut s = String::new();
+                f.read_to_string(&mut s).unwrap();
+                s.trim().split('\n').next().unwrap().parse::<f32>().unwrap()
+            }
+            Err(_) => return None,
+        };
+
+        let vram_used: u64 = match File::open(path.join("device/mem_info_vram_used")) {
+            Ok(mut f) => {
+                let mut s = String::new();
+                f.read_to_string(&mut s).unwrap();
+                s.trim().split('\n').next().unwrap().parse::<u64>().unwrap()
+            }
+            Err(_) => return None,
+        };
+
+        let vram_total: u64 = match File::open(path.join("device/mem_info_vram_total")) {
+            Ok(mut f) => {
+                let mut s = String::new();
+                f.read_to_string(&mut s).unwrap();
+                s.trim().split('\n').next().unwrap().parse::<u64>().unwrap()
+            }
+            Err(_) => return None,
+        };
+
+        let gpu = Gpu {
+            name: name,
+            gpu_usage: Some(gpu_usage),
+            vram_used: Some(vram_used/1024),
+            vram_total: Some(vram_total/1024),
+            freq: None,
+            freq_max: None,
+            vendor_id: vendor_id,
+            brand: None,
+        };
+
+        Some(gpu)
     }
 
     fn get_nvidia_gpu_info(_path: &Path) -> Option<Self> {

--- a/src/linux/gpu.rs
+++ b/src/linux/gpu.rs
@@ -31,10 +31,10 @@ impl Gpu {
                 let filename = entry.file_name().and_then(|x| x.to_str()).unwrap_or("");
                 if filename.starts_with("card") && !filename.contains('-') {
                     let gpu: Option<Self> = match get_vendor_id(&entry.join("device")) {
-                        Some(id) => match id.as_str() {
-                            "8086" => Self::get_intel_gpu_info(&entry),
-                            "10de" => Self::get_nvidia_gpu_info(&entry),
-                            "1002" => Self::get_amd_gpu_info(&entry),
+                        Some(id) => match id {
+                            0x8086 => Self::get_intel_gpu_info(&entry),
+                            0x10de => Self::get_nvidia_gpu_info(&entry),
+                            0x1002 => Self::get_amd_gpu_info(&entry),
                             _ => None,
                         },
                         None => None,
@@ -182,11 +182,11 @@ impl GpuExt for Gpu {
     }
 }
 
-fn get_vendor_id(path: &Path) -> Option<String> {
+fn get_vendor_id(path: &Path) -> Option<u16> {
     let mut vendor_id: String = String::with_capacity(7);
     if let Ok(mut f) = File::open(path.join("vendor")) {
         if f.read_to_string(&mut vendor_id).is_ok() {
-            return Some(String::from(&vendor_id[2..6]));
+            return Some(u16::from_str_radix(&vendor_id[2..6], 16).unwrap());
         }
     }
     None

--- a/src/linux/gpu.rs
+++ b/src/linux/gpu.rs
@@ -1,0 +1,159 @@
+#![allow(clippy::too_many_arguments)]
+
+use std::fs::{read_dir, File};
+use std::io::Read;
+use std::path::Path;
+
+use crate::GpuExt;
+
+#[doc = include_str!("../../md_doc/gpu.md")]
+pub struct Gpu {
+    name: String,
+    gpu_usage: Option<f32>,
+    vram_used: Option<u64>,
+    vram_total: Option<u64>,
+    freq: Option<u64>,
+    freq_max: Option<u64>,
+    vendor_id: String,
+    brand: Option<String>,
+}
+
+impl Gpu {
+    /// Creates a new instance of `Gpu` with everything set to `None`.
+    pub fn new() -> Self {
+        Gpu {
+            name: String::new(),
+            gpu_usage: None,
+            vram_used: None,
+            vram_total: None,
+            freq: None,
+            freq_max: None,
+            vendor_id: String::new(),
+            brand: None,
+        }
+    }
+
+    /// Find all the GPUs in the system.
+    pub fn get_gpus() -> Vec<Self> {
+        let mut gpus = Vec::new();
+        if let Ok(dir) = read_dir(&Path::new("/sys/class/drm/")) {
+            for entry in dir.flatten() {
+                let entry = entry.path();
+                if entry.is_dir()
+                    && entry
+                        .file_name()
+                        .and_then(|x| x.to_str())
+                        .unwrap_or("")
+                        .starts_with("card")
+                    && !entry
+                        .file_name()
+                        .and_then(|x| x.to_str())
+                        .unwrap_or("")
+                        .contains("-")
+                {
+                    let gpu: Option<Self> = match get_vendor_id(&Path::new(&entry).join("device")) {
+                        Some(id) => match id.as_str() {
+                            "8086" => Self::get_intel_gpu_info(&entry),
+                            "10de" => Self::get_nvidia_gpu_info(&entry),
+                            "1002" => Self::get_amd_gpu_info(&entry),
+                            _ => None,
+                        },
+                        None => None,
+                    };
+                    if let Some(gpu_info) = gpu {
+                        gpus.push(gpu_info);
+                    }
+                }
+            }
+        }
+        gpus
+    }
+
+    fn get_intel_gpu_info(path: &Path) -> Option<Self> {
+        let vendor_id = String::from("Intel");
+        let name: String = path.file_name().unwrap().to_str().unwrap().to_string();
+
+        let cur_freq: u64 = match File::open(path.join("gt_cur_freq_mhz")) {
+            Ok(mut f) => {
+                let mut s = String::new();
+                f.read_to_string(&mut s).unwrap();
+                s.trim().split('\n').next().unwrap().parse::<u64>().unwrap()
+            }
+            Err(_) => return None,
+        };
+
+        let max_freq: u64 = match File::open(path.join("gt_max_freq_mhz")) {
+            Ok(mut f) => {
+                let mut s = String::new();
+                f.read_to_string(&mut s).unwrap();
+                s.trim().split('\n').next().unwrap().parse::<u64>().unwrap()
+            }
+            Err(_) => return None,
+        };
+
+        let gpu = Gpu {
+            name: name,
+            gpu_usage: None,
+            vram_used: None,
+            vram_total: None,
+            freq: Some(cur_freq),
+            freq_max: Some(max_freq),
+            vendor_id,
+            brand: None,
+        };
+
+        Some(gpu)
+    }
+
+    fn get_amd_gpu_info(_path: &Path) -> Option<Self> {
+        None
+    }
+
+    fn get_nvidia_gpu_info(_path: &Path) -> Option<Self> {
+        None
+    }
+}
+
+impl GpuExt for Gpu {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn gpu_usage(&self) -> Option<f32> {
+        self.gpu_usage
+    }
+
+    fn vram_used(&self) -> Option<u64> {
+        self.vram_used
+    }
+
+    fn vram_total(&self) -> Option<u64> {
+        self.vram_total
+    }
+
+    fn freq(&self) -> Option<u64> {
+        self.freq
+    }
+
+    fn freq_max(&self) -> Option<u64> {
+        self.freq_max
+    }
+
+    fn vendor_id(&self) -> String {
+        self.vendor_id.clone()
+    }
+
+    fn brand(&self) -> Option<String> {
+        self.brand.clone()
+    }
+}
+
+fn get_vendor_id(path: &Path) -> Option<String> {
+    let mut vendor_id: String = String::with_capacity(7);
+    if let Ok(mut f) = File::open(path.join("vendor")) {
+        if f.read_to_string(&mut vendor_id).is_ok() {
+            return Some(String::from(&vendor_id[2..6]));
+        }
+    }
+    return None;
+}

--- a/src/linux/gpu.rs
+++ b/src/linux/gpu.rs
@@ -49,7 +49,7 @@ impl Gpu {
                         .file_name()
                         .and_then(|x| x.to_str())
                         .unwrap_or("")
-                        .contains("-")
+                        .contains('-')
                 {
                     let gpu: Option<Self> = match get_vendor_id(&Path::new(&entry).join("device")) {
                         Some(id) => match id.as_str() {
@@ -92,7 +92,7 @@ impl Gpu {
         };
 
         let gpu = Gpu {
-            name: name,
+            name,
             gpu_usage: None,
             vram_used: None,
             vram_total: None,
@@ -137,13 +137,13 @@ impl Gpu {
         };
 
         let gpu = Gpu {
-            name: name,
+            name,
             gpu_usage: Some(gpu_usage),
             vram_used: Some(vram_used / 1024),
             vram_total: Some(vram_total / 1024),
             freq: None,
             freq_max: None,
-            vendor_id: vendor_id,
+            vendor_id,
             brand: None,
         };
 
@@ -155,17 +155,23 @@ impl Gpu {
         let name: String = path.file_name().unwrap().to_str().unwrap().to_string();
 
         let gpu = Gpu {
-            name: name,
+            name,
             gpu_usage: None,
             vram_used: None,
             vram_total: None,
             freq: None,
             freq_max: None,
-            vendor_id: vendor_id,
+            vendor_id,
             brand: None,
         };
 
         Some(gpu)
+    }
+}
+
+impl Default for Gpu {
+    fn default() -> Self {
+        Gpu::new()
     }
 }
 
@@ -210,5 +216,5 @@ fn get_vendor_id(path: &Path) -> Option<String> {
             return Some(String::from(&vendor_id[2..6]));
         }
     }
-    return None;
+    None
 }

--- a/src/linux/gpu.rs
+++ b/src/linux/gpu.rs
@@ -150,8 +150,22 @@ impl Gpu {
         Some(gpu)
     }
 
-    fn get_nvidia_gpu_info(_path: &Path) -> Option<Self> {
-        None
+    fn get_nvidia_gpu_info(path: &Path) -> Option<Self> {
+        let vendor_id = String::from("NVIDIA");
+        let name: String = path.file_name().unwrap().to_str().unwrap().to_string();
+
+        let gpu = Gpu {
+            name: name,
+            gpu_usage: None,
+            vram_used: None,
+            vram_total: None,
+            freq: None,
+            freq_max: None,
+            vendor_id: vendor_id,
+            brand: None,
+        };
+
+        Some(gpu)
     }
 }
 

--- a/src/linux/gpu.rs
+++ b/src/linux/gpu.rs
@@ -139,8 +139,8 @@ impl Gpu {
         let gpu = Gpu {
             name: name,
             gpu_usage: Some(gpu_usage),
-            vram_used: Some(vram_used/1024),
-            vram_total: Some(vram_total/1024),
+            vram_used: Some(vram_used / 1024),
+            vram_total: Some(vram_total / 1024),
             freq: None,
             freq_max: None,
             vendor_id: vendor_id,

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -3,6 +3,7 @@
 pub mod component;
 pub mod cpu;
 pub mod disk;
+pub mod gpu;
 pub mod network;
 pub mod process;
 pub mod system;
@@ -11,6 +12,7 @@ pub(crate) mod utils;
 pub use self::component::Component;
 pub use self::cpu::Cpu;
 pub use self::disk::Disk;
+pub use self::gpu::Gpu;
 pub use self::network::{NetworkData, Networks};
 pub use self::process::Process;
 pub use self::system::System;

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -6,7 +6,8 @@ use crate::sys::disk;
 use crate::sys::process::*;
 use crate::sys::utils::get_all_data;
 use crate::{
-    CpuRefreshKind, Disk, LoadAvg, Networks, Pid, ProcessRefreshKind, RefreshKind, SystemExt, User,
+    CpuRefreshKind, Disk, Gpu, LoadAvg, Networks, Pid, ProcessRefreshKind, RefreshKind, SystemExt,
+    User,
 };
 
 use libc::{self, c_char, c_int, sysconf, _SC_CLK_TCK, _SC_HOST_NAME_MAX, _SC_PAGESIZE};
@@ -172,6 +173,7 @@ pub struct System {
     disks: Vec<Disk>,
     networks: Networks,
     users: Vec<User>,
+    gpus: Vec<Gpu>,
     /// Field set to `false` in `update_cpus` and to `true` in `refresh_processes_specifics`.
     ///
     /// The reason behind this is to avoid calling the `update_cpus` more than necessary.
@@ -389,6 +391,7 @@ impl SystemExt for System {
             disks: Vec::with_capacity(2),
             networks: Networks::new(),
             users: Vec::new(),
+            gpus: Vec::new(),
             need_cpus_update: true,
             info,
             got_cpu_frequency: false,
@@ -490,6 +493,10 @@ impl SystemExt for System {
 
     fn refresh_users_list(&mut self) {
         self.users = crate::users::get_users_list();
+    }
+
+    fn refresh_gpus_list(&mut self) {
+        self.gpus = Gpu::get_gpus();
     }
 
     // COMMON PART
@@ -676,6 +683,10 @@ impl SystemExt for System {
                 None
             }
         }
+    }
+
+    fn gpus(&self) -> &[Gpu] {
+        &self.gpus
     }
 
     #[cfg(not(target_os = "android"))]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     common::{Gid, Uid},
-    sys::{Component, Cpu, Disk, Networks, Process},
+    sys::{Component, Cpu, Disk, Gpu, Networks, Process},
 };
 use crate::{
     CpuRefreshKind, DiskType, DiskUsage, LoadAvg, NetworksIter, Pid, ProcessRefreshKind,
@@ -610,6 +610,7 @@ pub trait SystemExt: Sized + Debug + Default + Send + Sync {
         self.refresh_processes();
         self.refresh_disks();
         self.refresh_networks();
+        self.refresh_gpus_list();
     }
 
     /// Refreshes system information (RAM, swap, CPU usage and components' temperature).
@@ -836,6 +837,16 @@ pub trait SystemExt: Sized + Debug + Default + Send + Sync {
     fn refresh_networks_list(&mut self) {
         self.networks_mut().refresh_networks_list();
     }
+
+    /// Refreshes gpus.
+    ///
+    /// ```no_run
+    /// use sysinfo::{System, SystemExt};
+    ///
+    /// let mut s = System::new_all();
+    ///     s.refresh_gpus_list();
+    /// ```
+    fn refresh_gpus_list(&mut self);
 
     /// Returns the process list.
     ///
@@ -1252,6 +1263,20 @@ pub trait SystemExt: Sized + Debug + Default + Send + Sync {
     fn get_user_by_id(&self, user_id: &Uid) -> Option<&User> {
         self.users().iter().find(|user| user.id() == user_id)
     }
+
+    /// Returns the list of the GPUs.
+    ///
+    /// By default, the list of gpue is empty until you call [`SystemExt::refresh_gpu`]
+    ///
+    /// ```no_run
+    /// use sysinfo::{GpuExt, System, SystemExt};
+    ///
+    /// let s = System::new_all();
+    /// for gpu in s.gpus() {
+    ///     println!("{}%", gpu.name());
+    /// }
+    /// ```
+    fn gpus(&self) -> &[Gpu];
 }
 
 /// Getting volume of received and transmitted data.
@@ -1579,4 +1604,104 @@ pub trait UserExt: Debug {
     /// }
     /// ```
     fn groups(&self) -> &[String];
+}
+
+/// Contains all the methods of the [`Gpu`][crate::Gpu] struct.
+pub trait GpuExt: Debug {
+    /// Returns the name of the GPU.
+    ///
+    /// ```no_run
+    /// use sysinfo::{GpuExt, System, SystemExt};
+    ///
+    /// let mut s = System::new_all();
+    /// for gpu in s.gpus() {
+    ///    println!("{}", gpu.name());
+    /// }
+    /// ```
+    fn name(&self) -> &str;
+
+    /// Returns this GPU's usage.
+    ///
+    ///
+    /// ```no_run
+    /// use sysinfo::{GpuExt, System, SystemExt};
+    ///
+    /// let s = System::new();
+    /// for gpu in s.gpus() {
+    ///     println!("{}%", gpu.gpu_usage());
+    /// }
+    /// ```
+    fn gpu_usage(&self) -> Option<f32>;
+
+    /// Returns this GPU's Vram usage.
+    ///
+    /// ```no_run
+    /// use sysinfo::{GpuExt, System, SystemExt};
+    ///
+    /// let s = System::new();
+    /// for gpu in s.gpus() {
+    ///    println!("{}%", gpu.vram_used());
+    /// }
+    /// ```
+    fn vram_used(&self) -> Option<u64>;
+
+    /// Returns this GPU's Vram total.
+    ///
+    /// ```no_run
+    /// use sysinfo::{GpuExt, System, SystemExt};
+    ///
+    /// let s = System::new();
+    /// for gpu in s.gpus() {
+    ///   println!("{}%", gpu.vram_total());
+    /// }
+    /// ```
+    fn vram_total(&self) -> Option<u64>;
+
+    /// Returns this GPU's vendor id.
+    ///
+    /// ```no_run
+    /// use sysinfo::{GpuExt, System, SystemExt};
+    ///
+    /// let s = System::new();
+    /// for gpu in s.gpus() {
+    ///   println!("{}", gpu.vendor_id());
+    /// }
+    /// ```
+    fn vendor_id(&self) -> String;
+
+    /// Returns this GPU's vendor brand.
+    ///
+    /// ```no_run
+    /// use sysinfo::{GpuExt, System, SystemExt};
+    ///
+    /// let s = System::new();
+    /// for gpu in s.gpus() {
+    ///     println!("{}", gpu.brand());
+    /// }
+    /// ```
+    fn brand(&self) -> Option<String>;
+
+    /// Returns this GPU's frequency.
+    ///
+    /// ```no_run
+    /// use sysinfo::{GpuExt, System, SystemExt};
+    ///
+    /// let s = System::new();
+    /// for gpu in s.gpus() {
+    ///     println!("{}", gpu.freq());
+    /// }
+    /// ```
+    fn freq(&self) -> Option<u64>;
+
+    /// Returns this GPU's max frequency.
+    ///
+    /// ```no_run
+    /// use sysinfo::{GpuExt, System, SystemExt};
+    ///
+    /// let s = System::new();
+    /// for gpu in s.gpus() {
+    ///     println!("{}", gpu.max_freq());
+    /// }
+    /// ```
+    fn freq_max(&self) -> Option<u64>;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1633,7 +1633,7 @@ pub trait GpuExt: Debug {
     /// ```
     fn gpu_usage(&self) -> Option<f32>;
 
-    /// Returns this GPU's Vram usage.
+    /// Returns this GPU's Vram usage in KiB.
     ///
     /// ```no_run
     /// use sysinfo::{GpuExt, System, SystemExt};
@@ -1645,7 +1645,7 @@ pub trait GpuExt: Debug {
     /// ```
     fn vram_used(&self) -> Option<u64>;
 
-    /// Returns this GPU's Vram total.
+    /// Returns this GPU's Vram total in KiB.
     ///
     /// ```no_run
     /// use sysinfo::{GpuExt, System, SystemExt};


### PR DESCRIPTION
This PR implements some basic fetching of GPU information. **It shouldn't be merged at the moment** because it only supports Linux and it is still under development. It is also my first contribution to this project, so there may be some mistakes to correct.

Currently, it is able to fetch the following information:

- Intel GPU
  - Vendor name
  - Clock speed
  - Maximum clock speed
- AMD GPU
  - Vendor name
  - Maximum VRAM
  - VRAM used
  - GPU usage percentage
- NVIDIA GPU
  - Vendor name

I will try to continue supporting more GPU information.