### PR TITLE
rename public DiskExt method `type_` to `kind`

### DIFF
--- a/src/apple/disk.rs
+++ b/src/apple/disk.rs
@@ -4,7 +4,7 @@ use crate::sys::{
     ffi,
     utils::{self, CFReleaser},
 };
-use crate::{DiskExt, DiskType};
+use crate::{DiskExt, DiskKind};
 
 use core_foundation_sys::array::CFArrayCreate;
 use core_foundation_sys::base::kCFAllocatorDefault;
@@ -21,7 +21,7 @@ use std::ptr;
 
 #[doc = include_str!("../../md_doc/disk.md")]
 pub struct Disk {
-    pub(crate) type_: DiskType,
+    pub(crate) type_: DiskKind,
     pub(crate) name: OsString,
     pub(crate) file_system: Vec<u8>,
     pub(crate) mount_point: PathBuf,
@@ -32,7 +32,7 @@ pub struct Disk {
 }
 
 impl DiskExt for Disk {
-    fn type_(&self) -> DiskType {
+    fn kind(&self) -> DiskKind {
         self.type_
     }
 
@@ -328,9 +328,9 @@ unsafe fn new_disk(
     // so we just assume the disk type is an SSD until Rust has a way to conditionally link to
     // IOKit in more recent deployment versions.
     #[cfg(target_os = "macos")]
-    let type_ = crate::sys::inner::disk::get_disk_type(&c_disk).unwrap_or(DiskType::Unknown(-1));
+    let type_ = crate::sys::inner::disk::get_disk_type(&c_disk).unwrap_or(DiskKind::Unknown(-1));
     #[cfg(not(target_os = "macos"))]
-    let type_ = DiskType::SSD;
+    let type_ = DiskKind::SSD;
 
     // Note: Since we requested these properties from the system, we don't expect
     // these property retrievals to fail.

--- a/src/apple/macos/disk.rs
+++ b/src/apple/macos/disk.rs
@@ -6,14 +6,14 @@ use crate::sys::{
     macos::utils::IOReleaser,
     utils::CFReleaser,
 };
-use crate::DiskType;
+use crate::DiskKind;
 
 use core_foundation_sys::base::{kCFAllocatorDefault, kCFAllocatorNull};
 use core_foundation_sys::string as cfs;
 
 use std::ffi::CStr;
 
-pub(crate) fn get_disk_type(disk: &libc::statfs) -> Option<DiskType> {
+pub(crate) fn get_disk_type(disk: &libc::statfs) -> Option<DiskKind> {
     let characteristics_string = unsafe {
         CFReleaser::new(cfs::CFStringCreateWithBytesNoCopy(
             kCFAllocatorDefault,
@@ -106,8 +106,8 @@ pub(crate) fn get_disk_type(disk: &libc::statfs) -> Option<DiskType> {
                 };
 
                 if let Some(disk_type) = disk_type.and_then(|medium| match medium.as_str() {
-                    _ if medium == ffi::kIOPropertyMediumTypeSolidStateKey => Some(DiskType::SSD),
-                    _ if medium == ffi::kIOPropertyMediumTypeRotationalKey => Some(DiskType::HDD),
+                    _ if medium == ffi::kIOPropertyMediumTypeSolidStateKey => Some(DiskKind::SSD),
+                    _ if medium == ffi::kIOPropertyMediumTypeRotationalKey => Some(DiskKind::HDD),
                     _ => None,
                 }) {
                     return Some(disk_type);
@@ -116,7 +116,7 @@ pub(crate) fn get_disk_type(disk: &libc::statfs) -> Option<DiskType> {
                     //
                     // In these cases, assuming that there were _any_ properties about them registered, we fallback
                     // to `HDD` when no storage medium is provided by the device instead of `Unknown`.
-                    return Some(DiskType::HDD);
+                    return Some(DiskKind::HDD);
                 }
             }
         }

--- a/src/common.rs
+++ b/src/common.rs
@@ -497,20 +497,20 @@ impl<'a> IntoIterator for &'a Networks {
     }
 }
 
-/// Enum containing the different supported disks types.
+/// Enum containing the different supported kinds of disks.
 ///
-/// This type is returned by [`Disk::get_type`][crate::Disk#method.type].
+/// This type is returned by [`crate::DiskExt::kind`].
 ///
 /// ```no_run
 /// use sysinfo::{System, SystemExt, DiskExt};
 ///
 /// let system = System::new_all();
 /// for disk in system.disks() {
-///     println!("{:?}: {:?}", disk.name(), disk.type_());
+///     println!("{:?}: {:?}", disk.name(), disk.kind());
 /// }
 /// ```
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub enum DiskType {
+pub enum DiskKind {
     /// HDD type.
     HDD,
     /// SSD type.

--- a/src/common.rs
+++ b/src/common.rs
@@ -499,7 +499,7 @@ impl<'a> IntoIterator for &'a Networks {
 
 /// Enum containing the different supported kinds of disks.
 ///
-/// This type is returned by [`crate::DiskExt::kind`].
+/// This type is returned by [`DiskExt::kind`](`crate::DiskExt::kind`).
 ///
 /// ```no_run
 /// use sysinfo::{System, SystemExt, DiskExt};

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -47,7 +47,7 @@ impl fmt::Debug for Disk {
                 .iter()
                 .map(|c| *c as char)
                 .collect::<Vec<_>>(),
-            self.type_(),
+            self.kind(),
             if self.is_removable() { "yes" } else { "no" },
             self.mount_point(),
             self.available_space(),

--- a/src/freebsd/disk.rs
+++ b/src/freebsd/disk.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::{DiskExt, DiskType};
+use crate::{DiskExt, DiskKind};
 
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
@@ -19,8 +19,8 @@ pub struct Disk {
 }
 
 impl DiskExt for Disk {
-    fn type_(&self) -> DiskType {
-        DiskType::Unknown(-1)
+    fn kind(&self) -> DiskKind {
+        DiskKind::Unknown(-1)
     }
 
     fn name(&self) -> &OsStr {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ cfg_if::cfg_if! {
 }
 
 pub use common::{
-    get_current_pid, CpuRefreshKind, DiskType, DiskUsage, Gid, LoadAvg, MacAddr, NetworksIter, Pid,
+    get_current_pid, CpuRefreshKind, DiskKind, DiskUsage, Gid, LoadAvg, MacAddr, NetworksIter, Pid,
     PidExt, ProcessRefreshKind, ProcessStatus, RefreshKind, Signal, Uid, User,
 };
 pub use sys::{Component, Cpu, Disk, NetworkData, Networks, Process, System};

--- a/src/linux/disk.rs
+++ b/src/linux/disk.rs
@@ -1,7 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use crate::sys::utils::{get_all_data, to_cpath};
-use crate::{DiskExt, DiskType};
+use crate::{DiskExt, DiskKind};
 
 use libc::statvfs;
 use std::ffi::{OsStr, OsString};
@@ -19,7 +19,7 @@ macro_rules! cast {
 #[doc = include_str!("../../md_doc/disk.md")]
 #[derive(PartialEq, Eq)]
 pub struct Disk {
-    type_: DiskType,
+    type_: DiskKind,
     device_name: OsString,
     file_system: Vec<u8>,
     mount_point: PathBuf,
@@ -29,7 +29,7 @@ pub struct Disk {
 }
 
 impl DiskExt for Disk {
-    fn type_(&self) -> DiskType {
+    fn kind(&self) -> DiskKind {
         self.type_
     }
 
@@ -111,7 +111,7 @@ fn new_disk(
 }
 
 #[allow(clippy::manual_range_contains)]
-fn find_type_for_device_name(device_name: &OsStr) -> DiskType {
+fn find_type_for_device_name(device_name: &OsStr) -> DiskKind {
     // The format of devices are as follows:
     //  - device_name is symbolic link in the case of /dev/mapper/
     //     and /dev/root, and the target is corresponding device under
@@ -171,13 +171,13 @@ fn find_type_for_device_name(device_name: &OsStr) -> DiskType {
         .ok()
     {
         // The disk is marked as rotational so it's a HDD.
-        Some(1) => DiskType::HDD,
+        Some(1) => DiskKind::HDD,
         // The disk is marked as non-rotational so it's very likely a SSD.
-        Some(0) => DiskType::SSD,
+        Some(0) => DiskKind::SSD,
         // Normally it shouldn't happen but welcome to the wonderful world of IT! :D
-        Some(x) => DiskType::Unknown(x),
+        Some(x) => DiskKind::Unknown(x),
         // The information isn't available...
-        None => DiskType::Unknown(-1),
+        None => DiskKind::Unknown(-1),
     }
 }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -2,7 +2,7 @@
 
 use crate::common::PidExt;
 use crate::{
-    ComponentExt, CpuExt, DiskExt, DiskType, DiskUsage, MacAddr, NetworkExt, NetworksExt,
+    ComponentExt, CpuExt, DiskExt, DiskKind, DiskUsage, MacAddr, NetworkExt, NetworksExt,
     ProcessExt, ProcessStatus, Signal, SystemExt, UserExt,
 };
 use serde::{ser::SerializeStruct, Serialize, Serializer};
@@ -15,7 +15,7 @@ impl Serialize for crate::Disk {
     {
         let mut state = serializer.serialize_struct("Disk", 7)?;
 
-        state.serialize_field("DiskType", &self.type_())?;
+        state.serialize_field("DiskKind", &self.kind())?;
         if let Some(s) = self.name().to_str() {
             state.serialize_field("name", s)?;
         }
@@ -272,21 +272,21 @@ impl Serialize for crate::User {
     }
 }
 
-impl Serialize for DiskType {
+impl Serialize for DiskKind {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         let (index, variant, maybe_value) = match *self {
-            DiskType::HDD => (0, "HDD", None),
-            DiskType::SSD => (1, "SSD", None),
-            DiskType::Unknown(ref s) => (2, "Unknown", Some(s)),
+            DiskKind::HDD => (0, "HDD", None),
+            DiskKind::SSD => (1, "SSD", None),
+            DiskKind::Unknown(ref s) => (2, "Unknown", Some(s)),
         };
 
         if let Some(ref value) = maybe_value {
-            serializer.serialize_newtype_variant("DiskType", index, variant, value)
+            serializer.serialize_newtype_variant("DiskKind", index, variant, value)
         } else {
-            serializer.serialize_unit_variant("DiskType", index, variant)
+            serializer.serialize_unit_variant("DiskKind", index, variant)
         }
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -5,7 +5,7 @@ use crate::{
     sys::{Component, Cpu, Disk, Networks, Process},
 };
 use crate::{
-    CpuRefreshKind, DiskType, DiskUsage, LoadAvg, NetworksIter, Pid, ProcessRefreshKind,
+    CpuRefreshKind, DiskKind, DiskUsage, LoadAvg, NetworksIter, Pid, ProcessRefreshKind,
     ProcessStatus, RefreshKind, Signal, User,
 };
 
@@ -22,21 +22,21 @@ use std::time::Duration;
 ///
 /// let s = System::new();
 /// for disk in s.disks() {
-///     println!("{:?}: {:?}", disk.name(), disk.type_());
+///     println!("{:?}: {:?}", disk.name(), disk.kind());
 /// }
 /// ```
 pub trait DiskExt: Debug {
-    /// Returns the disk type.
+    /// Returns the kind of disk.
     ///
     /// ```no_run
     /// use sysinfo::{DiskExt, System, SystemExt};
     ///
     /// let s = System::new();
     /// for disk in s.disks() {
-    ///     println!("{:?}", disk.type_());
+    ///     println!("{:?}", disk.kind());
     /// }
     /// ```
-    fn type_(&self) -> DiskType;
+    fn kind(&self) -> DiskKind;
 
     /// Returns the disk name.
     ///

--- a/src/unknown/disk.rs
+++ b/src/unknown/disk.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::{DiskExt, DiskType};
+use crate::{DiskExt, DiskKind};
 
 use std::{ffi::OsStr, path::Path};
 
@@ -8,7 +8,7 @@ use std::{ffi::OsStr, path::Path};
 pub struct Disk {}
 
 impl DiskExt for Disk {
-    fn type_(&self) -> DiskType {
+    fn kind(&self) -> DiskKind {
         unreachable!()
     }
 

--- a/src/windows/disk.rs
+++ b/src/windows/disk.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::{DiskExt, DiskType};
+use crate::{DiskExt, DiskKind};
 
 use std::ffi::{OsStr, OsString};
 use std::mem::size_of;
@@ -23,7 +23,7 @@ use winapi::um::winnt::{BOOLEAN, FILE_SHARE_READ, FILE_SHARE_WRITE, HANDLE, ULAR
 
 #[doc = include_str!("../../md_doc/disk.md")]
 pub struct Disk {
-    type_: DiskType,
+    type_: DiskKind,
     name: OsString,
     file_system: Vec<u8>,
     mount_point: Vec<u16>,
@@ -34,7 +34,7 @@ pub struct Disk {
 }
 
 impl DiskExt for Disk {
-    fn type_(&self) -> DiskType {
+    fn kind(&self) -> DiskKind {
         self.type_
     }
 
@@ -231,13 +231,13 @@ pub(crate) unsafe fn get_disks() -> Vec<Disk> {
             ) == 0
                 || dw_size != size_of::<DEVICE_SEEK_PENALTY_DESCRIPTOR>() as DWORD
             {
-                DiskType::Unknown(-1)
+                DiskKind::Unknown(-1)
             } else {
                 let is_ssd = result.IncursSeekPenalty == 0;
                 if is_ssd {
-                    DiskType::SSD
+                    DiskKind::SSD
                 } else {
-                    DiskType::HDD
+                    DiskKind::HDD
                 }
             };
             Some(Disk {


### PR DESCRIPTION
A cosmetic change, but a breaking one also.

The underscore at the end of `type_` has bothered for some time now. Maybe using a proximate synonym could be better?