### PR TITLE
Allow to only refresh CPU info in example and correctly parse /proc/cpuinfo file

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -66,6 +66,10 @@ fn print_help() {
     );
     writeln!(
         &mut io::stdout(),
+        "refresh_cpu        : reloads CPU information"
+    );
+    writeln!(
+        &mut io::stdout(),
         "refresh_disks      : reloads disks information"
     );
     writeln!(
@@ -175,6 +179,11 @@ fn interpret_input(
             components.refresh_list();
             writeln!(&mut io::stdout(), "Done.");
         }
+        "refresh_cpu" => {
+            writeln!(&mut io::stdout(), "Refreshing CPUs...");
+            sys.refresh_cpu();
+            writeln!(&mut io::stdout(), "Done.");
+        }
         "signals" => {
             let mut nb = 1i32;
 
@@ -198,8 +207,8 @@ fn interpret_input(
                 "total CPU usage: {}%",
                 sys.global_cpu_info().cpu_usage()
             );
-            for proc_ in sys.cpus() {
-                writeln!(&mut io::stdout(), "{proc_:?}");
+            for cpu in sys.cpus() {
+                writeln!(&mut io::stdout(), "{cpu:?}");
             }
         }
         "memory" => {
@@ -242,11 +251,14 @@ fn interpret_input(
             }
         }
         "frequency" => {
-            writeln!(
-                &mut io::stdout(),
-                "{} MHz",
-                sys.global_cpu_info().frequency()
-            );
+            for cpu in sys.cpus() {
+                writeln!(
+                    &mut io::stdout(),
+                    "[{}] {} MHz",
+                    cpu.name(),
+                    cpu.frequency(),
+                );
+            }
         }
         "vendor_id" => {
             writeln!(

--- a/src/unix/linux/cpu.rs
+++ b/src/unix/linux/cpu.rs
@@ -737,8 +737,6 @@ pub(crate) fn get_vendor_id_and_brand() -> HashMap<usize, (String, String)> {
     #[inline]
     fn is_new_processor(line: &str) -> bool {
         line.starts_with("processor\t")
-            || line.starts_with("processor ")
-            || line.starts_with("processor:")
     }
 
     #[derive(Default)]
@@ -790,7 +788,11 @@ pub(crate) fn get_vendor_id_and_brand() -> HashMap<usize, (String, String)> {
     let mut lines = s.split('\n');
     while let Some(line) = lines.next() {
         if is_new_processor(line) {
-            let index = match line.split(':').nth(1).and_then(|i| i.parse::<usize>().ok()) {
+            let index = match line
+                .split(':')
+                .nth(1)
+                .and_then(|i| i.trim().parse::<usize>().ok())
+            {
                 Some(index) => index,
                 None => {
                     sysinfo_debug!("Couldn't get processor ID from {line:?}, ignoring this core");

--- a/tests/cpu.rs
+++ b/tests/cpu.rs
@@ -6,17 +6,26 @@
 fn test_cpu() {
     use sysinfo::{CpuExt, SystemExt};
 
-    if sysinfo::System::IS_SUPPORTED {
-        let mut s = sysinfo::System::new();
-        assert!(s.cpus().is_empty());
-        s.refresh_cpu();
-        assert!(!s.cpus().is_empty());
+    let mut s = sysinfo::System::new();
+    assert!(s.cpus().is_empty());
 
-        let s = sysinfo::System::new_all();
-        assert!(!s.cpus().is_empty());
-
-        assert!(!s.cpus()[0].brand().chars().any(|c| c == '\0'));
+    if !sysinfo::System::IS_SUPPORTED {
+        return;
     }
+
+    s.refresh_cpu();
+    assert!(!s.cpus().is_empty());
+
+    let s = sysinfo::System::new_all();
+    assert!(!s.cpus().is_empty());
+
+    assert!(!s.cpus()[0].brand().chars().any(|c| c == '\0'));
+
+    if !cfg!(target_os = "freebsd") {
+        // This information is currently not retrieved on freebsd...
+        assert!(s.cpus().iter().any(|c| !c.brand().is_empty()));
+    }
+    assert!(s.cpus().iter().any(|c| !c.vendor_id().is_empty()));
 }
 
 #[test]


### PR DESCRIPTION
Follow-up of #1075 which wrongly updated this information.