### PR TITLE
Do not fallback to cmd[0] if /proc/pid/exe is unreadable

### DIFF
--- a/src/linux/process.rs
+++ b/src/linux/process.rs
@@ -411,20 +411,20 @@ pub(crate) fn _get_process_data(
     } else {
         p.name = name.into();
         tmp.pop();
+
         tmp.push("cmdline");
         p.cmd = copy_from_file(&tmp);
         tmp.pop();
+
         tmp.push("exe");
         match tmp.read_link() {
             Ok(exe_path) => {
                 p.exe = exe_path;
             }
             Err(_) => {
-                p.exe = if let Some(cmd) = p.cmd.get(0) {
-                    PathBuf::from(cmd)
-                } else {
-                    PathBuf::new()
-                };
+                // Do not use cmd[0] because it is not the same thing.
+                // See https://github.com/GuillaumeGomez/sysinfo/issues/697.
+                p.exe = PathBuf::new()
             }
         }
         tmp.pop();

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -208,6 +208,18 @@ pub trait ProcessExt: Debug {
     ///     println!("{}", process.exe().display());
     /// }
     /// ```
+    ///
+    /// ### Implementation notes
+    ///
+    /// On Linux, this method will return an empty path if there
+    /// was an error trying to read `/proc/<pid>/exe`. This can
+    /// happen, for example, if the permission levels or UID namespaces
+    /// between the caller and target processes are different.
+    ///
+    /// It is also the case that `cmd[0]` is _not_ usually a correct
+    /// replacement for this.
+    /// A process [may change its `cmd[0]` value](https://man7.org/linux/man-pages/man5/proc.5.html)
+    /// freely, making this an untrustworthy source of information.
     fn exe(&self) -> &Path;
 
     /// Returns the pid of the process.


### PR DESCRIPTION
This PR implements the changes discussed in https://github.com/GuillaumeGomez/sysinfo/issues/697, and publicly documents them as well.

Closes https://github.com/GuillaumeGomez/sysinfo/issues/697 