### PR TITLE
Ignore nfs on linux

### DIFF
--- a/md_doc/disk.md
+++ b/md_doc/disk.md
@@ -1,1 +1,5 @@
 Struct containing a disk information.
+
+## Linux
+
+On linux, the [NFS](https://en.wikipedia.org/wiki/Network_File_System) file systems are ignored and the information of a mounted NFS can **no longer** be obtained via `System::refresh_disks_list`. This is due to the fact that I/O function `statvfs` used by `System::refresh_disks_list` is blocking and [may hang](https://github.com/GuillaumeGomez/sysinfo/pull/876) in some cases, such as calling `systemctl stop` to terminate the NFS service from the remote server.

--- a/src/linux/disk.rs
+++ b/src/linux/disk.rs
@@ -234,7 +234,9 @@ fn get_all_disks_inner(content: &str) -> Vec<Disk> {
                 "pstore" | // https://www.kernel.org/doc/Documentation/ABI/testing/pstore
                 "squashfs" | // squashfs is a compressed read-only file system (for snaps)
                 "rpc_pipefs" | // The pipefs pseudo file system service
-                "iso9660" // optical media
+                "iso9660" | // optical media
+                "nfs4" | // stopped nfs server causes statvfs to hang
+                "nfs" // nfs2 or nfs3
             );
 
             !(filtered ||

--- a/src/linux/disk.rs
+++ b/src/linux/disk.rs
@@ -235,7 +235,7 @@ fn get_all_disks_inner(content: &str) -> Vec<Disk> {
                 "squashfs" | // squashfs is a compressed read-only file system (for snaps)
                 "rpc_pipefs" | // The pipefs pseudo file system service
                 "iso9660" | // optical media
-                "nfs4" | // stopped nfs server causes statvfs to hang
+                "nfs4" | // calling statvfs on a mounted NFS may hang
                 "nfs" // nfs2 or nfs3
             );
 


### PR DESCRIPTION
This PR tries to fix the problem that [calling `statvfs` on nfs may hang](https://github.com/GuillaumeGomez/sysinfo/issues/842). It is done by ignoring the fs having its type named `nfs` or `nfs4`.

Avoiding to call `statvfs` on nfs will leave `total_space` and `available_space` to be zeros and can be misleading. So I decide not to include nfs in what returns from `get_all_disks_inner` 