### PR TITLE
Fixes for Process.name() and swap memory computation on i686-pc-windows-msvc

### DIFF
--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -857,10 +857,6 @@ impl_RtlUserProcessParameters!(RTL_USER_PROCESS_PARAMETERS32);
 impl_RtlUserProcessParameters!(RTL_USER_PROCESS_PARAMETERS);
 
 unsafe fn get_process_params(process: &mut ProcessInner, refresh_kind: ProcessRefreshKind) {
-    if !cfg!(target_pointer_width = "64") {
-        sysinfo_debug!("Non 64 bit targets are not supported");
-        return;
-    }
     if !(refresh_kind.cmd().needs_update(|| process.cmd.is_empty())
         || refresh_kind
             .environ()

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -857,6 +857,10 @@ impl_RtlUserProcessParameters!(RTL_USER_PROCESS_PARAMETERS32);
 impl_RtlUserProcessParameters!(RTL_USER_PROCESS_PARAMETERS);
 
 unsafe fn get_process_params(process: &mut ProcessInner, refresh_kind: ProcessRefreshKind) {
+    if !cfg!(target_pointer_width = "64") {
+        sysinfo_debug!("Non 64 bit targets are not supported");
+        return;
+    }
     if !(refresh_kind.cmd().needs_update(|| process.cmd.is_empty())
         || refresh_kind
             .environ()

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -857,10 +857,6 @@ impl_RtlUserProcessParameters!(RTL_USER_PROCESS_PARAMETERS32);
 impl_RtlUserProcessParameters!(RTL_USER_PROCESS_PARAMETERS);
 
 unsafe fn get_process_params(process: &mut ProcessInner, refresh_kind: ProcessRefreshKind) {
-    // if !cfg!(target_pointer_width = "64") {
-    //     sysinfo_debug!("Non 64 bit targets are not supported");
-    //     return;
-    // }
     if !(refresh_kind.cmd().needs_update(|| process.cmd.is_empty())
         || refresh_kind
             .environ()

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -272,7 +272,7 @@ unsafe fn get_process_name(pid: Pid) -> Option<String> {
         ImageName: MaybeUninit::zeroed().assume_init(),
     };
     // `MaximumLength` MUST BE a power of 2: here 128
-    info.ImageName.MaximumLength = 1 << 7;
+    info.ImageName.MaximumLength = 1 << 15; // the returned name may be a full UNC path, up to 32767
 
     for i in 0.. {
         let local_alloc = LocalAlloc(
@@ -857,10 +857,10 @@ impl_RtlUserProcessParameters!(RTL_USER_PROCESS_PARAMETERS32);
 impl_RtlUserProcessParameters!(RTL_USER_PROCESS_PARAMETERS);
 
 unsafe fn get_process_params(process: &mut ProcessInner, refresh_kind: ProcessRefreshKind) {
-    if !cfg!(target_pointer_width = "64") {
-        sysinfo_debug!("Non 64 bit targets are not supported");
-        return;
-    }
+    // if !cfg!(target_pointer_width = "64") {
+    //     sysinfo_debug!("Non 64 bit targets are not supported");
+    //     return;
+    // }
     if !(refresh_kind.cmd().needs_update(|| process.cmd.is_empty())
         || refresh_kind
             .environ()

--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -153,16 +153,12 @@ impl SystemInner {
                 )
                 .as_bool()
                 {
-                    let swap_total = perf_info.PageSize.saturating_mul(
-                        perf_info
-                            .CommitLimit
-                            .saturating_sub(perf_info.PhysicalTotal),
-                    );
-                    let swap_used = perf_info.PageSize.saturating_mul(
-                        perf_info
-                            .CommitTotal
-                            .saturating_sub(perf_info.PhysicalTotal),
-                    );
+                    let page_size = perf_info.PageSize as u64;
+                    let physical_total = perf_info.PhysicalTotal as u64;
+                    let commit_limit = perf_info.CommitLimit as u64;
+                    let commit_total = perf_info.CommitTotal as u64;
+                    let swap_total = page_size.saturating_mul(commit_limit.saturating_sub(physical_total));
+                    let swap_used = page_size.saturating_mul(commit_total.saturating_sub(physical_total));
                     self.swap_total = swap_total as _;
                     self.swap_used = swap_used as _;
                 }

--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -157,8 +157,10 @@ impl SystemInner {
                     let physical_total = perf_info.PhysicalTotal as u64;
                     let commit_limit = perf_info.CommitLimit as u64;
                     let commit_total = perf_info.CommitTotal as u64;
-                    let swap_total = page_size.saturating_mul(commit_limit.saturating_sub(physical_total));
-                    let swap_used = page_size.saturating_mul(commit_total.saturating_sub(physical_total));
+                    let swap_total =
+                        page_size.saturating_mul(commit_limit.saturating_sub(physical_total));
+                    let swap_used =
+                        page_size.saturating_mul(commit_total.saturating_sub(physical_total));
                     self.swap_total = swap_total as _;
                     self.swap_used = swap_used as _;
                 }


### PR DESCRIPTION
Targetting `i686-pc-windows`, an initial try to fix #1188 which led to:
– A dead-end regarding this fix (because a 32-bit process can’t read 64-bits process memory… For obvious reasons 😅)
– A fix in `Process.name()` whose buffer length was too short
– A fix in swap memory computation, not using `usize` but extending to `u64` (because even on 32-bit platforms, memory can be big 😉).
