### PR TITLE
Make Process::tasks method available on all platforms and change its return type to `Option`

### DIFF
--- a/src/sysinfo.h
+++ b/src/sysinfo.h
@@ -28,9 +28,7 @@ void        sysinfo_refresh_memory(CSystem system);
 void        sysinfo_refresh_cpu(CSystem system);
 void        sysinfo_refresh_all(CSystem system);
 void        sysinfo_refresh_processes(CSystem system);
-#ifdef __linux__
 void        sysinfo_refresh_process(CSystem system, PID pid);
-#endif
 
 CDisks      sysinfo_disks_init(void);
 void        sysinfo_disks_destroy(CDisks disks);
@@ -48,10 +46,8 @@ void        sysinfo_cpus_usage(CSystem system, unsigned int *length, float **cpu
 
 size_t      sysinfo_processes(CSystem system, bool (*fn_pointer)(PID, CProcess, void*),
                               void *data);
-#ifdef __linux__
 size_t      sysinfo_process_tasks(CProcess process, bool (*fn_pointer)(PID, void*),
                                   void *data);
-#endif
 CProcess    sysinfo_process_by_pid(CSystem system, PID pid);
 PID         sysinfo_process_pid(CProcess process);
 PID         sysinfo_process_parent_pid(CProcess process);

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -393,10 +393,15 @@ fn test_refresh_tasks() {
     let mut s = System::new();
     s.refresh_processes();
 
-    assert!(s.process(pid).unwrap().tasks().iter().any(|task_pid| s
-        .process(*task_pid)
-        .map(|task| task.name() == task_name)
-        .unwrap_or(false)));
+    assert!(s
+        .process(pid)
+        .unwrap()
+        .tasks()
+        .map(|tasks| tasks.iter().any(|task_pid| s
+            .process(*task_pid)
+            .map(|task| task.name() == task_name)
+            .unwrap_or(false)))
+        .unwrap_or(false));
     assert!(s.processes_by_exact_name(task_name).next().is_some());
 
     // Let's give some time to the system to clean up...
@@ -404,10 +409,15 @@ fn test_refresh_tasks() {
 
     s.refresh_processes();
 
-    assert!(!s.process(pid).unwrap().tasks().iter().any(|task_pid| s
-        .process(*task_pid)
-        .map(|task| task.name() == task_name)
-        .unwrap_or(false)));
+    assert!(!s
+        .process(pid)
+        .unwrap()
+        .tasks()
+        .map(|tasks| tasks.iter().any(|task_pid| s
+            .process(*task_pid)
+            .map(|task| task.name() == task_name)
+            .unwrap_or(false)))
+        .unwrap_or(false));
     assert!(s.processes_by_exact_name(task_name).next().is_none());
 }
 


### PR DESCRIPTION
Follow-up of https://github.com/GuillaumeGomez/sysinfo/pull/1168.