### PR TITLE
Use `OsString` for Process Args and Env Vars

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ cargo-args = ["-Zbuild-std"]
 rustdoc-args = ["--generate-link-to-definition"]
 
 [dependencies]
+bstr = "1.9.0"
 cfg-if = "1.0"
 memchr = "2.7.1"
 rayon = { version = "^1.8", optional = true }
@@ -95,4 +96,3 @@ tempfile = "3.9"
 
 [dev-dependencies]
 serde_json = "1.0" # Used in documentation tests.
-bstr = "1.9.0" # Used in example

--- a/src/common.rs
+++ b/src/common.rs
@@ -8,7 +8,7 @@ use crate::{
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::fmt::Formatter;
 use std::net::IpAddr;
@@ -918,7 +918,7 @@ impl Process {
     ///     println!("{:?}", process.cmd());
     /// }
     /// ```
-    pub fn cmd(&self) -> &[String] {
+    pub fn cmd(&self) -> &[OsString] {
         self.inner.cmd()
     }
 
@@ -972,7 +972,7 @@ impl Process {
     ///     println!("{:?}", process.environ());
     /// }
     /// ```
-    pub fn environ(&self) -> &[String] {
+    pub fn environ(&self) -> &[OsString] {
         self.inner.environ()
     }
 

--- a/src/unix/apple/app_store/process.rs
+++ b/src/unix/apple/app_store/process.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::path::Path;
 
 use crate::{DiskUsage, Gid, Pid, ProcessStatus, Signal, Uid};
@@ -16,7 +16,7 @@ impl ProcessInner {
         OsStr::new("")
     }
 
-    pub(crate) fn cmd(&self) -> &[String] {
+    pub(crate) fn cmd(&self) -> &[OsString] {
         &[]
     }
 
@@ -28,7 +28,7 @@ impl ProcessInner {
         Pid(0)
     }
 
-    pub(crate) fn environ(&self) -> &[String] {
+    pub(crate) fn environ(&self) -> &[OsString] {
         &[]
     }
 

--- a/src/unix/freebsd/process.rs
+++ b/src/unix/freebsd/process.rs
@@ -43,11 +43,11 @@ impl fmt::Display for ProcessStatus {
 
 pub(crate) struct ProcessInner {
     pub(crate) name: OsString,
-    pub(crate) cmd: Vec<String>,
+    pub(crate) cmd: Vec<OsString>,
     pub(crate) exe: Option<PathBuf>,
     pub(crate) pid: Pid,
     parent: Option<Pid>,
-    pub(crate) environ: Vec<String>,
+    pub(crate) environ: Vec<OsString>,
     pub(crate) cwd: Option<PathBuf>,
     pub(crate) root: Option<PathBuf>,
     pub(crate) memory: u64,
@@ -77,7 +77,7 @@ impl ProcessInner {
         &self.name
     }
 
-    pub(crate) fn cmd(&self) -> &[String] {
+    pub(crate) fn cmd(&self) -> &[OsString] {
         &self.cmd
     }
 
@@ -89,7 +89,7 @@ impl ProcessInner {
         self.pid
     }
 
-    pub(crate) fn environ(&self) -> &[String] {
+    pub(crate) fn environ(&self) -> &[OsString] {
         &self.environ
     }
 

--- a/src/unknown/process.rs
+++ b/src/unknown/process.rs
@@ -2,7 +2,7 @@
 
 use crate::{DiskUsage, Gid, Pid, ProcessStatus, Signal, Uid};
 
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::path::Path;
 
@@ -26,7 +26,7 @@ impl ProcessInner {
         OsStr::new("")
     }
 
-    pub(crate) fn cmd(&self) -> &[String] {
+    pub(crate) fn cmd(&self) -> &[OsString] {
         &[]
     }
 
@@ -38,7 +38,7 @@ impl ProcessInner {
         self.pid
     }
 
-    pub(crate) fn environ(&self) -> &[String] {
+    pub(crate) fn environ(&self) -> &[OsString] {
         &[]
     }
 

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -1,5 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+use bstr::ByteSlice;
 use sysinfo::{Pid, ProcessRefreshKind, System, UpdateKind};
 
 #[test]
@@ -70,7 +71,7 @@ fn test_cmd() {
         if cfg!(target_os = "windows") {
             // Sometimes, we get the full path instead for some reasons... So just in case,
             // we check for the command independently that from the arguments.
-            assert!(process.cmd()[0].contains("waitfor"));
+            assert!(process.cmd()[0].as_encoded_bytes().contains_str("waitfor"));
             assert_eq!(&process.cmd()[1..], &["/t", "3", "CmdSignal"]);
         } else {
             assert_eq!(process.cmd(), &["sleep", "3"]);
@@ -147,7 +148,7 @@ fn test_environ() {
         p.kill().expect("Unable to kill process.");
         assert_eq!(proc_.pid(), pid);
         let env = format!("FOO={big_env}");
-        assert!(proc_.environ().iter().any(|e| *e == env));
+        assert!(proc_.environ().iter().any(|e| *e == *env));
     } else {
         panic!("Process not found!");
     }


### PR DESCRIPTION
This continues the "os stringification" on the `Process` type where now not only the process name, but also the arguments and environment variables are also done as `OsString`, mirroring `std`.