### PR TITLE
Don't get cpu frequency by default when using refresh_cpu

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -441,6 +441,10 @@ mod test {
         }
         s.refresh_cpu();
         for proc_ in s.cpus() {
+            assert_eq!(proc_.frequency(), 0);
+        }
+        s.refresh_cpu_specifics(CpuRefreshKind::everything());
+        for proc_ in s.cpus() {
             assert_ne!(proc_.frequency(), 0);
         }
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -650,7 +650,7 @@ pub trait SystemExt: Sized + Debug + Default + Send + Sync {
     /// 200ms) to get accurate values as it uses previous results to compute the next value.
     ///
     /// Calling this method is the same as calling
-    /// `refresh_cpu_specifics(CpuRefreshKind::everything())`.
+    /// `refresh_cpu_specifics(CpuRefreshKind::new().with_cpu_usage())`.
     ///
     /// ```no_run
     /// use sysinfo::{System, SystemExt};
@@ -659,7 +659,7 @@ pub trait SystemExt: Sized + Debug + Default + Send + Sync {
     /// s.refresh_cpu();
     /// ```
     fn refresh_cpu(&mut self) {
-        self.refresh_cpu_specifics(CpuRefreshKind::everything())
+        self.refresh_cpu_specifics(CpuRefreshKind::new().with_cpu_usage())
     }
 
     /// Refreshes CPUs specific information.


### PR DESCRIPTION
Changing the behaviour of `refresh_cpu` to disable refreshing CPU frequency.