### PR TITLE
Multithreaded component refresh

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -3822,9 +3822,15 @@ impl Components {
     /// components.refresh();
     /// ```
     pub fn refresh(&mut self) {
-        for component in self.list_mut() {
-            component.refresh();
+        #[cfg(feature = "multithread")]
+        {
+            use rayon::iter::ParallelIterator;
+            use rayon::iter::IntoParallelRefMutIterator;
+            self.list_mut().par_iter_mut().for_each(|component| component.refresh());
         }
+
+        #[cfg(not(feature = "multithread"))]
+        self.list_mut().iter().for_each(|component| component.refresh());
     }
 
     /// The component list will be emptied then completely recomputed.


### PR DESCRIPTION
This PR causes the `bench_refresh_components` benchmark to go from 1,517,282 ns/iter to  142,299 ns/iter when the "multithread" feature is enabled, which it is by default.  This massive improvement in speed is because reading from the `/sys/class/hwmon/` files in Linux can be slow.  In particular reading the CPU and chipset temperatures were taking about 60 ms each on my system. 