### PR TITLE
Fix null pointer dereference in parse_interface_address.

### DIFF
--- a/src/network_helper_nix.rs
+++ b/src/network_helper_nix.rs
@@ -70,6 +70,9 @@ impl From<&libc::sockaddr_dl> for MacAddr {
 #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "ios"))]
 unsafe fn parse_interface_address(ifap: *const libc::ifaddrs) -> Option<MacAddr> {
     let sock_addr = (*ifap).ifa_addr;
+    if sock_addr.is_null() {
+        return None;
+    }
     match (*sock_addr).sa_family as libc::c_int {
         libc::AF_LINK => {
             let addr = sock_addr as *const libc::sockaddr_dl;
@@ -84,6 +87,9 @@ unsafe fn parse_interface_address(ifap: *const libc::ifaddrs) -> Option<MacAddr>
     use libc::sockaddr_ll;
 
     let sock_addr = (*ifap).ifa_addr;
+    if sock_addr.is_null() {
+        return None;
+    }
     match (*sock_addr).sa_family as libc::c_int {
         libc::AF_PACKET => {
             let addr = sock_addr as *const sockaddr_ll;


### PR DESCRIPTION
I ran into a segfault in parse_interface_address, after some debugging I concluded the following.

1. The segfault was caused by ifa_addr being null.
2. ifa_addr being null is documented as a possibility in the getifaddr man page.
3. Specifically, on my linux 4.19 system this happens for "tun" interfaces which do not have a MAC address. 

This pull request makes the function return null if ifa_addr is null.
