### PR TITLE
Update use of `libc::timespec` to prepare for future libc version

### DIFF
--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -82,11 +82,8 @@ fn boot_time() -> u64 {
         }
     }
     // Either we didn't find "btime" or "/proc/stat" wasn't available for some reason...
-    let mut up = libc::timespec {
-        tv_sec: 0,
-        tv_nsec: 0,
-    };
     unsafe {
+        let mut up: libc::timespec = std::mem::zeroed();
         if libc::clock_gettime(libc::CLOCK_BOOTTIME, &mut up) == 0 {
             up.tv_sec as u64
         } else {


### PR DESCRIPTION
In a future release of the `libc` crate, `libc::timespec` will contain private padding fields on `*-linux-musl` targets and so the struct will no longer be able to be created using the literal initialization syntax.

Update the use of `libc::timespec` to create a value by calling `std::mem::zeroed()` which works with both current versions of `libc` as well as the future version which contains that change.

See also https://github.com/rust-lang/libc/pull/2088