### PR TITLE
doc: update `System::new` document to reflect not loading cpus list by default

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -536,9 +536,10 @@ pub trait SystemExt: Sized + Debug + Default + Send + Sync {
     /// ```
     const SUPPORTED_SIGNALS: &'static [Signal];
 
-    /// Creates a new [`System`] instance with nothing loaded except the cpus list. If you
-    /// want to load components, network interfaces or the disks, you'll have to use the
-    /// `refresh_*_list` methods. [`SystemExt::refresh_networks_list`] for example.
+    /// Creates a new [`System`] instance with nothing loaded. If you want to
+    /// load components, network interfaces or the disks, you'll have to use the
+    /// `refresh_*_list` methods. [`SystemExt::refresh_networks_list`] for
+    /// example.
     ///
     /// Use the [`refresh_all`] method to update its internal information (or any of the `refresh_`
     /// method).


### PR DESCRIPTION
It looks like `System::new` no longer forces refreshing of CPU list. As far as I can tell, this was done in https://github.com/GuillaumeGomez/sysinfo/commit/da1c65c1e34fa2a4bbee441a1616613423217037. 

Thanks!