### PR TITLE
Fix processes_by_name(_exact) lifetimes

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -934,10 +934,10 @@ pub trait SystemExt: Sized + Debug + Default + Send + Sync {
     /// }
     /// ```
     // FIXME: replace the returned type with `impl Iterator<Item = &Process>` when it's supported!
-    fn processes_by_name<'a>(
+    fn processes_by_name<'a: 'b, 'b>(
         &'a self,
-        name: &'a str,
-    ) -> Box<dyn Iterator<Item = &'a Process> + 'a> {
+        name: &'b str,
+    ) -> Box<dyn Iterator<Item = &'a Process> + 'b> {
         Box::new(
             self.processes()
                 .values()
@@ -965,10 +965,10 @@ pub trait SystemExt: Sized + Debug + Default + Send + Sync {
     /// }
     /// ```
     // FIXME: replace the returned type with `impl Iterator<Item = &Process>` when it's supported!
-    fn processes_by_exact_name<'a>(
+    fn processes_by_exact_name<'a: 'b, 'b>(
         &'a self,
-        name: &'a str,
-    ) -> Box<dyn Iterator<Item = &'a Process> + 'a> {
+        name: &'b str,
+    ) -> Box<dyn Iterator<Item = &'a Process> + 'b> {
         Box::new(
             self.processes()
                 .values()


### PR DESCRIPTION
For these two functions, the lifetime of the returned process is currently coerced into being the smaller lifetime of either the System or the &str. This works fine when the System's lifetime is shorter than the &str, but creates errors when you do things like:
```rs
let process = system.processes_by_exact_name(&String::from("str")).next().unwrap();
```
This can be fixed by changing the bounds to say that the iterator needs to live as long as the System and &str, but the returned Process reference only needs to live as long as the System.