### PR TITLE
introduce-report_windows_memory_in_kibi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,3 +80,4 @@ multithread = ["rayon"]
 debug = ["libc/extra_traits"]
 # This feature is used on CI to emulate unknown/unsupported target.
 unknown-ci = []
+report_windows_memory_in_kibi = []


### PR DESCRIPTION
# Background

Reporting Windows memory values in kilos instead of kibis is causing me problems.  Especially given the fact that, under Linux, the same values are reported in kibis.

# Change

Introduce a feature that results in Windows memory values being reported in kibis rather than kilos.
