### PR TITLE
Change `Disk::file_system()` to return `&OsStr`

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1922,7 +1922,7 @@ impl Disk {
     ///     println!("[{:?}] {:?}", disk.name(), disk.file_system());
     /// }
     /// ```
-    pub fn file_system(&self) -> &[u8] {
+    pub fn file_system(&self) -> &OsStr {
         self.inner.file_system()
     }
 

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -39,10 +39,7 @@ impl fmt::Debug for Disk {
             fmt,
             "Disk({:?})[FS: {:?}][Type: {:?}][removable: {}] mounted on {:?}: {}/{} B",
             self.name(),
-            self.file_system()
-                .iter()
-                .map(|c| *c as char)
-                .collect::<Vec<_>>(),
+            self.file_system(),
             self.kind(),
             if self.is_removable() { "yes" } else { "no" },
             self.mount_point(),

--- a/src/unix/linux/disk.rs
+++ b/src/unix/linux/disk.rs
@@ -19,7 +19,7 @@ macro_rules! cast {
 pub(crate) struct DiskInner {
     type_: DiskKind,
     device_name: OsString,
-    file_system: Vec<u8>,
+    file_system: OsString,
     mount_point: PathBuf,
     total_space: u64,
     available_space: u64,
@@ -35,7 +35,7 @@ impl DiskInner {
         &self.device_name
     }
 
-    pub(crate) fn file_system(&self) -> &[u8] {
+    pub(crate) fn file_system(&self) -> &OsStr {
         &self.file_system
     }
 
@@ -96,7 +96,7 @@ impl crate::DisksInner {
 fn new_disk(
     device_name: &OsStr,
     mount_point: &Path,
-    file_system: &[u8],
+    file_system: &OsStr,
     removable_entries: &[PathBuf],
 ) -> Option<Disk> {
     let mount_point_cpath = to_cpath(mount_point);
@@ -273,7 +273,7 @@ fn get_all_list(container: &mut Vec<Disk>, content: &str) {
             new_disk(
                 fs_spec.as_ref(),
                 Path::new(&fs_file),
-                fs_vfstype.as_bytes(),
+                fs_vfstype.as_ref(),
                 &removable_entries,
             )
         })

--- a/src/unknown/disk.rs
+++ b/src/unknown/disk.rs
@@ -15,8 +15,8 @@ impl DiskInner {
         unreachable!()
     }
 
-    pub(crate) fn file_system(&self) -> &[u8] {
-        &[]
+    pub(crate) fn file_system(&self) -> &OsStr {
+        Default::default()
     }
 
     pub(crate) fn mount_point(&self) -> &Path {


### PR DESCRIPTION
As discussed in #1105, this PR changes the public interface `Disk::file_system()` to return an `&OsStr` instead of a `&[u8]`.

(I've decided to move the MSRV change into a separate PR #1108 because there is really no connection between these two PRs)