### PR TITLE
Update MSRV and update crate version to 0.26.3

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,11 +1,11 @@
 task:
-  name: rust 1.54 on freebsd 13
+  name: rust 1.56 on freebsd 13
   freebsd_instance:
     image: freebsd-13-1-release-amd64
   setup_script:
     - pkg install -y curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh
-    - sh rustup.sh -y --profile=minimal --default-toolchain=1.54
+    - sh rustup.sh -y --profile=minimal --default-toolchain=1.56
     - . $HOME/.cargo/env
     - rustup --version
     - rustup component add clippy
@@ -37,13 +37,13 @@ task:
     - FREEBSD_CI=1 cargo test -j1
 
 task:
-  name: rust 1.54 on mac m1
+  name: rust 1.56 on mac m1
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-base:latest
   setup_script:
     - brew install curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh
-    - sh rustup.sh -y --profile=minimal --default-toolchain=1.54
+    - sh rustup.sh -y --profile=minimal --default-toolchain=1.56
     - source $HOME/.cargo/env
     - rustup --version
     - rustup component add clippy

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -65,7 +65,7 @@ jobs:
           - { os: 'ubuntu-latest', target: 'x86_64-linux-android', cross: true }
           - { os: 'ubuntu-latest', target: 'i686-linux-android', cross: true }
         toolchain:
-          - "1.54.0"  # minimum supported rust version
+          - "1.56.0"  # minimum supported rust version
           - stable
           - nightly
     steps:
@@ -136,7 +136,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - "1.54.0"  # minimum supported rust version
+          - "1.56.0"  # minimum supported rust version
           - stable
           - nightly
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.26.3
+
+ * Update minimum supported Rust version (MSRV) to `1.56`.
+
 # 0.26.2
 
  * Linux: Fix process information retrieval.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "Library to get system information such as processes, CPUs, disks,
 repository = "https://github.com/GuillaumeGomez/sysinfo"
 license = "MIT"
 readme = "README.md"
-rust-version = "1.54"
+rust-version = "1.56"
 exclude = ["/test-unknown"]
 
 categories = ["filesystem", "os", "api-bindings"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysinfo"
-version = "0.26.2"
+version = "0.26.3"
 authors = ["Guillaume Gomez <guillaume1.gomez@gmail.com>"]
 
 description = "Library to get system information such as processes, CPUs, disks, components and networks"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can still use `sysinfo` on non-supported OSes, it'll simply do nothing and a
 empty values. You can check in your program directly if an OS is supported by checking the
 [`SystemExt::IS_SUPPORTED`] constant.
 
-The minimum-supported version of `rustc` is **1.54**.
+The minimum-supported version of `rustc` is **1.56**.
 
 ## Usage
 


### PR DESCRIPTION
`once_cell` updated its MSRV so we need to update it in `sysinfo` too. Interesting discussion about it is [here](https://github.com/matklad/once_cell/issues/201).