### PR TITLE
Add missing warning for Windows support for `System::load_average`

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -572,6 +572,8 @@ impl System {
 
     /// Returns the system load average value.
     ///
+    /// ⚠️ This is currently not working on **Windows**.
+    ///
     /// ```no_run
     /// use sysinfo::System;
     ///


### PR DESCRIPTION
Fixes #1087.