### PR TITLE
add the netdevs feature for the optional bring back of NFS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ apple-sandbox = []
 apple-app-store = ["apple-sandbox"]
 c-interface = []
 multithread = ["rayon"]
+netdevs = []
 debug = ["libc/extra_traits"]
 # This feature is used on CI to emulate unknown/unsupported target.
 unknown-ci = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ apple-sandbox = []
 apple-app-store = ["apple-sandbox"]
 c-interface = []
 multithread = ["rayon"]
-netdevs = []
+linux-netdevs = []
 debug = ["libc/extra_traits"]
 # This feature is used on CI to emulate unknown/unsupported target.
 unknown-ci = []

--- a/src/common.rs
+++ b/src/common.rs
@@ -2110,6 +2110,12 @@ impl Disk {
 ///     println!("{disk:?}");
 /// }
 /// ```
+///
+/// ⚠️ Note that network devices are excluded by default under Linux.
+/// To display mount points using the CIFS and NFS protocols, the `linux-netdevs`
+/// feature must be enabled. Note, however, that sysinfo may hang under certain
+/// circumstances. For example, if a CIFS or NFS share has been mounted with
+/// the _hard_ option, but the connection has an error, such as the share server has stopped.
 pub struct Disks {
     inner: crate::DisksInner,
 }

--- a/src/unix/linux/disk.rs
+++ b/src/unix/linux/disk.rs
@@ -261,7 +261,7 @@ fn get_all_list(container: &mut Vec<Disk>, content: &str) {
                 "iso9660" // optical media
             );
 
-            // If the nfs_support feature is enabled, don't filter it out.
+            // If the netdevs feature is enabled, don't filter cifs/nfs out.
             if !cfg!(feature = "netdevs") && matches!(*fs_vfstype, "cifs" | "nfs" | "nfs4") {
                 // calling statvfs on a mounted CIFS or NFS may hang, when they are mounted with option: hard
                 filtered = true;

--- a/src/unix/linux/disk.rs
+++ b/src/unix/linux/disk.rs
@@ -258,10 +258,14 @@ fn get_all_list(container: &mut Vec<Disk>, content: &str) {
                 "pstore" | // https://www.kernel.org/doc/Documentation/ABI/testing/pstore
                 "squashfs" | // squashfs is a compressed read-only file system (for snaps)
                 "rpc_pipefs" | // The pipefs pseudo file system service
-                "iso9660" | // optical media
-                "nfs4" | // calling statvfs on a mounted NFS may hang
-                "nfs" // nfs2 or nfs3
+                "iso9660" // optical media
             );
+
+            // If the nfs_support feature is enabled, don't filter it out.
+            if !cfg!(feature = "netdevs") && matches!(*fs_vfstype, "cifs" | "nfs" | "nfs4") {
+                // calling statvfs on a mounted CIFS or NFS may hang, when they are mounted with option: hard
+                filtered = true;
+            }
 
             !(filtered ||
                fs_file.starts_with("/sys") || // check if fs_file is an 'ignored' mount point

--- a/src/unix/linux/disk.rs
+++ b/src/unix/linux/disk.rs
@@ -246,7 +246,7 @@ fn get_all_list(container: &mut Vec<Disk>, content: &str) {
         })
         .filter(|(fs_spec, fs_file, fs_vfstype)| {
             // Check if fs_vfstype is one of our 'ignored' file systems.
-            let filtered = matches!(
+            let mut filtered = matches!(
                 *fs_vfstype,
                 "rootfs" | // https://www.kernel.org/doc/Documentation/filesystems/ramfs-rootfs-initramfs.txt
                 "sysfs" | // pseudo file system for kernel objects

--- a/src/unix/linux/disk.rs
+++ b/src/unix/linux/disk.rs
@@ -246,8 +246,7 @@ fn get_all_list(container: &mut Vec<Disk>, content: &str) {
         })
         .filter(|(fs_spec, fs_file, fs_vfstype)| {
             // Check if fs_vfstype is one of our 'ignored' file systems.
-            let mut filtered = matches!(
-                *fs_vfstype,
+            let filtered = match *fs_vfstype {
                 "rootfs" | // https://www.kernel.org/doc/Documentation/filesystems/ramfs-rootfs-initramfs.txt
                 "sysfs" | // pseudo file system for kernel objects
                 "proc" |  // another pseudo file system
@@ -259,13 +258,11 @@ fn get_all_list(container: &mut Vec<Disk>, content: &str) {
                 "squashfs" | // squashfs is a compressed read-only file system (for snaps)
                 "rpc_pipefs" | // The pipefs pseudo file system service
                 "iso9660" // optical media
-            );
-
-            // If the netdevs feature is enabled, don't filter cifs/nfs out.
-            if !cfg!(feature = "netdevs") && matches!(*fs_vfstype, "cifs" | "nfs" | "nfs4") {
+                => true,
                 // calling statvfs on a mounted CIFS or NFS may hang, when they are mounted with option: hard
-                filtered = true;
-            }
+                "cifs" | "nfs" | "nfs4" => !cfg!(feature = "linux-netdevs"),
+                _ => false,
+            };
 
             !(filtered ||
                fs_file.starts_with("/sys") || // check if fs_file is an 'ignored' mount point


### PR DESCRIPTION
This brings NFS back, but only as an optional feature called `netdevs`.

Why `netdevs`? Because when CIFS is mounted with the **hard** option, it would cause the same hang as NFS. The only difference is that NFS is hard by default and CIFS is soft by default. So in my option it makes more sense to disable both by default, but enable them with feature if users have no problem with the risk.

More details about the issues with mounting NFS: https://github.com/GuillaumeGomez/sysinfo/issues/842#issuecomment-1815859527