### PR TITLE
Update use of `libc::timespec` to prepare for future libc version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.26.9
+
+ * Linux: Improve compatibility with upcoming `libc` changes for musl targets.
+
 # 0.26.8
 
  * Add `ProcessExt::session_id` method.

--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -81,11 +81,8 @@ fn boot_time() -> u64 {
         }
     }
     // Either we didn't find "btime" or "/proc/stat" wasn't available for some reason...
-    let mut up = libc::timespec {
-        tv_sec: 0,
-        tv_nsec: 0,
-    };
     unsafe {
+        let mut up: libc::timespec = std::mem::zeroed();
         if libc::clock_gettime(libc::CLOCK_BOOTTIME, &mut up) == 0 {
             up.tv_sec as u64
         } else {


### PR DESCRIPTION
In a future release of the `libc` crate, `libc::timespec` will contain private padding fields on `*-linux-musl` targets and so the struct will no longer be able to be created using the literal initialization syntax.

Update the use of `libc::timespec` to create a value by calling `std::mem::zeroed()` which works with both current versions of `libc` as well as the future version which contains that change.

(Backport of #909, I tried to match up the parent commit but I'm not sure how you want to merge this. I did validate that this fixes the issue in `0.26` as well.)