### PR TITLE
Add Process::{effective_user_id, effective_group_id} + user_id & group_id to return real IDs

### DIFF
--- a/src/apple/app_store/process.rs
+++ b/src/apple/app_store/process.rs
@@ -76,7 +76,15 @@ impl ProcessExt for Process {
         None
     }
 
+    fn effective_user_id(&self) -> Option<&Uid> {
+        None
+    }
+
     fn group_id(&self) -> Option<Gid> {
+        None
+    }
+
+    fn effective_group_id(&self) -> Option<Gid> {
         None
     }
 

--- a/src/apple/macos/process.rs
+++ b/src/apple/macos/process.rs
@@ -526,8 +526,8 @@ unsafe fn create_new_process(
     p.memory = task_info.pti_resident_size;
     p.virtual_memory = task_info.pti_virtual_size;
 
-    p.user_id = Some(Uid(info.pbi_uid));
-    p.group_id = Some(Gid(info.pbi_gid));
+    p.user_id = Some(Uid(info.pbi_ruid));
+    p.group_id = Some(Gid(info.pbi_rgid));
     p.process_status = ProcessStatus::from(info.pbi_status);
     if refresh_kind.disk_usage() {
         update_proc_disk_activity(&mut p);

--- a/src/apple/macos/process.rs
+++ b/src/apple/macos/process.rs
@@ -33,7 +33,9 @@ pub struct Process {
     pub(crate) updated: bool,
     cpu_usage: f32,
     user_id: Option<Uid>,
+    effective_user_id: Option<Uid>,
     group_id: Option<Gid>,
+    effective_group_id: Option<Gid>,
     pub(crate) process_status: ProcessStatus,
     /// Status of process (running, stopped, waiting, etc). `None` means `sysinfo` doesn't have
     /// enough rights to get this information.
@@ -66,7 +68,9 @@ impl Process {
             start_time: 0,
             run_time: 0,
             user_id: None,
+            effective_user_id: None,
             group_id: None,
+            effective_group_id: None,
             process_status: ProcessStatus::Unknown(0),
             status: None,
             old_read_bytes: 0,
@@ -95,7 +99,9 @@ impl Process {
             start_time,
             run_time,
             user_id: None,
+            effective_user_id: None,
             group_id: None,
+            effective_group_id: None,
             process_status: ProcessStatus::Unknown(0),
             status: None,
             old_read_bytes: 0,
@@ -181,8 +187,16 @@ impl ProcessExt for Process {
         self.user_id.as_ref()
     }
 
+    fn effective_user_id(&self) -> Option<&Uid> {
+        self.effective_user_id.as_ref()
+    }
+
     fn group_id(&self) -> Option<Gid> {
         self.group_id
+    }
+
+    fn effective_group_id(&self) -> Option<Gid> {
+        self.effective_group_id
     }
 
     fn wait(&self) {
@@ -527,7 +541,9 @@ unsafe fn create_new_process(
     p.virtual_memory = task_info.pti_virtual_size;
 
     p.user_id = Some(Uid(info.pbi_ruid));
+    p.effective_user_id = Some(Uid(info.pbi_uid));
     p.group_id = Some(Gid(info.pbi_rgid));
+    p.effective_group_id = Some(Gid(info.pbi_gid));
     p.process_status = ProcessStatus::from(info.pbi_status);
     if refresh_kind.disk_usage() {
         update_proc_disk_activity(&mut p);

--- a/src/freebsd/process.rs
+++ b/src/freebsd/process.rs
@@ -58,7 +58,9 @@ pub struct Process {
     run_time: u64,
     pub(crate) status: ProcessStatus,
     user_id: Uid,
+    effective_user_id: Uid,
     group_id: Gid,
+    effective_group_id: Gid,
     read_bytes: u64,
     old_read_bytes: u64,
     written_bytes: u64,
@@ -140,8 +142,16 @@ impl ProcessExt for Process {
         Some(&self.user_id)
     }
 
+    fn effective_user_id(&self) -> Option<&Uid> {
+        Some(&self.effective_user_id)
+    }
+
     fn group_id(&self) -> Option<Gid> {
         Some(self.group_id)
+    }
+
+    fn effective_group_id(&self) -> Option<Gid> {
+        Some(self.effective_group_id)
     }
 
     fn wait(&self) {
@@ -259,7 +269,9 @@ pub(crate) unsafe fn get_process_data(
         pid: Pid(kproc.ki_pid),
         parent,
         user_id: Uid(kproc.ki_ruid),
+        effective_user_id: Uid(kproc.ki_uid),
         group_id: Gid(kproc.ki_rgid),
+        effective_group_id: Gid(kproc.ki_svgid),
         start_time,
         run_time: now.saturating_sub(start_time),
         cpu_usage,

--- a/src/linux/process.rs
+++ b/src/linux/process.rs
@@ -5,7 +5,6 @@ use std::collections::HashMap;
 use std::fmt;
 use std::fs::{self, File};
 use std::io::Read;
-use std::mem::MaybeUninit;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
@@ -644,20 +643,6 @@ fn copy_from_file(entry: &Path) -> Vec<String> {
 }
 
 fn get_uid_and_gid(file_path: &Path) -> Option<(uid_t, gid_t)> {
-    use std::os::unix::ffi::OsStrExt;
-
-    unsafe {
-        let mut sstat: MaybeUninit<libc::stat> = MaybeUninit::uninit();
-
-        let mut file_path: Vec<u8> = file_path.as_os_str().as_bytes().to_vec();
-        file_path.push(0);
-        if libc::stat(file_path.as_ptr() as *const _, sstat.as_mut_ptr()) == 0 {
-            let sstat = sstat.assume_init();
-
-            return Some((sstat.st_uid, sstat.st_gid));
-        }
-    }
-
     let status_data = get_all_data(file_path, 16_385).ok()?;
 
     // We're only interested in the lines starting with Uid: and Gid:

--- a/src/linux/process.rs
+++ b/src/linux/process.rs
@@ -661,12 +661,12 @@ fn get_uid_and_gid(file_path: &Path) -> Option<(uid_t, gid_t)> {
     let status_data = get_all_data(file_path, 16_385).ok()?;
 
     // We're only interested in the lines starting with Uid: and Gid:
-    // here. From these lines, we're looking at the second entry to get
-    // the effective u/gid.
+    // here. From these lines, we're looking at the first entry to get
+    // the real u/gid.
 
     let f = |h: &str, n: &str| -> Option<uid_t> {
         if h.starts_with(n) {
-            h.split_whitespace().nth(2).unwrap_or("0").parse().ok()
+            h.split_whitespace().nth(1).unwrap_or("0").parse().ok()
         } else {
             None
         }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -403,6 +403,26 @@ pub trait ProcessExt: Debug {
     /// ```
     fn user_id(&self) -> Option<&Uid>;
 
+    /// Returns the user ID of the effective owner of this process or `None` if this information
+    /// couldn't be retrieved. If you want to get the [`User`] from it, take a look at
+    /// [`SystemExt::get_user_by_id`].
+    ///
+    /// If you run something with `sudo`, the real user ID of the launched process will be the ID of
+    /// the user you are logged in as but effective user ID will be `0` (i-e root).
+    ///
+    /// ⚠️ It always returns `None` on Windows.
+    ///
+    /// ```no_run
+    /// use sysinfo::{Pid, ProcessExt, System, SystemExt};
+    ///
+    /// let mut s = System::new_all();
+    ///
+    /// if let Some(process) = s.process(Pid::from(1337)) {
+    ///     eprintln!("User id for process 1337: {:?}", process.effective_user_id());
+    /// }
+    /// ```
+    fn effective_user_id(&self) -> Option<&Uid>;
+
     /// Returns the process group ID of the process.
     ///
     /// ⚠️ It always returns `None` on Windows.
@@ -417,6 +437,24 @@ pub trait ProcessExt: Debug {
     /// }
     /// ```
     fn group_id(&self) -> Option<Gid>;
+
+    /// Returns the effective group ID of the process.
+    ///
+    /// If you run something with `sudo`, the real group ID of the launched process will be the
+    /// primary group ID you are logged in as but effective group ID will be `0` (i-e root).
+    ///
+    /// ⚠️ It always returns `None` on Windows.
+    ///
+    /// ```no_run
+    /// use sysinfo::{Pid, ProcessExt, System, SystemExt};
+    ///
+    /// let mut s = System::new_all();
+    ///
+    /// if let Some(process) = s.process(Pid::from(1337)) {
+    ///     eprintln!("User id for process 1337: {:?}", process.effective_group_id());
+    /// }
+    /// ```
+    fn effective_group_id(&self) -> Option<Gid>;
 
     /// Wait for process termination.
     ///

--- a/src/unknown/process.rs
+++ b/src/unknown/process.rs
@@ -86,7 +86,15 @@ impl ProcessExt for Process {
         None
     }
 
+    fn effective_user_id(&self) -> Option<&Uid> {
+        None
+    }
+
     fn group_id(&self) -> Option<Gid> {
+        None
+    }
+
+    fn effective_group_id(&self) -> Option<Gid> {
         None
     }
 

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -525,7 +525,15 @@ impl ProcessExt for Process {
         self.user_id.as_ref()
     }
 
+    fn effective_user_id(&self) -> Option<&Uid> {
+        None
+    }
+
     fn group_id(&self) -> Option<Gid> {
+        None
+    }
+
+    fn effective_group_id(&self) -> Option<Gid> {
         None
     }
 


### PR DESCRIPTION
Add API to query effective IDs of a process and make `Process::{user_id, group_id}` return real IDs on Linux and Apple, so the behavior is as expected and consistent with the FreeBSD implementation.

Fixes #970.

---

Zeeshan Ali Khan on behalf of MBition GmbH.

[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md#mbition-gmbh).