### PR TITLE
Correctly handle where group name is NULL

### DIFF
--- a/src/users.rs
+++ b/src/users.rs
@@ -36,6 +36,9 @@ pub(crate) unsafe fn get_group_name(
     }
     let g = g.assume_init();
     let mut group_name = Vec::new();
+    if g.gr_name.is_null() {
+        return Some(String::new());
+    }
     let c_group_name = g.gr_name;
     let mut x = 0;
     loop {


### PR DESCRIPTION
Fixes https://github.com/GuillaumeGomez/sysinfo/issues/1154.

In the new version, the code has been re-written and the check is already in place, so nothing to do for 0.30.