### PR TITLE
FIX#821 Allow code to keep temperature data for device without label.

### DIFF
--- a/src/linux/component.rs
+++ b/src/linux/component.rs
@@ -87,8 +87,8 @@ fn append_files(components: &mut Vec<Component>, folder: &Path) {
                 let mut p_crit = folder.to_path_buf();
                 let mut p_max = folder.to_path_buf();
 
-                // Disk have no labe why Don't know.
-                // So we use model name instead
+                // Disk have no label. Why? Don't know.
+                // So we use the model name instead.
                 let fragment_label = match found_label {
                     Some(_) => format!("temp{}_label", key),
                     None => "device/model".to_string(),

--- a/src/linux/component.rs
+++ b/src/linux/component.rs
@@ -80,13 +80,21 @@ fn append_files(components: &mut Vec<Component>, folder: &Path) {
                     _ => {}
                 }
             }
-            if let (Some(_), Some(found_input)) = (found_label, found_input) {
+
+            if let Some(found_input) = found_input {
                 let mut p_label = folder.to_path_buf();
                 let mut p_input = folder.to_path_buf();
                 let mut p_crit = folder.to_path_buf();
                 let mut p_max = folder.to_path_buf();
 
-                p_label.push(&format!("temp{}_label", key));
+                // Disk have no labe why Don't know.
+                // So we use model name instead
+                let fragment_label = match found_label {
+                    Some(_) => format!("temp{}_label", key),
+                    None => "device/model".to_string(),
+                };
+
+                p_label.push(&fragment_label);
                 p_input.push(&format!("temp{}{}", key, val[found_input]));
                 p_max.push(&format!("temp{}_max", key));
                 p_crit.push(&format!("temp{}_crit", key));

--- a/src/linux/component.rs
+++ b/src/linux/component.rs
@@ -33,6 +33,35 @@ fn is_file<T: AsRef<Path>>(path: T) -> bool {
     metadata(path).ok().map(|m| m.is_file()).unwrap_or(false)
 }
 
+/// Read out `hwmon` info (hardware monitor) from `folder` [Path]
+/// for value path to check at refresh and files containing `max`,
+/// `critical value and `label` and store this info in `components`.
+///
+/// What is read:
+///
+/// - Optionnal: sensor label, in the general case content of `tempN_label`
+///   see below for special cases
+/// - Optionnal: max value defined in `tempN_max`
+/// - Optionnal: critical value defined in `tempN_crit`
+///
+/// Where `N` is a u32 associated to a sensor like `temp1_max`, `temp1_input`.
+///
+/// ## Special case: Disk drive with `drivetemp` module
+///
+/// For some crazy rational, hardware monitoring exposed by `drivetemp` has no label so the `label of a `Component`
+/// deduced.
+///
+/// So the `device/model` content will be used instead of `tempN_label` content.
+///
+/// ## Special case: RasperryPy CPU and some vendor sensors
+///
+/// Have empty label, file exist but is empty, they will be labelled `Components N`.
+///
+/// ## Doc to Linux kernel API.
+///
+/// Kernel hwmon API: https://www.kernel.org/doc/html/latest/hwmon/hwmon-kernel-api.html
+/// DriveTemp kernel API: https://docs.kernel.org/gpu/amdgpu/thermal.html#hwmon-interfaces
+/// Amdgpu hwmon interface: https://www.kernel.org/doc/html/latest/hwmon/drivetemp.html
 fn append_files(components: &mut Vec<Component>, folder: &Path) {
     let mut matchings: HashMap<u32, Vec<String>> = HashMap::with_capacity(10);
 

--- a/src/linux/component.rs
+++ b/src/linux/component.rs
@@ -39,23 +39,23 @@ fn is_file<T: AsRef<Path>>(path: T) -> bool {
 ///
 /// What is read:
 ///
-/// - Optionnal: sensor label, in the general case content of `tempN_label`
+/// - Optional: sensor label, in the general case content of `tempN_label`
 ///   see below for special cases
-/// - Optionnal: max value defined in `tempN_max`
-/// - Optionnal: critical value defined in `tempN_crit`
+/// - Optional: max value defined in `tempN_max`
+/// - Optional: critical value defined in `tempN_crit`
 ///
 /// Where `N` is a u32 associated to a sensor like `temp1_max`, `temp1_input`.
 ///
 /// ## Special case: Disk drive with `drivetemp` module
 ///
-/// For some crazy rational, hardware monitoring exposed by `drivetemp` has no label so the `label of a `Component`
-/// deduced.
+/// For some crazy rational, hardware monitoring exposed by `drivetemp` has no label so the `label`
+/// of a `Component` is deduced and not retrieved.
 ///
 /// So the `device/model` content will be used instead of `tempN_label` content.
 ///
-/// ## Special case: RasperryPy CPU and some vendor sensors
+/// ## Special case: Rasperry Pi CPU and some vendor sensors
 ///
-/// Have empty label, file exist but is empty, they will be labelled `Components N`.
+/// Have empty label, files exist but are empty, they will be labelled `Components N`.
 ///
 /// ## Doc to Linux kernel API.
 ///

--- a/src/linux/component.rs
+++ b/src/linux/component.rs
@@ -35,7 +35,7 @@ fn is_file<T: AsRef<Path>>(path: T) -> bool {
 
 /// Read out `hwmon` info (hardware monitor) from `folder` [Path]
 /// for value path to check at refresh and files containing `max`,
-/// `critical value and `label` and store this info in `components`.
+/// `critical value` and `label` and store this info in `components`.
 ///
 /// What is read:
 ///


### PR DESCRIPTION
Allow to track temperature of disks and more, using their models instead of label.

A run of 
```sh
cargo run --example simple 
temperature
```
gives me

```
### it's acpitz checked /name
Component 1: 37°C (max: 37°C) 
Component 1: 46°C (max: 46°C)
Component 1: 41°C (max: 41°C / critical: 128°C)
## PC_MODEL_SONDE checked /name
Component 3: 0°C (max: 0°C)
Component 4: 0°C (max: 0°C)
Component 5: 0°C (max: 0°C)
Component 6: 0°C (max: 0°C)
Component 7: 0°C (max: 0°C)
Component 8: 0°C (max: 0°C)
Core 0: 42°C (max: 100°C / critical: 100°C)
Core 1: 41°C (max: 100°C / critical: 100°C)
Core 2: 40°C (max: 100°C / critical: 100°C)
Core 3: 40°C (max: 100°C / critical: 100°C)
CPU: 41°C (max: 41°C)
GPU: 40°C (max: 40°C)
Package id 0: 43°C (max: 100°C / critical: 100°C)
UNICORN SOLIDDRIVE: 41°C (max: 41°C)
PONY HARDMETALDRIVE: 36°C (max: 60°C / critical: 85°C)
CPU: 41°C (max: 41°C)
```

Instead of:
```
Core 0: 46°C (max: 100°C / critical: 100°C)
Core 1: 43°C (max: 100°C / critical: 100°C)
Core 2: 44°C (max: 100°C / critical: 100°C)
Core 3: 43°C (max: 100°C / critical: 100°C)
CPU: 53°C (max: 53°C)
GPU: 42°C (max: 42°C)
Package id 0: 46°C (max: 100°C / critical: 100°C)
CPU: 53°C (max: 53°C)
```