### PR TITLE
Multithreaded component refresh

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -3822,7 +3822,11 @@ impl Components {
     /// components.refresh();
     /// ```
     pub fn refresh(&mut self) {
-        #[cfg(feature = "multithread")]
+        #[cfg(all(
+            feature = "multithread",
+            not(feature = "unknown-ci"),
+            not(all(target_os = "macos", feature = "apple-sandbox")),
+        ))]
         use rayon::iter::ParallelIterator;
         into_iter_mut(self.list_mut()).for_each(|component| component.refresh());
     }

--- a/src/common.rs
+++ b/src/common.rs
@@ -3822,9 +3822,15 @@ impl Components {
     /// components.refresh();
     /// ```
     pub fn refresh(&mut self) {
-        for component in self.list_mut() {
-            component.refresh();
+        #[cfg(feature = "multithread")]
+        {
+            use rayon::iter::ParallelIterator;
+            use rayon::iter::IntoParallelRefMutIterator;
+            self.list_mut().par_iter_mut().for_each(|component| component.refresh());
         }
+
+        #[cfg(not(feature = "multithread"))]
+        self.list_mut().iter().for_each(|component| component.refresh());
     }
 
     /// The component list will be emptied then completely recomputed.

--- a/src/common.rs
+++ b/src/common.rs
@@ -3824,13 +3824,17 @@ impl Components {
     pub fn refresh(&mut self) {
         #[cfg(feature = "multithread")]
         {
-            use rayon::iter::ParallelIterator;
             use rayon::iter::IntoParallelRefMutIterator;
-            self.list_mut().par_iter_mut().for_each(|component| component.refresh());
+            use rayon::iter::ParallelIterator;
+            self.list_mut()
+                .par_iter_mut()
+                .for_each(|component| component.refresh());
         }
 
         #[cfg(not(feature = "multithread"))]
-        self.list_mut().iter().for_each(|component| component.refresh());
+        self.list_mut()
+            .iter_mut()
+            .for_each(|component| component.refresh());
     }
 
     /// The component list will be emptied then completely recomputed.

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,8 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use crate::{
-    ComponentInner, ComponentsInner, CpuInner, NetworkDataInner, NetworksInner, ProcessInner,
-    SystemInner, UserInner,
+    utils::into_iter_mut, ComponentInner, ComponentsInner, CpuInner, NetworkDataInner,
+    NetworksInner, ProcessInner, SystemInner, UserInner,
 };
 
 use std::cmp::Ordering;
@@ -3823,18 +3823,8 @@ impl Components {
     /// ```
     pub fn refresh(&mut self) {
         #[cfg(feature = "multithread")]
-        {
-            use rayon::iter::IntoParallelRefMutIterator;
-            use rayon::iter::ParallelIterator;
-            self.list_mut()
-                .par_iter_mut()
-                .for_each(|component| component.refresh());
-        }
-
-        #[cfg(not(feature = "multithread"))]
-        self.list_mut()
-            .iter_mut()
-            .for_each(|component| component.refresh());
+        use rayon::iter::ParallelIterator;
+        into_iter_mut(self.list_mut()).for_each(|component| component.refresh());
     }
 
     /// The component list will be emptied then completely recomputed.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ mod common;
 mod debug;
 #[cfg(feature = "serde")]
 mod serde;
-mod utils;
+pub(crate) mod utils;
 
 /// This function is only used on Linux targets, on the other platforms it does nothing and returns
 /// `false`.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -22,6 +22,7 @@ where
     feature = "unknown-ci",
     all(target_os = "macos", feature = "apple-sandbox")
 ))]
+#[allow(dead_code)]
 pub(crate) fn into_iter<T>(val: T) -> T::IntoIter
 where
     T: IntoIterator,
@@ -42,7 +43,7 @@ pub(crate) fn into_iter_mut<'a, T>(
 where
     T: rayon::iter::IntoParallelRefMutIterator<'a> + ?Sized,
 {
-    return val.par_iter_mut();
+    val.par_iter_mut()
 }
 
 /// Converts the value into a sequential mutable iterator if the `multithread` feature is disabled.
@@ -56,5 +57,5 @@ pub(crate) fn into_iter_mut<T>(val: T) -> T::IntoIter
 where
     T: IntoIterator,
 {
-    return val.into_iter();
+    val.into_iter()
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,15 +1,13 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-/// Converts the value into a parallel iterator (if the multi-thread feature is enabled).
+/// Converts the value into a parallel iterator if the `multithread` feature is enabled.
 /// Uses the `rayon::iter::IntoParallelIterator` trait.
 #[cfg(all(
-    all(
-        any(target_os = "macos", target_os = "windows", target_os = "freebsd",),
-        feature = "multithread"
-    ),
+    feature = "multithread",
+    not(feature = "unknown-ci"),
     not(all(target_os = "macos", feature = "apple-sandbox")),
-    not(feature = "unknown-ci")
 ))]
+#[allow(dead_code)]
 pub(crate) fn into_iter<T>(val: T) -> T::Iter
 where
     T: rayon::iter::IntoParallelIterator,
@@ -17,19 +15,46 @@ where
     val.into_par_iter()
 }
 
-/// Converts the value into a sequential iterator (if the multithread feature is disabled).
+/// Converts the value into a sequential iterator if the `multithread` feature is disabled.
 /// Uses the `std::iter::IntoIterator` trait.
-#[cfg(all(
-    all(
-        any(target_os = "macos", target_os = "windows", target_os = "freebsd",),
-        not(feature = "multithread")
-    ),
-    not(feature = "unknown-ci"),
-    not(all(target_os = "macos", feature = "apple-sandbox"))
+#[cfg(any(
+    not(feature = "multithread"),
+    feature = "unknown-ci",
+    all(target_os = "macos", feature = "apple-sandbox")
 ))]
 pub(crate) fn into_iter<T>(val: T) -> T::IntoIter
 where
     T: IntoIterator,
 {
     val.into_iter()
+}
+
+/// Converts the value into a parallel mutable iterator if the `multithread` feature is enabled.
+/// Uses the `rayon::iter::IntoParallelRefMutIterator` trait.
+#[cfg(all(
+    feature = "multithread",
+    not(feature = "unknown-ci"),
+    not(all(target_os = "macos", feature = "apple-sandbox")),
+))]
+pub(crate) fn into_iter_mut<'a, T>(
+    val: &'a mut T,
+) -> <T as rayon::iter::IntoParallelRefMutIterator<'a>>::Iter
+where
+    T: rayon::iter::IntoParallelRefMutIterator<'a> + ?Sized,
+{
+    return val.par_iter_mut();
+}
+
+/// Converts the value into a sequential mutable iterator if the `multithread` feature is disabled.
+/// Uses the `std::iter::IntoIterator` trait.
+#[cfg(any(
+    not(feature = "multithread"),
+    feature = "unknown-ci",
+    all(target_os = "macos", feature = "apple-sandbox")
+))]
+pub(crate) fn into_iter_mut<T>(val: T) -> T::IntoIter
+where
+    T: IntoIterator,
+{
+    return val.into_iter();
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -46,6 +46,10 @@ where
     val.par_iter_mut()
 }
 
+// In the multithreaded version of `into_iter_mut` above, the `&mut` on the argument is indicating
+// the parallel iterator is an exclusive reference. In the non-multithreaded case, the `&mut` is
+// already part of `T` and specifying it will result in the argument being `&mut &mut T`.
+
 /// Converts the value into a sequential mutable iterator if the `multithread` feature is disabled.
 /// Uses the `std::iter::IntoIterator` trait.
 #[cfg(any(


### PR DESCRIPTION
This PR causes the bench_refresh_components benchmark to go from 1,517,282 ns/iter to 142,299 ns/iter when the "multithread" feature is enabled, which it is on by default. This massive improvement in speed is because reading from the `/sys/class/hwmon/` files in Linux can be slow. In particular reading the CPU and chipset temperatures were taking about 60 ms each on my system.
