### PR TITLE
Correct comment about `disk_usage()` in FreeBSD

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1140,8 +1140,8 @@ impl Process {
 
     /// Returns number of bytes read and written to disk.
     ///
-    /// ⚠️ On Windows and FreeBSD, this method actually returns **ALL** I/O
-    /// read and written bytes.
+    /// ⚠️ On Windows, this method actually returns **ALL** I/O read and
+    /// written bytes.
     ///
     /// ```no_run
     /// use sysinfo::{Pid, System};


### PR DESCRIPTION
During testing on FreeBSD, I found that `disk_usage()` only measures disk read/writes. This makes sense, since sysutil uses `getrusage`, and the [man page](https://man.freebsd.org/cgi/man.cgi?query=getrusage) clearly indicates that `ru_inblock` and `ru_oublock` represent disk I/O. Not sure where the comment about measuring all I/O comes from.
