### PR TITLE
Bugfix: Update `run_time` for MacOS processes during refresh

### DIFF
--- a/src/unix/apple/macos/process.rs
+++ b/src/unix/apple/macos/process.rs
@@ -686,7 +686,7 @@ pub(crate) fn update_process(
                 }
             };
             p.status = thread_status;
-            p.run_time = now.saturating_sub(start_time);
+            p.run_time = now.saturating_sub(p.start_time);
 
             if refresh_kind.cpu() || refresh_kind.memory() {
                 let task_info = get_task_info(pid);

--- a/src/unix/apple/macos/process.rs
+++ b/src/unix/apple/macos/process.rs
@@ -686,6 +686,7 @@ pub(crate) fn update_process(
                 }
             };
             p.status = thread_status;
+            p.run_time = now.saturating_sub(start_time);
 
             if refresh_kind.cpu() || refresh_kind.memory() {
                 let task_info = get_task_info(pid);


### PR DESCRIPTION
While doing some testing with sysinfo, I found out that run_time is not being updated when refresh is called.