### PR TITLE
hoist out timebase_to_ns in process interval calculation to fix CPU usage calculation

### DIFF
--- a/src/apple/macos/system.rs
+++ b/src/apple/macos/system.rs
@@ -126,8 +126,14 @@ impl SystemTimeInfo {
 
             // Now we convert the ticks to nanoseconds (if the interval is less than
             // `MINIMUM_CPU_UPDATE_INTERVAL`, we replace it with it instead):
-            (total as f64 / self.timebase_to_ns * self.clock_per_sec / cpu_count as f64)
-                .max(crate::System::MINIMUM_CPU_UPDATE_INTERVAL.as_secs_f64() * 1_000_000_000.)
+            let base_interval = total as f64 / cpu_count as f64 * self.clock_per_sec;
+            let smallest =
+                crate::System::MINIMUM_CPU_UPDATE_INTERVAL.as_secs_f64() * 1_000_000_000.0;
+            if base_interval < smallest {
+                smallest
+            } else {
+                base_interval / self.timebase_to_ns
+            }
         }
     }
 }


### PR DESCRIPTION
Seems to be one way to fix the issue highlighted in #956 due to `timebase_to_ns` differing between ARM and x86. From my experience, this has effectively no effect on x86 since `timebase_to_ns` is normally just 1 on that platform.

Tested on my M1 Macbook Pro and an x86 macOS emulator to both be close to `htop` when used to compile `process-viewer`.