### PR TITLE
serde.rs: fix serialize_struct field counts

### DIFF
--- a/src/serde.rs
+++ b/src/serde.rs
@@ -73,7 +73,7 @@ impl Serialize for crate::Cpu {
     where
         S: Serializer,
     {
-        let mut state = serializer.serialize_struct("Cpu", 1)?;
+        let mut state = serializer.serialize_struct("Cpu", 5)?;
 
         state.serialize_field("cpu_usage", &self.cpu_usage())?;
         state.serialize_field("name", &self.name())?;
@@ -90,7 +90,7 @@ impl serde::Serialize for crate::System {
     where
         S: serde::Serializer,
     {
-        let mut state = serializer.serialize_struct("System", 27)?;
+        let mut state = serializer.serialize_struct("System", 23)?;
 
         state.serialize_field("IS_SUPPORTED", &<Self as SystemExt>::IS_SUPPORTED)?;
         state.serialize_field("SUPPORTED_SIGNALS", <Self as SystemExt>::SUPPORTED_SIGNALS)?;
@@ -226,7 +226,7 @@ impl Serialize for crate::NetworkData {
     where
         S: Serializer,
     {
-        let mut state = serializer.serialize_struct("NetworkData", 1)?;
+        let mut state = serializer.serialize_struct("NetworkData", 13)?;
 
         state.serialize_field("received", &self.received())?;
         state.serialize_field("total_received", &self.total_received())?;
@@ -273,7 +273,7 @@ impl Serialize for crate::User {
     where
         S: Serializer,
     {
-        let mut state = serializer.serialize_struct("User", 1)?;
+        let mut state = serializer.serialize_struct("User", 4)?;
 
         state.serialize_field("id", &self.id().to_string())?;
 
@@ -292,7 +292,7 @@ impl Serialize for crate::Group {
     where
         S: Serializer,
     {
-        let mut state = serializer.serialize_struct("Group", 1)?;
+        let mut state = serializer.serialize_struct("Group", 2)?;
 
         state.serialize_field("id", &self.id().to_string())?;
         state.serialize_field("name", &self.name())?;


### PR DESCRIPTION
Some of the serializers used incorrect (too small) field counts when serializing structures. This commit/PR fixes that.

This is not an issue when using JSON serializer which doesn't need the length field to operate correctly [0] but it could be an issue if a different serializer would be used in the future which would rely on the length field [1].

[0] https://github.com/serde-rs/json/blob/b6e113f2036c52e994ca805e530ee4ffae791f71/src/value/ser.rs#L262-L277
[1] https://grep.app/search?q=fn%20serialize_map%28self%2C%20len%3A%20Option%3Cusize%3E%29%20-%3E%20Result%3CSelf%3A%3ASerial