### PR TITLE
Fix the problem that Process::exe() sometimes returns an empty PathBuf under windows

### DIFF
--- a/tests/process.rs
+++ b/tests/process.rs
@@ -11,7 +11,6 @@ fn test_process() {
         return;
     }
     assert!(!s.processes().is_empty());
-    #[cfg(not(windows))]
     assert!(s
         .processes()
         .values()


### PR DESCRIPTION
Some processes (such as svchost.exe) will cause `EnumProcessModulesEx` to fail, even when run with administrator privileges:

![image](https://user-images.githubusercontent.com/13356747/183242656-666b6293-2f41-4dd7-9763-beaa6fae76f0.png)

The official Microsoft documentation states that the `hModule` parameter of the `GetModuleFileNameExW` function can be NULL to get the path to the executable file: <https://docs.microsoft.com/en-us/windows/win32/api/psapi/nf-psapi-getmodulefilenameexw>.

> [in, optional] hModule
> 
> A handle to the module. If this parameter is NULL, GetModuleFileNameEx returns the path of the executable file of the process specified in hProcess.
