### PR TITLE
Move cgroup limits computation into its own function to split it out from the "normal" memory values

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -458,6 +458,9 @@ impl System {
     /// let s = System::new_all();
     /// println!("{} bytes", s.total_memory());
     /// ```
+    ///
+    /// On Linux, if you want to see this information with the limit of your cgroup, take a look
+    /// at [`cgroup_limits`](System::cgroup_limits).
     pub fn total_memory(&self) -> u64 {
         self.inner.total_memory()
     }
@@ -544,6 +547,26 @@ impl System {
     /// ```
     pub fn used_swap(&self) -> u64 {
         self.inner.used_swap()
+    }
+
+    /// Retrieves the limits for the current cgroup (if any), otherwise it returns `None`.
+    ///
+    /// This information is computed every time the method is called.
+    ///
+    /// ⚠️ You need to have run [`refresh_memory`](System::refresh_memory) at least once before
+    /// calling this method.
+    ///
+    /// ⚠️ This method is only implemented for Linux. It always returns `None` for all other
+    /// systems.
+    ///
+    /// ```no_run
+    /// use sysinfo::System;
+    ///
+    /// let s = System::new_all();
+    /// println!("limits: {:?}", s.cgroup_limits());
+    /// ```
+    pub fn cgroup_limits(&self) -> Option<CGroupLimits> {
+        self.inner.cgroup_limits()
     }
 
     /// Returns system uptime (in seconds).
@@ -2443,6 +2466,17 @@ impl std::fmt::Display for Signal {
         };
         f.write_str(s)
     }
+}
+
+/// Contains memory limits for the current process.
+#[derive(Default, Debug, Clone)]
+pub struct CGroupLimits {
+    /// Total memory (in bytes) for the current cgroup.
+    pub total_memory: u64,
+    /// Free memory (in bytes) for the current cgroup.
+    pub free_memory: u64,
+    /// Free swap (in bytes) for the current cgroup.
+    pub free_swap: u64,
 }
 
 /// A struct representing system load average value.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,9 +52,9 @@ cfg_if::cfg_if! {
 }
 
 pub use crate::common::{
-    get_current_pid, Component, Components, Cpu, CpuRefreshKind, Disk, DiskKind, DiskUsage, Disks,
-    Gid, Group, LoadAvg, MacAddr, NetworkData, Networks, NetworksIter, Pid, Process,
-    ProcessRefreshKind, ProcessStatus, RefreshKind, Signal, System, Uid, User, Users,
+    get_current_pid, CGroupLimits, Component, Components, Cpu, CpuRefreshKind, Disk, DiskKind,
+    DiskUsage, Disks, Gid, Group, LoadAvg, MacAddr, NetworkData, Networks, NetworksIter, Pid,
+    Process, ProcessRefreshKind, ProcessStatus, RefreshKind, Signal, System, Uid, User, Users,
 };
 
 pub(crate) use crate::sys::{

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -134,6 +134,22 @@ impl serde::Serialize for crate::System {
     }
 }
 
+impl Serialize for crate::CGroupLimits {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // `3` corresponds to the number of fields.
+        let mut state = serializer.serialize_struct("CGroupLimits", 3)?;
+
+        state.serialize_field("total_memory", &self.total_memory)?;
+        state.serialize_field("free_memory", &self.free_memory)?;
+        state.serialize_field("free_swap", &self.free_swap)?;
+
+        state.end()
+    }
+}
+
 impl Serialize for crate::Networks {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/src/unix/apple/system.rs
+++ b/src/unix/apple/system.rs
@@ -159,6 +159,10 @@ impl SystemInner {
         }
     }
 
+    pub(crate) fn cgroup_limits(&self) -> Option<crate::CGroupLimits> {
+        None
+    }
+
     pub(crate) fn refresh_cpu_specifics(&mut self, refresh_kind: CpuRefreshKind) {
         self.cpus.refresh(refresh_kind, self.port);
     }

--- a/src/unix/freebsd/system.rs
+++ b/src/unix/freebsd/system.rs
@@ -55,6 +55,10 @@ impl SystemInner {
         self.swap_used = swap_used;
     }
 
+    pub(crate) fn cgroup_limits(&self) -> Option<crate::CGroupLimits> {
+        None
+    }
+
     pub(crate) fn refresh_cpu_specifics(&mut self, refresh_kind: CpuRefreshKind) {
         self.cpus.refresh(refresh_kind)
     }

--- a/src/unix/linux/system.rs
+++ b/src/unix/linux/system.rs
@@ -225,6 +225,10 @@ impl SystemInner {
                 .saturating_sub(self.mem_shmem);
         }
 
+        self.refresh_cgroup();
+    }
+
+    fn refresh_cgroup(&mut self) {
         if let (Some(mem_cur), Some(mem_max)) = (
             read_u64("/sys/fs/cgroup/memory.current"),
             read_u64("/sys/fs/cgroup/memory.max"),

--- a/src/unknown/system.rs
+++ b/src/unknown/system.rs
@@ -21,6 +21,10 @@ impl SystemInner {
 
     pub(crate) fn refresh_memory(&mut self) {}
 
+    pub(crate) fn cgroup_limits(&self) -> Option<crate::CGroupLimits> {
+        None
+    }
+
     pub(crate) fn refresh_cpu_specifics(&mut self, _refresh_kind: CpuRefreshKind) {}
 
     pub(crate) fn refresh_processes_specifics(&mut self, _refresh_kind: ProcessRefreshKind) {}

--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -165,6 +165,10 @@ impl SystemInner {
         }
     }
 
+    pub(crate) fn cgroup_limits(&self) -> Option<crate::CGroupLimits> {
+        None
+    }
+
     #[allow(clippy::map_entry)]
     pub(crate) fn refresh_process_specifics(
         &mut self,


### PR DESCRIPTION
Fixes https://github.com/GuillaumeGomez/sysinfo/issues/1071.