### PR TITLE
fix: fixed Windows boot time

### DIFF
--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -73,7 +73,7 @@ unsafe impl<T> Sync for Wrap<T> {}
 
 unsafe fn boot_time() -> u64 {
     match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
-        Ok(n) => n.as_secs().saturating_sub(GetTickCount64()) / 1000,
+        Ok(n) => n.as_secs().saturating_sub(GetTickCount64() / 1000),
         Err(_e) => {
             sysinfo_debug!("Failed to compute boot time: {:?}", _e);
             0


### PR DESCRIPTION
That's a fixup of 87773f69e3a128d3071d9d1702fc127083adf72e, which introduced a wrong operation order