### PR TITLE
first column in statm is total size, second column is resident set size

### DIFF
--- a/src/unix/linux/process.rs
+++ b/src/unix/linux/process.rs
@@ -566,12 +566,12 @@ fn get_memory(path: &Path, entry: &mut ProcessInner, info: &SystemInfo) -> bool 
         return false;
     }
     let mut parts = buf.split(|c| *c == b' ');
-    entry.memory = parts
+    entry.virtual_memory = parts
         .next()
         .map(slice_to_nb)
         .unwrap_or(0)
         .saturating_mul(info.page_size_b);
-    entry.virtual_memory = parts
+    entry.memory = parts
         .next()
         .map(slice_to_nb)
         .unwrap_or(0)


### PR DESCRIPTION
The new get_memory function for linux mixes up total memory and resident memory, see [proc(5)](https://man7.org/linux/man-pages/man5/proc.5.html).