### PR TITLE
More precise used memory calculation on Linux

### DIFF
--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -383,11 +383,7 @@ impl SystemExt for System {
     }
 
     fn used_memory(&self) -> u64 {
-        self.mem_total
-            - self.mem_free
-            - self.mem_buffers
-            - self.mem_page_cache
-            - self.mem_slab_reclaimable
+        self.mem_total - self.mem_available
     }
 
     fn total_swap(&self) -> u64 {


### PR DESCRIPTION
Use MemTotal - MemAvailable for used memory calculation when possible and fallback to the old way of estimating available memory.

Some references:
- https://bugzilla.gnome.org/show_bug.cgi?id=727543
- https://github.com/KittyKatt/screenFetch/issues/386#issuecomment-249312716
- https://github.com/htop-dev/htop/issues/281