### PR TITLE
deps: Update ntapi to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ winapi = { version = "0.3.9", features = [
   "shellapi",
   "std"
 ]}
-ntapi = "0.3"
+ntapi = "0.4"
 
 [target.'cfg(not(any(target_os = "unknown", target_arch = "wasm32")))'.dependencies]
 libc = "^0.2.112"


### PR DESCRIPTION
This notably fixes a `future-incompatibility` warning on Rust 1.64.0
