### PR TITLE
Remove memory stat code from cgroup mem calculation

### DIFF
--- a/src/unix/linux/system.rs
+++ b/src/unix/linux/system.rs
@@ -557,10 +557,6 @@ impl crate::CGroupLimits {
                 limits.free_swap = sys.swap_total.saturating_sub(swap_cur);
             }
 
-            read_table("/sys/fs/cgroup/memory.stat", ' ', |_key, value| {
-                limits.free_memory = limits.free_memory.saturating_sub(value);
-            });
-
             Some(limits)
         } else if let (Some(mem_cur), Some(mem_max)) = (
             // cgroups v1


### PR DESCRIPTION
Fixes #1219