### PR TITLE
Fix cgroups always being ignored when refreshing memory

### DIFF
--- a/src/linux/system.rs
+++ b/src/linux/system.rs
@@ -597,7 +597,7 @@ impl SystemExt for System {
 fn read_u64(filename: &str) -> Option<u64> {
     get_all_data(filename, 16_635)
         .ok()
-        .and_then(|d| u64::from_str(&d).ok())
+        .and_then(|d| u64::from_str(d.trim()).ok())
 }
 
 fn read_table<F>(filename: &str, colsep: char, mut f: F)


### PR DESCRIPTION
This solves the newline issue I described in #954, though the disk issue probably remains (and the memory issue might also remain specifically for LXC, I don't know how it sets up its cgroups).