### PR TITLE
Fix: windows process name in 0.29.6 are broken

### DIFF
--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -344,9 +344,12 @@ unsafe fn get_process_name(pid: Pid) -> Option<String> {
         // The length is in bytes, not the length of string
         info.ImageName.Length as usize / std::mem::size_of::<u16>(),
     );
-    let name = String::from_utf16_lossy(s);
+    let os_str = OsString::from_wide(s);
+    let name = Path::new(&os_str)
+        .file_name()
+        .map(|s| s.to_string_lossy().to_string());
     LocalFree(info.ImageName.Buffer as _);
-    Some(name)
+    name
 }
 
 unsafe fn get_exe(process_handler: &HandleWrapper) -> PathBuf {

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -43,7 +43,7 @@ use winapi::um::errhandlingapi::GetLastError;
 use winapi::um::handleapi::CloseHandle;
 use winapi::um::heapapi::{GetProcessHeap, HeapAlloc, HeapFree};
 use winapi::um::memoryapi::{ReadProcessMemory, VirtualQueryEx};
-use winapi::um::minwinbase::LMEM_FIXED;
+use winapi::um::minwinbase::{LMEM_FIXED, LMEM_ZEROINIT};
 use winapi::um::processthreadsapi::{
     GetProcessTimes, GetSystemTimes, OpenProcess, OpenProcessToken, ProcessIdToSessionId,
 };
@@ -293,7 +293,10 @@ unsafe fn get_process_name(pid: Pid) -> Option<String> {
     };
 
     for i in 0.. {
-        info.ImageName.Buffer = LocalAlloc(LMEM_FIXED, info.ImageName.MaximumLength as _) as *mut _;
+        info.ImageName.Buffer = LocalAlloc(
+            LMEM_FIXED | LMEM_ZEROINIT,
+            info.ImageName.MaximumLength as _,
+        ) as *mut _;
         if info.ImageName.Buffer.is_null() {
             sysinfo_debug!("Couldn't get process infos: LocalAlloc failed");
             return None;

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -339,7 +339,11 @@ unsafe fn get_process_name(pid: Pid) -> Option<String> {
         return None;
     }
 
-    let s = std::slice::from_raw_parts(info.ImageName.Buffer, info.ImageName.Length as _);
+    let s = std::slice::from_raw_parts(
+        info.ImageName.Buffer,
+        // The length is in bytes, not the length of string
+        info.ImageName.Length as usize / std::mem::size_of::<u16>(),
+    );
     let name = String::from_utf16_lossy(s);
     LocalFree(info.ImageName.Buffer as _);
     Some(name)


### PR DESCRIPTION
- fix: zero init image name memory to avoid leftoverdata interfering
- fix: ImageName.Length is in bytes, we want the size in wide-chars

Use the following:

```rust
use std::process::Command;

use sysinfo::{Pid, PidExt, ProcessExt, System, SystemExt};

fn main() {
    let mut ping_process = Command::new(r"C:\Windows\System32\PiNg.eXE")
        .args(["-n", "50", "127.0.0.1"])
        .stdout(std::process::Stdio::null())
        .spawn()
        .unwrap();
    let ping_id = ping_process.id();

    // For some reason, on my VM, retrieving the process too quickly will lead to
    // "process.name()" being empty. To avoid this, retry until the process has a name.
    loop {
        let mut system = System::default();
        system.refresh_process_specifics(Pid::from_u32(ping_id), Default::default());
        let proc = system.process(Pid::from_u32(ping_id)).unwrap();
        if !proc.name().is_empty() {
            println!("ping.exe: {}", proc.name());
            break;
        }
    }

    let _ = ping_process.kill();
}
```

Then run it:

## Without the fix

```
C:\Users\alexis>pg2.exe
ping.exe: \Device\HarddiskVolume4\Windows\System32\PING.EXE   恀Ȁ        Ā †   衬疼䒏 뻐Ȏ ŐȎ     衭疽䒄က奰Ȏ 夐Ȏ 嚠
```

## With the fix

```
C:\Users\alexis>pg2.exe
ping.exe: \Device\HarddiskVolume4\Windows\System32\PING.EXE
```
