### PR TITLE
Use `OsString` everywhere

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,10 +1,10 @@
 task:
-  name: rust 1.69 on freebsd 13
+  name: rust 1.74 on freebsd 13
   freebsd_instance:
     image: freebsd-13-1-release-amd64
   setup_script:
     - curl https://sh.rustup.rs -sSf --output rustup.sh
-    - sh rustup.sh -y --profile=minimal --default-toolchain=1.69
+    - sh rustup.sh -y --profile=minimal --default-toolchain=1.74
     - . $HOME/.cargo/env
     - rustup --version
     - rustup component add clippy
@@ -37,14 +37,14 @@ task:
     - FREEBSD_CI=1 cargo test --lib -j1 -- --ignored
 
 task:
-  name: rust 1.69 on mac m1
+  name: rust 1.74 on mac m1
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-base:latest
   setup_script:
     - brew update
     - brew install curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh
-    - sh rustup.sh -y --profile=minimal --default-toolchain=1.69
+    - sh rustup.sh -y --profile=minimal --default-toolchain=1.74
     - source $HOME/.cargo/env
     - rustup --version
     - rustup component add clippy

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -68,7 +68,7 @@ jobs:
           - { os: 'ubuntu-latest', target: 'x86_64-linux-android', cross: true }
           - { os: 'ubuntu-latest', target: 'i686-linux-android', cross: true }
         toolchain:
-          - "1.69.0"  # minimum supported rust version
+          - "1.74.0"  # minimum supported rust version
           - stable
           - nightly
     steps:
@@ -139,7 +139,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - "1.69.0"  # minimum supported rust version
+          - "1.74.0"  # minimum supported rust version
           - stable
           - nightly
     steps:
@@ -205,7 +205,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - "1.69.0" # minimum supported rust version
+          - "1.74.0" # minimum supported rust version
           - stable
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
+name = "bstr"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +116,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
+name = "memchr"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
 name = "memoffset"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +193,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+
+[[package]]
 name = "rustix"
 version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,9 +263,11 @@ dependencies = [
 name = "sysinfo"
 version = "0.30.3"
 dependencies = [
+ "bstr",
  "cfg-if",
  "core-foundation-sys",
  "libc",
+ "memchr",
  "ntapi",
  "once_cell",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "Library to get system information such as processes, CPUs, disks,
 repository = "https://github.com/GuillaumeGomez/sysinfo"
 license = "MIT"
 readme = "README.md"
-rust-version = "1.69"
+rust-version = "1.74"
 exclude = ["/test-unknown"]
 categories = ["filesystem", "os", "api-bindings"]
 edition = "2018"
@@ -40,7 +40,9 @@ cargo-args = ["-Zbuild-std"]
 rustdoc-args = ["--generate-link-to-definition"]
 
 [dependencies]
+bstr = "1.9.0"
 cfg-if = "1.0"
+memchr = "2.7.1"
 rayon = { version = "^1.8", optional = true }
 serde = { version = "^1.0.190", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can still use `sysinfo` on non-supported OSes, it'll simply do nothing and a
 empty values. You can check in your program directly if an OS is supported by checking the
 [`IS_SUPPORTED_SYSTEM`] constant.
 
-The minimum-supported version of `rustc` is **1.69**.
+The minimum-supported version of `rustc` is **1.74**.
 
 ## Usage
 
@@ -68,7 +68,7 @@ println!("NB CPUs: {}", sys.cpus().len());
 
 // Display processes ID, name na disk usage:
 for (pid, process) in sys.processes() {
-    println!("[{pid}] {} {:?}", process.name(), process.disk_usage());
+    println!("[{pid}] {:?} {:?}", process.name(), process.disk_usage());
 }
 
 // We display all disks' information:
@@ -82,7 +82,7 @@ for disk in &disks {
 let networks = Networks::new_with_refreshed_list();
 println!("=> networks:");
 for (interface_name, data) in &networks {
-    println!("{interface_name}: {}/{} B", data.received(), data.transmitted());
+    println!("{interface_name:?}: {}/{} B", data.received(), data.transmitted());
 }
 
 // Components temperature:
@@ -176,8 +176,8 @@ virtual systems.
 
 Apple has restrictions as to which APIs can be linked into binaries that are distributed through the app store.
 By default, `sysinfo` is not compatible with these restrictions. You can use the `apple-app-store`
-feature flag to disable the Apple prohibited features. This also enables the `apple-sandbox` feature. 
-In the case of applications using the sandbox outside of the app store, the `apple-sandbox` feature 
+feature flag to disable the Apple prohibited features. This also enables the `apple-sandbox` feature.
+In the case of applications using the sandbox outside of the app store, the `apple-sandbox` feature
 can be used alone to avoid causing policy violations at runtime.
 
 ### How it works

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -4,6 +4,7 @@
 #![allow(unused_must_use, non_upper_case_globals)]
 #![allow(clippy::manual_range_contains)]
 
+use bstr::ByteSlice;
 use std::io::{self, BufRead, Write};
 use std::str::FromStr;
 use sysinfo::{Components, Disks, Networks, Pid, Signal, System, Users};
@@ -242,7 +243,7 @@ fn interpret_input(
                     &mut io::stdout(),
                     "{}:{} status={:?}",
                     pid,
-                    proc_.name(),
+                    proc_.name().as_encoded_bytes().as_bstr(),
                     proc_.status()
                 );
             }
@@ -252,7 +253,7 @@ fn interpret_input(
                 writeln!(
                     &mut io::stdout(),
                     "[{}] {} MHz",
-                    cpu.name(),
+                    cpu.name().as_encoded_bytes().as_bstr(),
                     cpu.frequency(),
                 );
             }
@@ -261,11 +262,15 @@ fn interpret_input(
             writeln!(
                 &mut io::stdout(),
                 "vendor ID: {}",
-                sys.cpus()[0].vendor_id()
+                sys.cpus()[0].vendor_id().as_encoded_bytes().as_bstr()
             );
         }
         "brand" => {
-            writeln!(&mut io::stdout(), "brand: {}", sys.cpus()[0].brand());
+            writeln!(
+                &mut io::stdout(),
+                "brand: {}",
+                sys.cpus()[0].brand().as_encoded_bytes().as_bstr()
+            );
         }
         "load_avg" => {
             let load_avg = System::load_average();
@@ -289,8 +294,12 @@ fn interpret_input(
                 };
             } else {
                 let proc_name = tmp[1];
-                for proc_ in sys.processes_by_name(proc_name) {
-                    writeln!(&mut io::stdout(), "==== {} ====", proc_.name());
+                for proc_ in sys.processes_by_name(proc_name.as_ref()) {
+                    writeln!(
+                        &mut io::stdout(),
+                        "==== {} ====",
+                        proc_.name().as_encoded_bytes().as_bstr()
+                    );
                     writeln!(&mut io::stdout(), "{proc_:?}");
                 }
             }
@@ -305,7 +314,7 @@ fn interpret_input(
                 writeln!(
                     &mut io::stdout(),
                     "{}:\n  ether {}\n  input data  (new / total): {} / {} B\n  output data (new / total): {} / {} B",
-                    interface_name,
+                    interface_name.as_encoded_bytes().as_bstr(),
                     data.mac_address(),
                     data.received(),
                     data.total_received(),
@@ -435,11 +444,26 @@ fn interpret_input(
                  System OS version:        {}\n\
                  System OS (long) version: {}\n\
                  System host name:         {}",
-                System::name().unwrap_or_else(|| "<unknown>".to_owned()),
-                System::kernel_version().unwrap_or_else(|| "<unknown>".to_owned()),
-                System::os_version().unwrap_or_else(|| "<unknown>".to_owned()),
-                System::long_os_version().unwrap_or_else(|| "<unknown>".to_owned()),
-                System::host_name().unwrap_or_else(|| "<unknown>".to_owned()),
+                System::name()
+                    .unwrap_or_else(|| "<unknown>".into())
+                    .as_encoded_bytes()
+                    .as_bstr(),
+                System::kernel_version()
+                    .unwrap_or_else(|| "<unknown>".into())
+                    .as_encoded_bytes()
+                    .as_bstr(),
+                System::os_version()
+                    .unwrap_or_else(|| "<unknown>".into())
+                    .as_encoded_bytes()
+                    .as_bstr(),
+                System::long_os_version()
+                    .unwrap_or_else(|| "<unknown>".into())
+                    .as_encoded_bytes()
+                    .as_bstr(),
+                System::host_name()
+                    .unwrap_or_else(|| "<unknown>".into())
+                    .as_encoded_bytes()
+                    .as_bstr(),
             );
         }
         e => {

--- a/src/c_interface.rs
+++ b/src/c_interface.rs
@@ -524,7 +524,7 @@ pub extern "C" fn sysinfo_cpu_vendor_id(system: CSystem) -> RString {
         let c_string = if let Some(c) = system
             .cpus()
             .first()
-            .and_then(|cpu| CString::new(cpu.vendor_id()).ok())
+            .and_then(|cpu| CString::new(cpu.vendor_id().as_encoded_bytes()).ok())
         {
             c.into_raw() as RString
         } else {
@@ -544,7 +544,7 @@ pub extern "C" fn sysinfo_cpu_brand(system: CSystem) -> RString {
         let c_string = if let Some(c) = system
             .cpus()
             .first()
-            .and_then(|cpu| CString::new(cpu.brand()).ok())
+            .and_then(|cpu| CString::new(cpu.brand().as_encoded_bytes()).ok())
         {
             c.into_raw() as RString
         } else {
@@ -586,18 +586,21 @@ pub extern "C" fn sysinfo_cpu_frequency(system: CSystem) -> u64 {
 /// Equivalent of [`System::name()`][crate::System#method.name].
 #[no_mangle]
 pub extern "C" fn sysinfo_system_name() -> RString {
-    let c_string = if let Some(c) = System::name().and_then(|p| CString::new(p).ok()) {
-        c.into_raw() as _
-    } else {
-        std::ptr::null()
-    };
+    let c_string =
+        if let Some(c) = System::name().and_then(|p| CString::new(p.as_encoded_bytes()).ok()) {
+            c.into_raw() as _
+        } else {
+            std::ptr::null()
+        };
     c_string
 }
 
 /// Equivalent of [`System::version()`][crate::System#method.version].
 #[no_mangle]
 pub extern "C" fn sysinfo_system_version() -> RString {
-    let c_string = if let Some(c) = System::os_version().and_then(|c| CString::new(c).ok()) {
+    let c_string = if let Some(c) =
+        System::os_version().and_then(|c| CString::new(c.as_encoded_bytes()).ok())
+    {
         c.into_raw() as _
     } else {
         std::ptr::null()
@@ -608,7 +611,9 @@ pub extern "C" fn sysinfo_system_version() -> RString {
 /// Equivalent of [`System::kernel_version()`][crate::System#method.kernel_version].
 #[no_mangle]
 pub extern "C" fn sysinfo_system_kernel_version() -> RString {
-    let c_string = if let Some(c) = System::kernel_version().and_then(|c| CString::new(c).ok()) {
+    let c_string = if let Some(c) =
+        System::kernel_version().and_then(|c| CString::new(c.as_encoded_bytes()).ok())
+    {
         c.into_raw() as _
     } else {
         std::ptr::null()
@@ -620,7 +625,9 @@ pub extern "C" fn sysinfo_system_kernel_version() -> RString {
 /// Equivalent of [`System::host_name()`][crate::System#method.host_name].
 #[no_mangle]
 pub extern "C" fn sysinfo_system_host_name() -> RString {
-    let c_string = if let Some(c) = System::host_name().and_then(|c| CString::new(c).ok()) {
+    let c_string = if let Some(c) =
+        System::host_name().and_then(|c| CString::new(c.as_encoded_bytes()).ok())
+    {
         c.into_raw() as _
     } else {
         std::ptr::null()
@@ -631,7 +638,9 @@ pub extern "C" fn sysinfo_system_host_name() -> RString {
 /// Equivalent of [`System::long_os_version()`][crate::System#method.long_os_version].
 #[no_mangle]
 pub extern "C" fn sysinfo_system_long_version() -> RString {
-    let c_string = if let Some(c) = System::long_os_version().and_then(|c| CString::new(c).ok()) {
+    let c_string = if let Some(c) =
+        System::long_os_version().and_then(|c| CString::new(c.as_encoded_bytes()).ok())
+    {
         c.into_raw() as _
     } else {
         std::ptr::null()

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,5 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+use bstr::ByteSlice;
+
 use crate::{
     Component, Components, Cpu, Disk, Disks, NetworkData, Networks, Process, System, User, Users,
 };
@@ -73,14 +75,7 @@ impl fmt::Debug for Process {
 
 impl fmt::Debug for Components {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "Components {{ {} }}",
-            self.iter()
-                .map(|x| format!("{x:?}"))
-                .collect::<Vec<_>>()
-                .join(", ")
-        )
+        f.debug_list().entries(self.iter()).finish()
     }
 }
 
@@ -90,7 +85,7 @@ impl fmt::Debug for Component {
             write!(
                 f,
                 "{}: {}°C (max: {}°C / critical: {}°C)",
-                self.label(),
+                self.label().as_encoded_bytes().as_bstr(),
                 self.temperature(),
                 self.max(),
                 critical
@@ -99,7 +94,7 @@ impl fmt::Debug for Component {
             write!(
                 f,
                 "{}: {}°C (max: {}°C)",
-                self.label(),
+                self.label().as_encoded_bytes().as_bstr(),
                 self.temperature(),
                 self.max()
             )
@@ -109,14 +104,7 @@ impl fmt::Debug for Component {
 
 impl fmt::Debug for Networks {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "Networks {{ {} }}",
-            self.iter()
-                .map(|x| format!("{x:?}"))
-                .collect::<Vec<_>>()
-                .join(", ")
-        )
+        f.debug_list().entries(self.iter()).finish()
     }
 }
 
@@ -141,27 +129,13 @@ impl fmt::Debug for NetworkData {
 
 impl fmt::Debug for Disks {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "Disks {{ {} }}",
-            self.iter()
-                .map(|x| format!("{x:?}"))
-                .collect::<Vec<_>>()
-                .join(", ")
-        )
+        f.debug_list().entries(self.iter()).finish()
     }
 }
 
 impl fmt::Debug for Users {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "Users {{ {} }}",
-            self.iter()
-                .map(|x| format!("{x:?}"))
-                .collect::<Vec<_>>()
-                .join(", ")
-        )
+        f.debug_list().entries(self.iter()).finish()
     }
 }
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,12 +1,13 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use std::collections::HashMap;
+use std::ffi::OsString;
 
 use crate::network_helper::get_interface_address;
 use crate::NetworkData;
 
 /// Interface addresses are OS-independent
-pub(crate) fn refresh_networks_addresses(interfaces: &mut HashMap<String, NetworkData>) {
+pub(crate) fn refresh_networks_addresses(interfaces: &mut HashMap<OsString, NetworkData>) {
     match get_interface_address() {
         Ok(ifa_iterator) => {
             for (name, ifa) in ifa_iterator {

--- a/src/unix/apple/app_store/component.rs
+++ b/src/unix/apple/app_store/component.rs
@@ -1,5 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+use std::ffi::OsStr;
+
 use crate::Component;
 
 pub(crate) struct ComponentInner;
@@ -17,8 +19,8 @@ impl ComponentInner {
         None
     }
 
-    pub(crate) fn label(&self) -> &str {
-        ""
+    pub(crate) fn label(&self) -> &OsStr {
+        OsStr::new("")
     }
 
     pub(crate) fn refresh(&mut self) {}

--- a/src/unix/apple/app_store/process.rs
+++ b/src/unix/apple/app_store/process.rs
@@ -1,6 +1,9 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use std::path::Path;
+use std::{
+    ffi::{OsStr, OsString},
+    path::Path,
+};
 
 use crate::{DiskUsage, Gid, Pid, ProcessStatus, Signal, Uid};
 
@@ -11,11 +14,11 @@ impl ProcessInner {
         None
     }
 
-    pub(crate) fn name(&self) -> &str {
-        ""
+    pub(crate) fn name(&self) -> &OsStr {
+        OsStr::new("")
     }
 
-    pub(crate) fn cmd(&self) -> &[String] {
+    pub(crate) fn cmd(&self) -> &[OsString] {
         &[]
     }
 
@@ -27,7 +30,7 @@ impl ProcessInner {
         Pid(0)
     }
 
-    pub(crate) fn environ(&self) -> &[String] {
+    pub(crate) fn environ(&self) -> &[OsString] {
         &[]
     }
 

--- a/src/unix/apple/disk.rs
+++ b/src/unix/apple/disk.rs
@@ -269,6 +269,7 @@ unsafe fn get_dict_value<T, F: FnOnce(*const c_void) -> Option<T>>(
 ) -> Option<T> {
     #[cfg(target_os = "macos")]
     let _defined;
+    #[allow(clippy::infallible_destructuring_match)]
     let key = match key {
         DictKey::Extern(val) => val,
         #[cfg(target_os = "macos")]
@@ -294,7 +295,7 @@ unsafe fn get_dict_value<T, F: FnOnce(*const c_void) -> Option<T>>(
     }
 }
 
-pub(super) unsafe fn get_str_value(dict: CFDictionaryRef, key: DictKey) -> Option<String> {
+pub(super) unsafe fn get_str_value(dict: CFDictionaryRef, key: DictKey) -> Option<OsString> {
     get_dict_value(dict, key, |v| {
         let v = v as cfs::CFStringRef;
 
@@ -313,7 +314,7 @@ pub(super) unsafe fn get_str_value(dict: CFDictionaryRef, key: DictKey) -> Optio
             );
 
             if success != 0 {
-                utils::vec_to_rust(buf)
+                Some(utils::vec_to_rust(buf))
             } else {
                 None
             }

--- a/src/unix/apple/macos/component/arm.rs
+++ b/src/unix/apple/macos/component/arm.rs
@@ -1,6 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use std::ffi::CStr;
+use std::ffi::{CStr, OsStr, OsString};
+use std::os::unix::ffi::OsStrExt;
 
 use core_foundation_sys::array::{CFArrayGetCount, CFArrayGetValueAtIndex};
 use core_foundation_sys::base::{kCFAllocatorDefault, CFRetain};
@@ -114,7 +115,7 @@ impl ComponentsInner {
 
                 let name_ptr =
                     CFStringGetCStringPtr(name.inner() as *const _, kCFStringEncodingUTF8);
-                let name_str = CStr::from_ptr(name_ptr).to_string_lossy().to_string();
+                let name_str = OsStr::from_bytes(CStr::from_ptr(name_ptr).to_bytes()).to_owned();
 
                 let mut component = ComponentInner::new(name_str, None, None, service);
                 component.refresh();
@@ -128,14 +129,14 @@ impl ComponentsInner {
 pub(crate) struct ComponentInner {
     service: CFReleaser<__IOHIDServiceClient>,
     temperature: f32,
-    label: String,
+    label: OsString,
     max: f32,
     critical: Option<f32>,
 }
 
 impl ComponentInner {
     pub(crate) fn new(
-        label: String,
+        label: OsString,
         max: Option<f32>,
         critical: Option<f32>,
         service: CFReleaser<__IOHIDServiceClient>,
@@ -161,7 +162,7 @@ impl ComponentInner {
         self.critical
     }
 
-    pub(crate) fn label(&self) -> &str {
+    pub(crate) fn label(&self) -> &OsStr {
         &self.label
     }
 

--- a/src/unix/apple/macos/component/x86.rs
+++ b/src/unix/apple/macos/component/x86.rs
@@ -5,7 +5,7 @@ use crate::Component;
 
 use libc::{c_char, c_int, c_void};
 
-use std::mem;
+use std::{ffi::OsStr, mem};
 
 const COMPONENTS_TEMPERATURE_IDS: &[(&str, &[i8])] = &[
     ("PECI CPU", &['T' as i8, 'C' as i8, 'X' as i8, 'C' as i8]), // PECI CPU "TCXC"
@@ -86,9 +86,7 @@ impl ComponentsInner {
                 get_temperature(connection, &['T' as i8, 'C' as i8, '0' as i8, 'D' as i8, 0]);
 
             for (id, v) in COMPONENTS_TEMPERATURE_IDS.iter() {
-                if let Some(c) =
-                    ComponentInner::new((*id).to_owned(), None, critical_temp, v, connection)
-                {
+                if let Some(c) = ComponentInner::new(id, None, critical_temp, v, connection) {
                     self.components.push(Component { inner: c });
                 }
             }
@@ -100,14 +98,14 @@ pub(crate) struct ComponentInner {
     temperature: f32,
     max: f32,
     critical: Option<f32>,
-    label: String,
+    label: &'static str,
     ffi_part: ComponentFFI,
 }
 
 impl ComponentInner {
     /// Creates a new `ComponentInner` with the given information.
     pub(crate) fn new(
-        label: String,
+        label: &'static str,
         max: Option<f32>,
         critical: Option<f32>,
         key: &[i8],
@@ -135,8 +133,8 @@ impl ComponentInner {
         self.critical
     }
 
-    pub(crate) fn label(&self) -> &str {
-        &self.label
+    pub(crate) fn label(&self) -> &OsStr {
+        OsStr::new(&self.label)
     }
 
     pub(crate) fn refresh(&mut self) {

--- a/src/unix/apple/macos/disk.rs
+++ b/src/unix/apple/macos/disk.rs
@@ -105,7 +105,7 @@ pub(crate) fn get_disk_type(disk: &libc::statfs) -> Option<DiskKind> {
                     )
                 };
 
-                if let Some(disk_type) = disk_type.and_then(|medium| match medium.as_str() {
+                if let Some(disk_type) = disk_type.and_then(|medium| match &medium {
                     _ if medium == ffi::kIOPropertyMediumTypeSolidStateKey => Some(DiskKind::SSD),
                     _ if medium == ffi::kIOPropertyMediumTypeRotationalKey => Some(DiskKind::HDD),
                     _ => None,

--- a/src/unix/apple/network.rs
+++ b/src/unix/apple/network.rs
@@ -3,6 +3,8 @@
 use libc::{self, c_char, if_msghdr2, CTL_NET, NET_RT_IFLIST2, PF_ROUTE, RTM_IFINFO2};
 
 use std::collections::{hash_map, HashMap};
+use std::ffi::OsString;
+use std::os::unix::ffi::OsStringExt;
 use std::ptr::null_mut;
 
 use crate::common::MacAddr;
@@ -17,7 +19,7 @@ macro_rules! old_and_new {
 }
 
 pub(crate) struct NetworksInner {
-    pub(crate) interfaces: HashMap<String, NetworkData>,
+    pub(crate) interfaces: HashMap<OsString, NetworkData>,
 }
 
 impl NetworksInner {
@@ -27,7 +29,7 @@ impl NetworksInner {
         }
     }
 
-    pub(crate) fn list(&self) -> &HashMap<String, NetworkData> {
+    pub(crate) fn list(&self) -> &HashMap<OsString, NetworkData> {
         &self.interfaces
     }
 
@@ -96,7 +98,7 @@ impl NetworksInner {
                         continue;
                     }
                     name.set_len(libc::strlen(pname));
-                    let name = String::from_utf8_unchecked(name);
+                    let name = OsString::from_vec(name);
                     match self.interfaces.entry(name) {
                         hash_map::Entry::Occupied(mut e) => {
                             let interface = e.get_mut();

--- a/src/unix/apple/system.rs
+++ b/src/unix/apple/system.rs
@@ -9,8 +9,9 @@ use crate::{Cpu, CpuRefreshKind, LoadAvg, MemoryRefreshKind, Pid, Process, Proce
 
 use std::cell::UnsafeCell;
 use std::collections::HashMap;
-use std::ffi::CStr;
+use std::ffi::{CStr, OsString};
 use std::mem;
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
 #[cfg(all(target_os = "macos", not(feature = "apple-sandbox")))]
 use std::time::SystemTime;
 
@@ -348,62 +349,56 @@ impl SystemInner {
         boot_time()
     }
 
-    pub(crate) fn name() -> Option<String> {
+    pub(crate) fn name() -> Option<OsString> {
         get_system_info(libc::KERN_OSTYPE, Some("Darwin"))
     }
 
-    pub(crate) fn long_os_version() -> Option<String> {
+    pub(crate) fn long_os_version() -> Option<OsString> {
         #[cfg(target_os = "macos")]
-        let friendly_name = match Self::os_version().unwrap_or_default() {
-            f_n if f_n.starts_with("14.0") => "Sonoma",
-            f_n if f_n.starts_with("10.16")
-                | f_n.starts_with("11.0")
-                | f_n.starts_with("11.1")
-                | f_n.starts_with("11.2") =>
+        let friendly_name = match Self::os_version().unwrap_or_default().as_bytes() {
+            f_n if f_n.starts_with(b"14.0") => "Sonoma",
+            f_n if f_n.starts_with(b"10.16")
+                | f_n.starts_with(b"11.0")
+                | f_n.starts_with(b"11.1")
+                | f_n.starts_with(b"11.2") =>
             {
                 "Big Sur"
             }
-            f_n if f_n.starts_with("10.15") => "Catalina",
-            f_n if f_n.starts_with("10.14") => "Mojave",
-            f_n if f_n.starts_with("10.13") => "High Sierra",
-            f_n if f_n.starts_with("10.12") => "Sierra",
-            f_n if f_n.starts_with("10.11") => "El Capitan",
-            f_n if f_n.starts_with("10.10") => "Yosemite",
-            f_n if f_n.starts_with("10.9") => "Mavericks",
-            f_n if f_n.starts_with("10.8") => "Mountain Lion",
-            f_n if f_n.starts_with("10.7") => "Lion",
-            f_n if f_n.starts_with("10.6") => "Snow Leopard",
-            f_n if f_n.starts_with("10.5") => "Leopard",
-            f_n if f_n.starts_with("10.4") => "Tiger",
-            f_n if f_n.starts_with("10.3") => "Panther",
-            f_n if f_n.starts_with("10.2") => "Jaguar",
-            f_n if f_n.starts_with("10.1") => "Puma",
-            f_n if f_n.starts_with("10.0") => "Cheetah",
+            f_n if f_n.starts_with(b"10.15") => "Catalina",
+            f_n if f_n.starts_with(b"10.14") => "Mojave",
+            f_n if f_n.starts_with(b"10.13") => "High Sierra",
+            f_n if f_n.starts_with(b"10.12") => "Sierra",
             _ => "",
         };
 
         #[cfg(target_os = "macos")]
-        let long_name = Some(format!(
-            "MacOS {} {}",
-            Self::os_version().unwrap_or_default(),
-            friendly_name
-        ));
+        let long_name = {
+            let mut buf = b"macOS ".to_vec();
+            buf.extend(Self::os_version().unwrap_or_default().as_bytes());
+            buf.push(b' ');
+            buf.extend(friendly_name.as_bytes());
+            Some(OsString::from_vec(buf))
+        };
 
         #[cfg(target_os = "ios")]
-        let long_name = Some(format!("iOS {}", Self::os_version().unwrap_or_default()));
+        let long_name = {
+            let mut buf = b"iOS ".to_vec();
+            buf.extend(Self::os_version().unwrap_or_default().as_bytes());
+            Some(OsString::from_vec(buf))
+        };
 
         long_name
     }
 
-    pub(crate) fn host_name() -> Option<String> {
+    pub(crate) fn host_name() -> Option<OsString> {
         get_system_info(libc::KERN_HOSTNAME, None)
     }
 
-    pub(crate) fn kernel_version() -> Option<String> {
+    pub(crate) fn kernel_version() -> Option<OsString> {
         get_system_info(libc::KERN_OSRELEASE, None)
     }
 
-    pub(crate) fn os_version() -> Option<String> {
+    pub(crate) fn os_version() -> Option<OsString> {
         unsafe {
             // get the size for the buffer first
             let mut size = 0;
@@ -423,7 +418,7 @@ impl SystemInner {
                         buf.resize(pos, 0);
                     }
 
-                    String::from_utf8(buf).ok()
+                    Some(OsString::from_vec(buf))
                 } else {
                     // getting the system value failed
                     None
@@ -435,8 +430,8 @@ impl SystemInner {
         }
     }
 
-    pub(crate) fn distribution_id() -> String {
-        std::env::consts::OS.to_owned()
+    pub(crate) fn distribution_id() -> OsString {
+        std::env::consts::OS.into()
     }
 
     pub(crate) fn cpu_arch() -> Option<String> {
@@ -462,7 +457,7 @@ impl SystemInner {
     }
 }
 
-fn get_system_info(value: c_int, default: Option<&str>) -> Option<String> {
+fn get_system_info(value: c_int, default: Option<&str>) -> Option<OsString> {
     let mut mib: [c_int; 2] = [libc::CTL_KERN, value];
     let mut size = 0;
 
@@ -479,7 +474,7 @@ fn get_system_info(value: c_int, default: Option<&str>) -> Option<String> {
 
         // exit early if we did not update the size
         if size == 0 {
-            default.map(|s| s.to_owned())
+            default.map(|s| s.into())
         } else {
             // set the buffer to the correct size
             let mut buf = vec![0_u8; size as _];
@@ -494,14 +489,14 @@ fn get_system_info(value: c_int, default: Option<&str>) -> Option<String> {
             ) == -1
             {
                 // If command fails return default
-                default.map(|s| s.to_owned())
+                default.map(|s| s.into())
             } else {
                 if let Some(pos) = buf.iter().position(|x| *x == 0) {
                     // Shrink buffer to terminate the null bytes
                     buf.resize(pos, 0);
                 }
 
-                String::from_utf8(buf).ok()
+                Some(OsString::from_vec(buf))
             }
         }
     }

--- a/src/unix/apple/utils.rs
+++ b/src/unix/apple/utils.rs
@@ -2,7 +2,7 @@
 
 use core_foundation_sys::base::CFRelease;
 use libc::{c_void, sysctl, sysctlbyname};
-use std::ptr::NonNull;
+use std::{ffi::OsString, os::unix::ffi::OsStringExt, ptr::NonNull};
 
 // A helper using to auto release the resource got from CoreFoundation.
 // More information about the ownership policy for CoreFoundation pelease refer the link below:
@@ -35,13 +35,12 @@ impl<T> Drop for CFReleaser<T> {
 unsafe impl<T> Send for CFReleaser<T> {}
 unsafe impl<T> Sync for CFReleaser<T> {}
 
-pub(crate) fn vec_to_rust(buf: Vec<i8>) -> Option<String> {
-    String::from_utf8(
+pub(crate) fn vec_to_rust(buf: Vec<i8>) -> OsString {
+    OsString::from_vec(
         buf.into_iter()
             .flat_map(|b| if b > 0 { Some(b as u8) } else { None })
             .collect(),
     )
-    .ok()
 }
 
 pub(crate) unsafe fn get_sys_value(mut len: usize, value: *mut c_void, mib: &mut [i32]) -> bool {

--- a/src/unix/freebsd/component.rs
+++ b/src/unix/freebsd/component.rs
@@ -1,5 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+use std::ffi::OsStr;
+
 use super::utils::get_sys_value_by_name;
 use crate::Component;
 
@@ -23,8 +25,8 @@ impl ComponentInner {
         None
     }
 
-    pub(crate) fn label(&self) -> &str {
-        &self.label
+    pub(crate) fn label(&self) -> &OsStr {
+        OsStr::new(&self.label)
     }
 
     pub(crate) fn refresh(&mut self) {

--- a/src/unix/freebsd/cpu.rs
+++ b/src/unix/freebsd/cpu.rs
@@ -1,5 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+use std::ffi::{OsStr, OsString};
+
 use crate::sys::utils::{
     get_sys_value_array, get_sys_value_by_name, get_sys_value_str_by_name, init_mib, VecSwitcher,
 };
@@ -47,7 +49,7 @@ impl CpusWrapper {
             init_mib(b"kern.cp_times\0", &mut mib_cp_times);
             Self {
                 global_cpu: Cpu {
-                    inner: CpuInner::new(String::new(), String::new(), 0),
+                    inner: CpuInner::new(String::new(), OsString::new(), 0),
                 },
                 cpus: Vec::with_capacity(nb_cpus),
                 got_cpu_frequency: false,
@@ -66,7 +68,7 @@ impl CpusWrapper {
 
             // We get the CPU vendor ID in here.
             let vendor_id =
-                get_sys_value_str_by_name(b"hw.model\0").unwrap_or_else(|| "<unknown>".to_owned());
+                get_sys_value_str_by_name(b"hw.model\0").unwrap_or_else(|| "<unknown>".into());
 
             for pos in 0..self.nb_cpus {
                 if refresh_kind.frequency() {
@@ -139,12 +141,12 @@ impl CpusWrapper {
 pub(crate) struct CpuInner {
     pub(crate) cpu_usage: f32,
     name: String,
-    pub(crate) vendor_id: String,
+    pub(crate) vendor_id: OsString,
     pub(crate) frequency: u64,
 }
 
 impl CpuInner {
-    pub(crate) fn new(name: String, vendor_id: String, frequency: u64) -> Self {
+    pub(crate) fn new(name: String, vendor_id: OsString, frequency: u64) -> Self {
         Self {
             cpu_usage: 0.,
             name,
@@ -157,20 +159,20 @@ impl CpuInner {
         self.cpu_usage
     }
 
-    pub(crate) fn name(&self) -> &str {
-        &self.name
+    pub(crate) fn name(&self) -> &OsStr {
+        OsStr::new(&self.name)
     }
 
     pub(crate) fn frequency(&self) -> u64 {
         self.frequency
     }
 
-    pub(crate) fn vendor_id(&self) -> &str {
+    pub(crate) fn vendor_id(&self) -> &OsStr {
         &self.vendor_id
     }
 
-    pub(crate) fn brand(&self) -> &str {
-        ""
+    pub(crate) fn brand(&self) -> &OsStr {
+        OsStr::new("")
     }
 }
 

--- a/src/unix/freebsd/disk.rs
+++ b/src/unix/freebsd/disk.rs
@@ -134,13 +134,7 @@ pub unsafe fn get_all_list(container: &mut Vec<Disk>) {
             continue;
         }
 
-        let mount_point = match c_buf_to_str(&fs_info.f_mntonname) {
-            Some(m) => m,
-            None => {
-                sysinfo_debug!("Cannot get disk mount point, ignoring it.");
-                continue;
-            }
-        };
+        let mount_point = c_buf_to_str(&fs_info.f_mntonname);
 
         let name = if mount_point == "/" {
             OsString::from("root")

--- a/src/unix/freebsd/process.rs
+++ b/src/unix/freebsd/process.rs
@@ -2,6 +2,7 @@
 
 use crate::{DiskUsage, Gid, Pid, Process, ProcessRefreshKind, ProcessStatus, Signal, Uid};
 
+use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::path::{Path, PathBuf};
 
@@ -41,12 +42,12 @@ impl fmt::Display for ProcessStatus {
 }
 
 pub(crate) struct ProcessInner {
-    pub(crate) name: String,
-    pub(crate) cmd: Vec<String>,
+    pub(crate) name: OsString,
+    pub(crate) cmd: Vec<OsString>,
     pub(crate) exe: Option<PathBuf>,
     pub(crate) pid: Pid,
     parent: Option<Pid>,
-    pub(crate) environ: Vec<String>,
+    pub(crate) environ: Vec<OsString>,
     pub(crate) cwd: Option<PathBuf>,
     pub(crate) root: Option<PathBuf>,
     pub(crate) memory: u64,
@@ -72,11 +73,11 @@ impl ProcessInner {
         unsafe { Some(libc::kill(self.pid.0, c_signal) == 0) }
     }
 
-    pub(crate) fn name(&self) -> &str {
+    pub(crate) fn name(&self) -> &OsStr {
         &self.name
     }
 
-    pub(crate) fn cmd(&self) -> &[String] {
+    pub(crate) fn cmd(&self) -> &[OsString] {
         &self.cmd
     }
 
@@ -88,7 +89,7 @@ impl ProcessInner {
         self.pid
     }
 
-    pub(crate) fn environ(&self) -> &[String] {
+    pub(crate) fn environ(&self) -> &[OsString] {
         &self.environ
     }
 
@@ -280,7 +281,7 @@ pub(crate) unsafe fn get_process_data(
             cwd: None,
             exe: None,
             // kvm_getargv isn't thread-safe so we get it in the main thread.
-            name: String::new(),
+            name: OsString::new(),
             // kvm_getargv isn't thread-safe so we get it in the main thread.
             cmd: Vec::new(),
             // kvm_getargv isn't thread-safe so we get it in the main thread.

--- a/src/unix/linux/utils.rs
+++ b/src/unix/linux/utils.rs
@@ -7,14 +7,14 @@ use std::sync::atomic::Ordering;
 
 use crate::sys::system::REMAINING_FILES;
 
-pub(crate) fn get_all_data_from_file(file: &mut File, size: usize) -> io::Result<String> {
-    let mut buf = String::with_capacity(size);
+pub(crate) fn get_all_data_from_file(file: &mut File, size: usize) -> io::Result<Vec<u8>> {
+    let mut buf = Vec::with_capacity(size);
     file.rewind()?;
-    file.read_to_string(&mut buf)?;
+    file.read_to_end(&mut buf)?;
     Ok(buf)
 }
 
-pub(crate) fn get_all_data<P: AsRef<Path>>(file_path: P, size: usize) -> io::Result<String> {
+pub(crate) fn get_all_data<P: AsRef<Path>>(file_path: P, size: usize) -> io::Result<Vec<u8>> {
     let mut file = File::open(file_path.as_ref())?;
     get_all_data_from_file(&mut file, size)
 }

--- a/src/unix/network_helper.rs
+++ b/src/unix/network_helper.rs
@@ -1,7 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use crate::common::MacAddr;
-use std::ptr::null_mut;
+use std::{ffi::OsString, os::unix::ffi::OsStringExt, ptr::null_mut};
 
 /// This iterator yields an interface name and address.
 pub(crate) struct InterfaceAddressIterator {
@@ -12,7 +12,7 @@ pub(crate) struct InterfaceAddressIterator {
 }
 
 impl Iterator for InterfaceAddressIterator {
-    type Item = (String, MacAddr);
+    type Item = (OsString, MacAddr);
 
     fn next(&mut self) -> Option<Self::Item> {
         unsafe {
@@ -31,7 +31,7 @@ impl Iterator for InterfaceAddressIterator {
                     let mut name = vec![0u8; libc::IFNAMSIZ + 6];
                     libc::strcpy(name.as_mut_ptr() as _, (*ifap).ifa_name);
                     name.set_len(libc::strlen((*ifap).ifa_name));
-                    let name = String::from_utf8_unchecked(name);
+                    let name = OsString::from_vec(name);
 
                     return Some((name, addr));
                 }

--- a/src/unix/utils.rs
+++ b/src/unix/utils.rs
@@ -1,12 +1,14 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+use std::{ffi::OsString, os::unix::ffi::OsStringExt};
+
 use libc::c_char;
 
-pub(crate) fn cstr_to_rust(c: *const c_char) -> Option<String> {
+pub(crate) fn cstr_to_rust(c: *const c_char) -> Option<OsString> {
     cstr_to_rust_with_size(c, None)
 }
 
-pub(crate) fn cstr_to_rust_with_size(c: *const c_char, size: Option<usize>) -> Option<String> {
+pub(crate) fn cstr_to_rust_with_size(c: *const c_char, size: Option<usize>) -> Option<OsString> {
     if c.is_null() {
         return None;
     }
@@ -27,6 +29,6 @@ pub(crate) fn cstr_to_rust_with_size(c: *const c_char, size: Option<usize>) -> O
                 break;
             }
         }
-        String::from_utf8(s).ok()
+        Some(OsString::from_vec(s))
     }
 }

--- a/src/unknown/component.rs
+++ b/src/unknown/component.rs
@@ -1,5 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+use std::ffi::OsStr;
+
 use crate::Component;
 
 pub(crate) struct ComponentInner;
@@ -17,8 +19,8 @@ impl ComponentInner {
         None
     }
 
-    pub(crate) fn label(&self) -> &str {
-        ""
+    pub(crate) fn label(&self) -> &OsStr {
+        OsStr::new("")
     }
 
     pub(crate) fn refresh(&mut self) {}

--- a/src/unknown/cpu.rs
+++ b/src/unknown/cpu.rs
@@ -1,5 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+use std::ffi::OsStr;
+
 pub(crate) struct CpuInner;
 
 impl CpuInner {
@@ -11,19 +13,19 @@ impl CpuInner {
         0.0
     }
 
-    pub(crate) fn name(&self) -> &str {
-        ""
+    pub(crate) fn name(&self) -> &OsStr {
+        OsStr::new("")
     }
 
     pub(crate) fn frequency(&self) -> u64 {
         0
     }
 
-    pub(crate) fn vendor_id(&self) -> &str {
-        ""
+    pub(crate) fn vendor_id(&self) -> &OsStr {
+        OsStr::new("")
     }
 
-    pub(crate) fn brand(&self) -> &str {
-        ""
+    pub(crate) fn brand(&self) -> &OsStr {
+        OsStr::new("")
     }
 }

--- a/src/unknown/network.rs
+++ b/src/unknown/network.rs
@@ -4,9 +4,10 @@ use crate::common::MacAddr;
 use crate::NetworkData;
 
 use std::collections::HashMap;
+use std::ffi::OsString;
 
 pub(crate) struct NetworksInner {
-    pub(crate) interfaces: HashMap<String, NetworkData>,
+    pub(crate) interfaces: HashMap<OsString, NetworkData>,
 }
 
 impl NetworksInner {
@@ -16,7 +17,7 @@ impl NetworksInner {
         }
     }
 
-    pub(crate) fn list(&self) -> &HashMap<String, NetworkData> {
+    pub(crate) fn list(&self) -> &HashMap<OsString, NetworkData> {
         &self.interfaces
     }
 

--- a/src/unknown/process.rs
+++ b/src/unknown/process.rs
@@ -2,6 +2,7 @@
 
 use crate::{DiskUsage, Gid, Pid, ProcessStatus, Signal, Uid};
 
+use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::path::Path;
 
@@ -21,11 +22,11 @@ impl ProcessInner {
         None
     }
 
-    pub(crate) fn name(&self) -> &str {
-        ""
+    pub(crate) fn name(&self) -> &OsStr {
+        OsStr::new("")
     }
 
-    pub(crate) fn cmd(&self) -> &[String] {
+    pub(crate) fn cmd(&self) -> &[OsString] {
         &[]
     }
 
@@ -37,7 +38,7 @@ impl ProcessInner {
         self.pid
     }
 
-    pub(crate) fn environ(&self) -> &[String] {
+    pub(crate) fn environ(&self) -> &[OsString] {
         &[]
     }
 

--- a/src/unknown/system.rs
+++ b/src/unknown/system.rs
@@ -4,7 +4,7 @@ use crate::{
     Cpu, CpuInner, CpuRefreshKind, LoadAvg, MemoryRefreshKind, Pid, Process, ProcessRefreshKind,
 };
 
-use std::collections::HashMap;
+use std::{collections::HashMap, ffi::OsString};
 
 pub(crate) struct SystemInner {
     processes_list: HashMap<Pid, Process>,
@@ -112,27 +112,27 @@ impl SystemInner {
         }
     }
 
-    pub(crate) fn name() -> Option<String> {
+    pub(crate) fn name() -> Option<OsString> {
         None
     }
 
-    pub(crate) fn long_os_version() -> Option<String> {
+    pub(crate) fn long_os_version() -> Option<OsString> {
         None
     }
 
-    pub(crate) fn kernel_version() -> Option<String> {
+    pub(crate) fn kernel_version() -> Option<OsString> {
         None
     }
 
-    pub(crate) fn os_version() -> Option<String> {
+    pub(crate) fn os_version() -> Option<OsString> {
         None
     }
 
-    pub(crate) fn distribution_id() -> String {
-        std::env::consts::OS.to_owned()
+    pub(crate) fn distribution_id() -> OsString {
+        std::env::consts::OS.into()
     }
 
-    pub(crate) fn host_name() -> Option<String> {
+    pub(crate) fn host_name() -> Option<OsString> {
         None
     }
     pub(crate) fn cpu_arch() -> Option<String> {

--- a/src/unknown/users.rs
+++ b/src/unknown/users.rs
@@ -1,5 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+use std::ffi::OsStr;
+
 use crate::{Gid, Group, Uid, User};
 
 pub(crate) struct UserInner;
@@ -13,8 +15,8 @@ impl UserInner {
         Gid(0)
     }
 
-    pub(crate) fn name(&self) -> &str {
-        ""
+    pub(crate) fn name(&self) -> &OsStr {
+        OsStr::new("")
     }
 
     pub(crate) fn groups(&self) -> Vec<Group> {

--- a/src/windows/component.rs
+++ b/src/windows/component.rs
@@ -1,5 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+use std::ffi::OsStr;
+
 use crate::Component;
 
 use windows::core::w;
@@ -21,7 +23,6 @@ pub(crate) struct ComponentInner {
     temperature: f32,
     max: f32,
     critical: Option<f32>,
-    label: String,
     connection: Option<Connection>,
 }
 
@@ -38,7 +39,6 @@ impl ComponentInner {
         c.temperature(true)
             .map(|(temperature, critical)| ComponentInner {
                 temperature,
-                label: "Computer".to_owned(),
                 max: temperature,
                 critical,
                 connection: Some(c),
@@ -57,8 +57,8 @@ impl ComponentInner {
         self.critical
     }
 
-    pub(crate) fn label(&self) -> &str {
-        &self.label
+    pub(crate) fn label(&self) -> &OsStr {
+        OsStr::new("Computer")
     }
 
     pub(crate) fn refresh(&mut self) {

--- a/src/windows/network.rs
+++ b/src/windows/network.rs
@@ -5,6 +5,8 @@ use crate::network::refresh_networks_addresses;
 use crate::NetworkData;
 
 use std::collections::{hash_map, HashMap};
+use std::ffi::OsString;
+use std::os::windows::ffi::OsStringExt;
 
 use windows::Win32::NetworkManagement::IpHelper::{
     FreeMibTable, GetIfEntry2, GetIfTable2, MIB_IF_ROW2, MIB_IF_TABLE2,
@@ -19,7 +21,7 @@ macro_rules! old_and_new {
 }
 
 pub(crate) struct NetworksInner {
-    pub(crate) interfaces: HashMap<String, NetworkData>,
+    pub(crate) interfaces: HashMap<OsString, NetworkData>,
 }
 
 impl NetworksInner {
@@ -29,7 +31,7 @@ impl NetworksInner {
         }
     }
 
-    pub(crate) fn list(&self) -> &HashMap<String, NetworkData> {
+    pub(crate) fn list(&self) -> &HashMap<OsString, NetworkData> {
         &self.interfaces
     }
 
@@ -91,10 +93,7 @@ impl NetworksInner {
                     }
                     pos += 1;
                 }
-                let interface_name = match String::from_utf16(&ptr.Alias[..pos]) {
-                    Ok(s) => s,
-                    _ => continue,
-                };
+                let interface_name = OsString::from_wide(&ptr.Alias[..pos]);
                 match self.interfaces.entry(interface_name) {
                     hash_map::Entry::Occupied(mut e) => {
                         let interface = e.get_mut();

--- a/src/windows/sid.rs
+++ b/src/windows/sid.rs
@@ -1,7 +1,9 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+use std::ffi::OsString;
 use std::{fmt::Display, str::FromStr};
 
+use bstr::ByteSlice;
 use windows::core::{PCWSTR, PWSTR};
 use windows::Win32::Foundation::{LocalFree, ERROR_INSUFFICIENT_BUFFER, HLOCAL, PSID};
 use windows::Win32::Security::Authorization::{ConvertSidToStringSidW, ConvertStringSidToSidW};
@@ -56,7 +58,7 @@ impl Sid {
     }
 
     /// Retrieves the account name of this SID.
-    pub(crate) fn account_name(&self) -> Option<String> {
+    pub(crate) fn account_name(&self) -> Option<OsString> {
         unsafe {
             let mut name_len = 0;
             let mut domain_len = 0;
@@ -109,7 +111,7 @@ impl Sid {
 
 impl Display for Sid {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        unsafe fn convert_sid_to_string_sid(sid: PSID) -> Option<String> {
+        unsafe fn convert_sid_to_string_sid(sid: PSID) -> Option<OsString> {
             let mut string_sid = PWSTR::null();
             if let Err(_err) = ConvertSidToStringSidW(sid, &mut string_sid) {
                 sysinfo_debug!("ConvertSidToStringSidW failed: {:?}", _err);
@@ -124,7 +126,7 @@ impl Display for Sid {
             unsafe { convert_sid_to_string_sid(PSID((self.sid.as_ptr() as *mut u8).cast())) };
         let string_sid = string_sid.ok_or(std::fmt::Error)?;
 
-        write!(f, "{string_sid}")
+        write!(f, "{}", string_sid.as_encoded_bytes().as_bstr())
     }
 }
 

--- a/src/windows/users.rs
+++ b/src/windows/users.rs
@@ -7,6 +7,8 @@ use crate::{
     Group, User,
 };
 
+use std::ffi::{OsStr, OsString};
+use std::os::windows::ffi::OsStringExt;
 use std::ptr::null_mut;
 use windows::core::{w, PCWSTR};
 use windows::Win32::Foundation::{ERROR_MORE_DATA, LUID};
@@ -23,13 +25,13 @@ use windows::Win32::Security::Authentication::Identity::{
 pub(crate) struct UserInner {
     pub(crate) uid: Uid,
     pub(crate) gid: Gid,
-    pub(crate) name: String,
+    pub(crate) name: OsString,
     c_user_name: Option<Vec<u16>>,
     is_local: bool,
 }
 
 impl UserInner {
-    fn new(uid: Uid, name: String, c_name: PCWSTR, is_local: bool) -> Self {
+    fn new(uid: Uid, name: OsString, c_name: PCWSTR, is_local: bool) -> Self {
         let c_user_name = if c_name.is_null() {
             None
         } else {
@@ -52,7 +54,7 @@ impl UserInner {
         self.gid
     }
 
-    pub(crate) fn name(&self) -> &str {
+    pub(crate) fn name(&self) -> &OsStr {
         &self.name
     }
 
@@ -248,14 +250,10 @@ pub(crate) fn get_users(users: &mut Vec<User>) {
                     // a better name), but fall back to the name we were given
                     // if this fails.
                     let name = sid.account_name().unwrap_or_else(|| {
-                        String::from_utf16(std::slice::from_raw_parts(
+                        OsString::from_wide(std::slice::from_raw_parts(
                             data.UserName.Buffer.as_ptr(),
                             data.UserName.Length as usize / std::mem::size_of::<u16>(),
                         ))
-                        .unwrap_or_else(|_err| {
-                            sysinfo_debug!("Failed to convert from UTF-16 string: {}", _err);
-                            String::new()
-                        })
                     });
 
                     users.push(User {

--- a/tests/cpu.rs
+++ b/tests/cpu.rs
@@ -17,7 +17,7 @@ fn test_cpu() {
     let s = sysinfo::System::new_all();
     assert!(!s.cpus().is_empty());
 
-    assert!(!s.cpus()[0].brand().chars().any(|c| c == '\0'));
+    assert!(!s.cpus()[0].brand().as_encoded_bytes().contains(&b'\0'));
 
     if !cfg!(target_os = "freebsd") {
         // This information is currently not retrieved on freebsd...

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -96,7 +96,7 @@ fn check_if_send_and_sync() {
 #[test]
 fn check_hostname_has_no_nuls() {
     if let Some(hostname) = System::host_name() {
-        assert!(!hostname.contains('\u{0}'))
+        assert!(!hostname.as_encoded_bytes().contains(&b'\0'))
     }
 }
 


### PR DESCRIPTION
This makes it so `OsString` / `OsStr` are used everywhere instead of `String` / `str`, because the operating systems make no guarantee that the values provided are valid UTF-8. The `OsString` / `OsStr` types are specifically provided by the standard library for these situations. This fixes situations where `sysinfo` either had to lossily lose some of the information, had some subtle undefined behavior, and partially rejected processes and other resources entirely, making them impossible to be accessed by the user of this crate.

Resolves #1190