### PR TITLE
Add SystemExt::distribution_id()

### DIFF
--- a/src/apple/system.rs
+++ b/src/apple/system.rs
@@ -605,6 +605,10 @@ impl SystemExt for System {
             }
         }
     }
+
+    fn distribution_id(&self) -> String {
+        std::env::consts::OS.to_owned()
+    }
 }
 
 impl Default for System {

--- a/src/freebsd/system.rs
+++ b/src/freebsd/system.rs
@@ -361,6 +361,10 @@ impl SystemExt for System {
     fn os_version(&self) -> Option<String> {
         self.system_info.get_os_release()
     }
+
+    fn distribution_id(&self) -> String {
+        std::env::consts::OS.to_owned()
+    }
 }
 
 impl Default for System {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,9 +328,10 @@ mod test {
 
     #[test]
     fn check_system_info() {
+        let s = System::new();
+
         // We don't want to test on unsupported systems.
         if System::IS_SUPPORTED {
-            let s = System::new();
             assert!(!s.name().expect("Failed to get system name").is_empty());
 
             assert!(!s
@@ -345,6 +346,8 @@ mod test {
                 .expect("Failed to get long OS version")
                 .is_empty());
         }
+
+        assert!(!s.distribution_id().is_empty());
     }
 
     #[test]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1235,6 +1235,23 @@ pub trait SystemExt: Sized + Debug + Default + Send + Sync {
     /// ```
     fn long_os_version(&self) -> Option<String>;
 
+    /// Returns the distribution id as defined by os-release,
+    /// or [`std::env::consts::OS`].
+    ///
+    /// See also
+    /// - https://www.freedesktop.org/software/systemd/man/os-release.html#ID=
+    /// - https://doc.rust-lang.org/std/env/consts/constant.OS.html
+    ///
+    /// **Important**: this information is computed every time this function is called.
+    ///
+    /// ```no_run
+    /// use sysinfo::{System, SystemExt};
+    ///
+    /// let s = System::new();
+    /// println!("Distribution ID: {:?}", s.distribution_id());
+    /// ```
+    fn distribution_id(&self) -> String;
+
     /// Returns the system hostname based off DNS
     ///
     /// **Important**: this information is computed every time this function is called.

--- a/src/unknown/system.rs
+++ b/src/unknown/system.rs
@@ -166,6 +166,10 @@ impl SystemExt for System {
         None
     }
 
+    fn distribution_id(&self) -> String {
+        std::env::consts::OS.to_owned()
+    }
+
     fn host_name(&self) -> Option<String> {
         None
     }

--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -496,6 +496,10 @@ impl SystemExt for System {
         };
         Some(format!("{} ({})", major, build_number))
     }
+
+    fn distribution_id(&self) -> String {
+        std::env::consts::OS.to_owned()
+    }
 }
 
 impl Default for System {


### PR DESCRIPTION
SystemExt::name() returns human-readable distribution name, but there is no machine-readable alternative.

SystemExt::distribution_id() returns os-release.ID, or std::env::consts::OS if os-release.ID is unavailable. Fallback behaviour is consistent with the os-release.ID specification on Linux.

See also
- https://www.freedesktop.org/software/systemd/man/os-release.html#ID=
- https://doc.rust-lang.org/std/env/consts/constant.OS.html

Closes #843.