### PR TITLE
Fixing refreshing CPU frequency under Linux

### DIFF
--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -308,7 +308,7 @@ impl System {
                 }
             }
 
-            if refresh_kind.frequency() && !self.got_cpu_frequency {
+            if refresh_kind.frequency() || !self.got_cpu_frequency {
                 #[cfg(feature = "multithread")]
                 use rayon::iter::{
                     IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator,

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -308,7 +308,7 @@ impl System {
                 }
             }
 
-            if refresh_kind.frequency() || !self.got_cpu_frequency {
+            if refresh_kind.frequency() {
                 #[cfg(feature = "multithread")]
                 use rayon::iter::{
                     IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator,


### PR DESCRIPTION
When trying to refresh the CPUs information, I noticed that even I specifically asked for refreshing the frequencies, it didn't work under Linux (frequencies stayed unchanged).

I simply changed a condition which seemed to be the problem in `src/linux/system.rs` and the refresh mechanism now works as expected.

Here is some example code that wasn't working and now works:

```rust
  let mut sys = System::new_with_specifics(RefreshKind::new().with_cpu(CpuRefreshKind::everything()));
  loop {
      thread::sleep(Duration::from_millis(200));
      sys.refresh_cpu();
      println!("{:#?}", sys.cpus());
  }
```