### PR TITLE
Windows: Fix invalid use of NULL pointer

### DIFF
--- a/src/windows/utils.rs
+++ b/src/windows/utils.rs
@@ -24,8 +24,11 @@ pub(crate) fn get_now() -> u64 {
 }
 
 pub(crate) unsafe fn to_str(p: LPWSTR) -> String {
-    let mut i = 0;
+    if p.is_null() {
+        return String::new();
+    }
 
+    let mut i = 0;
     loop {
         let c = *p.offset(i);
         if c == 0 {


### PR DESCRIPTION
As nicely pointed out [here](https://github.com/GuillaumeGomez/sysinfo/pull/950#issuecomment-1732376879), `sysinfo` was using pointers without checking if they were NULL first.

cc @poliorcetics  