### PR TITLE
Fix a compile error on Linux if the `apple-sandbox` feature is enabled

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -27,7 +27,7 @@ pub(crate) fn to_cpath(path: &std::path::Path) -> Vec<u8> {
         ),
         feature = "multithread"
     ),
-    not(feature = "apple-sandbox"),
+    not(all(target_os = "macos", feature = "apple-sandbox")),
     not(feature = "unknown-ci")
 ))]
 pub(crate) fn into_iter<T>(val: T) -> T::Iter
@@ -51,7 +51,7 @@ where
         not(feature = "multithread")
     ),
     not(feature = "unknown-ci"),
-    not(feature = "apple-sandbox")
+    not(all(target_os = "macos", feature = "apple-sandbox"))
 ))]
 pub(crate) fn into_iter<T>(val: T) -> T::IntoIter
 where


### PR DESCRIPTION
That combination is nonsensical, of course, but [it isn't currently possible to enable features only on specific targets][cargo-1197], so any project that targets both Linux and sandboxed macOS will currently fail to build on Linux.

[cargo-1197]: https://github.com/rust-lang/cargo/issues/1197