### PR TITLE
fix: make processes also update if their parent changes

### DIFF
--- a/src/unix/apple/macos/process.rs
+++ b/src/unix/apple/macos/process.rs
@@ -636,7 +636,7 @@ pub(crate) fn update_process(
             let p = &mut p.inner;
 
             if let Some(info) = get_bsd_info(pid) {
-                if info.pbi_start_tvsec != p.start_time {
+                if info.pbi_start_tvsec != p.start_time || (info.pbi_ppid != 0 && p.parent.map_or(false, |f| f.0 as u32 != info.pbi_ppid)) {
                     // We don't it to be removed, just replaced.
                     p.updated = true;
                     // The owner of this PID changed.


### PR DESCRIPTION
When a process dies, there is no way in your crate to note that the process' PPID is updated. This happens because even if you ask to update "everything", the condition for updating the process requires the process's start time differs and does not take into account if the PPID has changed through the lifetime of the process.

This is relevant for example if you want to use this crate to monitor orphaned processes.