### PR TITLE
Add feature flag `linux-tmpfs` to list tmpfs mounts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ apple-app-store = ["apple-sandbox"]
 c-interface = []
 multithread = ["rayon"]
 linux-netdevs = []
+linux-tmpfs = []
 debug = ["libc/extra_traits"]
 # This feature is used on CI to emulate unknown/unsupported target.
 unknown-ci = []

--- a/src/common.rs
+++ b/src/common.rs
@@ -2469,6 +2469,9 @@ impl Disk {
 /// }
 /// ```
 ///
+/// ⚠️ Note that tmpfs mounts are excluded by default under Linux.
+/// To display tmpfs mount points, the `linux-tmpfs` feature must be enabled.
+///
 /// ⚠️ Note that network devices are excluded by default under Linux.
 /// To display mount points using the CIFS and NFS protocols, the `linux-netdevs`
 /// feature must be enabled. Note, however, that sysinfo may hang under certain

--- a/src/unix/linux/disk.rs
+++ b/src/unix/linux/disk.rs
@@ -250,7 +250,6 @@ fn get_all_list(container: &mut Vec<Disk>, content: &str) {
                 "rootfs" | // https://www.kernel.org/doc/Documentation/filesystems/ramfs-rootfs-initramfs.txt
                 "sysfs" | // pseudo file system for kernel objects
                 "proc" |  // another pseudo file system
-                "tmpfs" |
                 "devtmpfs" |
                 "cgroup" |
                 "cgroup2" |
@@ -259,6 +258,7 @@ fn get_all_list(container: &mut Vec<Disk>, content: &str) {
                 "rpc_pipefs" | // The pipefs pseudo file system service
                 "iso9660" // optical media
                 => true,
+                "tmpfs" => !cfg!(feature = "linux-tmpfs"),
                 // calling statvfs on a mounted CIFS or NFS may hang, when they are mounted with option: hard
                 "cifs" | "nfs" | "nfs4" => !cfg!(feature = "linux-netdevs"),
                 _ => false,


### PR DESCRIPTION
Small addition as I needed to get stats on a tmpfs mount which is filtered out currently.

Let me know if there's anything that needs changing or if I've missed any limitations that resulted in tmpfs mounts being filtered in the first place