### PR TITLE
Use more consistent definition for free/avail memory on Darwin

### DIFF
--- a/src/apple/system.rs
+++ b/src/apple/system.rs
@@ -220,15 +220,12 @@ impl SystemExt for System {
                 //  * used to hold data that was read speculatively from disk but
                 //  * haven't actually been used by anyone so far.
                 //  */
-                self.mem_available = self.mem_total.saturating_sub(
-                    u64::from(stat.active_count)
-                        .saturating_add(u64::from(stat.inactive_count))
-                        .saturating_add(u64::from(stat.wire_count))
-                        .saturating_add(u64::from(stat.speculative_count))
-                        .saturating_sub(u64::from(stat.purgeable_count))
-                        .saturating_mul(self.page_size_kb),
-                );
-                self.mem_free = u64::from(stat.free_count).saturating_mul(self.page_size_kb);
+                self.mem_available = u64::from(stat.free_count)
+                    .saturating_add(u64::from(stat.inactive_count))
+                    .saturating_mul(self.page_size_kb);
+                self.mem_free = u64::from(stat.free_count)
+                    .saturating_sub(u64::from(stat.speculative_count))
+                    .saturating_mul(self.page_size_kb);
             }
         }
     }


### PR DESCRIPTION
Previously, we counted wired memory as available, which is incorrect; wired memory is memory that cannot be evicted from RAM to swap [0]. Looking over the definitions of the available counters, I came up with these simplified calculations for available and free memory, which happily line up with the calculations used in a sister rust crate, `sys-info` [1].

[0]: https://developer.apple.com/library/archive/documentation/Performance/Conceptual/ManagingMemory/Articles/AboutMemory.html
[1]: https://github.com/FillZpp/sys-info-rs/blob/60ecf1470a5b7c90242f429934a3bacb6023ec4d/c/darwin.c#L134-L135