### PR TITLE
Mitigate `cpu_usage()` from returning NaN on Macs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,6 +454,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::const_is_empty)]
     fn check_nb_supported_signals() {
         if IS_SUPPORTED_SYSTEM {
             assert!(

--- a/src/unix/apple/cpu.rs
+++ b/src/unix/apple/cpu.rs
@@ -38,8 +38,7 @@ impl CpusWrapper {
     pub(crate) fn refresh(&mut self, refresh_kind: CpuRefreshKind, port: mach_port_t) {
         let need_cpu_usage_update = self
             .last_update
-            .map(|last_update| last_update.elapsed() > crate::MINIMUM_CPU_UPDATE_INTERVAL)
-            .unwrap_or(true);
+            .is_some_and(|last_update| last_update.elapsed() > crate::MINIMUM_CPU_UPDATE_INTERVAL);
 
         let cpus = &mut self.cpus;
         if cpus.is_empty() {

--- a/tests/cpu.rs
+++ b/tests/cpu.rs
@@ -47,3 +47,18 @@ fn test_global_cpu_info_not_set() {
     assert_eq!(s.global_cpu_info().brand(), "");
     assert_eq!(s.global_cpu_info().frequency(), 0);
 }
+
+#[test]
+fn test_too_rapid_cpu_refresh() {
+    let mut s = sysinfo::System::new();
+    assert!(s.cpus().is_empty());
+
+    if !sysinfo::IS_SUPPORTED_SYSTEM {
+        return;
+    }
+
+    s.refresh_cpu();
+    s.refresh_cpu();
+
+    assert!(s.cpus().iter().any(|c| !c.cpu_usage().is_nan()));
+}


### PR DESCRIPTION

**Describe the bug**

Using the current latest checkout of this repo (or any 0.30.x version) on a Mac can result in `cpu.cpu_usage()` reporting a `NaN`. This is primarily caused by this code:

https://github.com/GuillaumeGomez/sysinfo/blob/b7d7f317bad003cd6053a967c668d524ab84b0b0/src/unix/apple/cpu.rs#L239-L244

If `refresh_cpu()` is called in rapid succession the collected data can be the same, resulting in `total` being 0, since `in_use` is divided by `total`, this creates a divide by zero situation and can return a NaN.

It can be worked around by waiting `sysinfo::MINIMUM_CPU_UPDATE_INTERVAL` between calls to `refresh_cpu()`, as the data will (hopefully) no longer be the same.

Some platforms, such as Linux, do this interval check internally: https://github.com/GuillaumeGomez/sysinfo/blob/b7d7f317bad003cd6053a967c668d524ab84b0b0/src/unix/linux/cpu.rs#L83-L85

This PR takes the same strategy as Linux and enforces an interval internally.

I can confirm that as a result of this change, `cargo test` passess successfully on my aarch64 Mac.

**To Reproduce**

> I used a aarch64 Mac, but it should be reproducable on any Mac. It was also observed on during local Rust builds with `build.metrics` enabled.

In order to reproduce this outside of the Rust repo, I did a bit of light refactoring of `compute_usage_of_cpu`:

```rust
// src/unix/apple/cpu.rs
pub(crate) fn compute_usage_of_cpu(proc_: &Cpu, cpu_info: *mut i32, offset: isize) -> f32 {
    let old_cpu_info = proc_.inner.data().cpu_info.0;
    let in_use;
    let total;

    // In case we are initializing cpus, there is no "old value" yet.
    if old_cpu_info == cpu_info {
        in_use = get_in_use(cpu_info, offset);
        eprintln !("in_use {in_use}");
        let idle = get_idle(cpu_info, offset);
        total = in_use.saturating_add(idle as _);
    } else {
        in_use = get_in_use(cpu_info, offset).saturating_sub(get_in_use(old_cpu_info, offset));
        eprintln !("in_use {in_use}");
        let idle = get_idle(cpu_info, offset);
        let old_idle = get_idle(old_cpu_info, offset);
        eprintln!("idle {idle}, old_idle {old_idle}");
        total = in_use.saturating_add(
            idle.saturating_sub(old_idle) as _,
        );
    }
    eprintln !("total {total}");
    in_use as f32 / total as f32 * 100.
}
```

Then I updated the the `test_cpu` test to rapidly call `refresh_cpu()` twice, and assert that none of the usage was `NaN`:

```rust
// tests/cpu.rs
#[test]
fn test_cpu() {
    let mut s = sysinfo::System::new();
    assert!(s.cpus().is_empty());

    if !sysinfo::IS_SUPPORTED_SYSTEM {
        return;
    }

    s.refresh_cpu();
    assert!(!s.cpus().is_empty());
    // std::thread::sleep(std::time::Duration::from_millis(200));
    s.refresh_cpu();

    assert!(s.cpus().iter().any(|c| !c.cpu_usage().is_nan()));

    let mut s = sysinfo::System::new_all();
    assert!(!s.cpus().is_empty());

    assert!(!s.cpus()[0].brand().chars().any(|c| c == '\0'));

    if !cfg!(target_os = "freebsd") {
        // This information is currently not retrieved on freebsd...
        assert!(s.cpus().iter().any(|c| !c.brand().is_empty()));
    }
    assert!(s.cpus().iter().any(|c| !c.vendor_id().is_empty()));
}
```

With that done, I was able to reproduce the issue via `cargo test test_cpu -- --nocapture`:

```bash
~/git/GuillameGomez/sysinfo> cargo test test_cpu -- --nocapture
# snipped

     Running tests/cpu.rs (target/debug/deps/cpu-02526d4c3ab91678)

running 1 test
in_use 5690012
total 24318088
in_use 5149645
total 24419660
in_use 3795005
total 24553864
in_use 2914872
total 24646964
in_use 2465127
total 24707921
in_use 2097229
total 24736675
in_use 878747
total 24836498
in_use 882113
total 24842076
in_use 874508
total 24843371
in_use 883108
total 24843382
in_use 886023
total 24844247
in_use 870234
total 24845131
in_use 0
idle 18628076, old_idle 18628076
total 0
in_use 0
idle 19270015, old_idle 19270015
total 0
in_use 0
idle 20758859, old_idle 20758859
total 0
in_use 0
idle 21732092, old_idle 21732092
total 0
in_use 0
idle 22242794, old_idle 22242794
total 0
in_use 0
idle 22639446, old_idle 22639446
total 0
in_use 0
idle 23957751, old_idle 23957751
total 0
in_use 0
idle 23959963, old_idle 23959963
total 0
in_use 0
idle 23968863, old_idle 23968863
total 0
in_use 0
idle 23960274, old_idle 23960274
total 0
in_use 0
idle 23958224, old_idle 23958224
total 0
in_use 0
idle 23974897, old_idle 23974897
total 0
thread 'test_cpu' panicked at tests/cpu.rs:19:5:
assertion failed: s.cpus().iter().any(|c| !c.cpu_usage().is_nan())
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test test_cpu ... FAILED

failures:

failures:
    test_cpu
```

I confirmed that adding the delay resolves the issue.