### PR TITLE
fix: refresh process memory on Windows on first update

### DIFF
--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -489,6 +489,7 @@ impl ProcessInner {
         if refresh_kind.disk_usage() {
             update_disk_usage(self);
         }
+        update_memory(self);
         self.run_time = now.saturating_sub(self.start_time());
         self.updated = true;
     }

--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -3,7 +3,7 @@
 use crate::{CpuRefreshKind, LoadAvg, Pid, ProcessRefreshKind};
 
 use crate::sys::cpu::*;
-use crate::sys::process::{get_start_time, update_memory};
+use crate::sys::process::get_start_time;
 use crate::sys::tools::*;
 use crate::sys::utils::{get_now, get_reg_string_value, get_reg_value_u32};
 use crate::{Process, ProcessInner};
@@ -473,7 +473,6 @@ fn refresh_existing_process(
     } else {
         return Some(false);
     }
-    update_memory(proc_);
     proc_.update(refresh_kind, nb_cpus, now);
     proc_.updated = false;
     Some(true)

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -659,3 +659,23 @@ fn test_process_creds() {
         true
     }));
 }
+
+// Regression test for <https://github.com/GuillaumeGomez/sysinfo/issues/1084>
+#[test]
+fn test_process_memory_refresh() {
+    if !sysinfo::IS_SUPPORTED || cfg!(feature = "apple-sandbox") {
+        return;
+    }
+
+    // Ensure the process memory is available on the first refresh.
+    let mut s = sysinfo::System::new();
+
+    // Refresh our own process
+    let pid = Pid::from_u32(std::process::id());
+    s.refresh_process_specifics(pid, sysinfo::ProcessRefreshKind::new());
+
+    let proc = s.process(pid).unwrap();
+    // Check that the memory values re not empty.
+    assert!(proc.memory() > 0);
+    assert!(proc.virtual_memory() > 0);
+}


### PR DESCRIPTION
The first time a process is refreshed on windows, its memory values are not fetched. This is only done on a second refresh.

Fix this my moving the refresh memory into the process update function so that it is called
everytime the process is updated.

Fixes #1084 