### PR TITLE
is_dir/is_file small improvements

### DIFF
--- a/src/unix/linux/component.rs
+++ b/src/unix/linux/component.rs
@@ -240,9 +240,16 @@ impl ComponentInner {
         let dir = read_dir(folder).ok()?;
         let mut matchings: HashMap<u32, Component> = HashMap::with_capacity(10);
         for entry in dir.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_dir() {
+                continue;
+            }
+
             let entry = entry.path();
             let filename = entry.file_name().and_then(|x| x.to_str()).unwrap_or("");
-            if entry.is_dir() || !filename.starts_with("temp") {
+            if !filename.starts_with("temp") {
                 continue;
             }
 
@@ -363,8 +370,11 @@ impl ComponentsInner {
         self.components.clear();
         if let Ok(dir) = read_dir(Path::new("/sys/class/hwmon/")) {
             for entry in dir.flatten() {
+                let Ok(file_type) = entry.file_type() else {
+                    continue;
+                };
                 let entry = entry.path();
-                if !entry.is_dir()
+                if !file_type.is_dir()
                     || !entry
                         .file_name()
                         .and_then(|x| x.to_str())

--- a/src/unix/linux/process.rs
+++ b/src/unix/linux/process.rs
@@ -651,6 +651,13 @@ fn get_all_pid_entries(
     entry: DirEntry,
     data: &mut Vec<ProcAndTasks>,
 ) -> Option<Pid> {
+    let Ok(file_type) = entry.file_type() else {
+        return None;
+    };
+    if !file_type.is_dir() {
+        return None;
+    }
+
     let entry = entry.path();
     let name = entry.file_name();
 
@@ -659,26 +666,23 @@ fn get_all_pid_entries(
         return None;
     }
     let name = name?;
-    if !entry.is_dir() {
-        return None;
-    }
     let pid = Pid::from(usize::from_str(name.to_str()?).ok()?);
 
     let tasks_dir = Path::join(&entry, "task");
-    let tasks = if tasks_dir.is_dir() {
+
+    let tasks = if let Ok(entries) = fs::read_dir(tasks_dir) {
         let mut tasks = HashSet::new();
-        if let Ok(entries) = fs::read_dir(tasks_dir) {
-            for task in entries
-                .into_iter()
-                .filter_map(|entry| get_all_pid_entries(Some(name), Some(pid), entry.ok()?, data))
-            {
-                tasks.insert(task);
-            }
+        for task in entries
+            .into_iter()
+            .filter_map(|entry| get_all_pid_entries(Some(name), Some(pid), entry.ok()?, data))
+        {
+            tasks.insert(task);
         }
         Some(tasks)
     } else {
         None
     };
+
     data.push(ProcAndTasks {
         pid,
         parent_pid,

--- a/tests/code_checkers/utils.rs
+++ b/tests/code_checkers/utils.rs
@@ -25,8 +25,9 @@ pub fn read_dirs<P: AsRef<Path>, F: FnMut(&Path, &str)>(dirs: &[P], callback: &m
 fn read_dir<P: AsRef<Path>, F: FnMut(&Path, &str)>(dir: P, callback: &mut F) {
     for entry in fs::read_dir(dir).expect("read_dir failed") {
         let entry = entry.expect("entry failed");
+        let file_type = entry.file_type().expect("file_type failed");
         let path = entry.path();
-        if path.is_dir() {
+        if file_type.is_dir() {
             read_dir(path, callback);
         } else if path
             .extension()


### PR DESCRIPTION
- reads file entry type instead using is_file/is_dir
- file type is checked now at the top of function to avoid unnecessary computations like `path = entry.path()`

changes are visible in flamegraph(probably no big gains, but at least helped a little in my project)

![Screenshot from 2024-04-07 14-19-11](https://github.com/GuillaumeGomez/sysinfo/assets/41945903/e63e7777-64cd-47ab-8496-dd90baab6ce1)

![Screenshot from 2024-04-07 14-52-53](https://github.com/GuillaumeGomez/sysinfo/assets/41945903/cba29d14-439c-499c-b9eb-972afc93d356)
