### PR TITLE
Remove cdylib crate-type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,6 @@ tempfile = "3.2"
 
 [lib]
 name = "sysinfo"
-crate_type = ["rlib", "cdylib"]
 
 [features]
 default = ["multithread"]

--- a/Makefile
+++ b/Makefile
@@ -27,12 +27,12 @@ OBJ = $(patsubst %,$(ODIR)/%,$(_OBJ))
 
 simple: $(OBJ)
 	@echo "Compiling in debug mode"
-	cargo build --features=c-interface
+	cargo rustc --features=c-interface --crate-type cdylib
 	gcc -o $@ $^ $(CFLAGS) -L$(LDIR) $(LIBS)
 
 release: $(OBJ)
 	@echo "Compiling in release mode"
-	cargo build --features=c-interface --release
+	cargo rustc --features=c-interface --release --crate-type cdylib
 	gcc -o simple $^ $(CFLAGS) -L$(LDIR-RELEASE) $(LIBS)
 
 $(ODIR)/%.o: %.c $(DEPS)


### PR DESCRIPTION
Clients who want a cdylib (including C clients) can use `cargo rustc --crate-type cdylib` to override the default crate-type.

Fixes #932, see there for more explanation.