### PR TITLE
Update documentation location for linux NFS disk handling

### DIFF
--- a/md_doc/disk.md
+++ b/md_doc/disk.md
@@ -1,5 +1,1 @@
 Struct containing a disk information.
-
-## Linux
-
-On linux, the [NFS](https://en.wikipedia.org/wiki/Network_File_System) file systems are ignored and the information of a mounted NFS can **no longer** be obtained via `System::refresh_disks_list`. This is due to the fact that I/O function `statvfs` used by `System::refresh_disks_list` is blocking and [may hang](https://github.com/GuillaumeGomez/sysinfo/pull/876) in some cases, such as calling `systemctl stop` to terminate the NFS service from the remote server.

--- a/src/linux/utils.rs
+++ b/src/linux/utils.rs
@@ -1,14 +1,14 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use std::fs::File;
-use std::io::{self, Read, Seek, SeekFrom};
+use std::io::{self, Read, Seek};
 use std::path::{Path, PathBuf};
 
 use crate::sys::system::REMAINING_FILES;
 
 pub(crate) fn get_all_data_from_file(file: &mut File, size: usize) -> io::Result<String> {
     let mut buf = String::with_capacity(size);
-    file.seek(SeekFrom::Start(0))?;
+    file.rewind()?;
     file.read_to_string(&mut buf)?;
     Ok(buf)
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -801,6 +801,16 @@ pub trait SystemExt: Sized + Debug + Default + Send + Sync {
 
     /// The disk list will be emptied then completely recomputed.
     ///
+    /// ## Linux
+    ///
+    /// ⚠️ On linux, the [NFS](https://en.wikipedia.org/wiki/Network_File_System) file
+    /// systems are ignored and the information of a mounted NFS **cannot** be obtained
+    /// via [`SystemExt::refresh_disks_list`]. This is due to the fact that I/O function
+    /// `statvfs` used by [`SystemExt::refresh_disks_list`] is blocking and
+    /// [may hang](https://github.com/GuillaumeGomez/sysinfo/pull/876) in some cases,
+    /// requiring to call `systemctl stop` to terminate the NFS service from the remote
+    /// server in some cases.
+    ///
     /// ```no_run
     /// use sysinfo::{System, SystemExt};
     ///


### PR DESCRIPTION
@kayoch1n: I moved the documentation directly on the `refresh_disks_list` method. I think it makes more sense this way.