### PR TITLE
/sys/class/hwmon* are not directories, they are symbolic links 

### DIFF
--- a/src/unix/linux/component.rs
+++ b/src/unix/linux/component.rs
@@ -374,16 +374,15 @@ impl ComponentsInner {
                     continue;
                 };
                 let entry = entry.path();
-                if !file_type.is_dir()
-                    || !entry
+                if !file_type.is_file()
+                    && entry
                         .file_name()
                         .and_then(|x| x.to_str())
                         .unwrap_or("")
                         .starts_with("hwmon")
                 {
-                    continue;
+                    ComponentInner::from_hwmon(&mut self.components, &entry);
                 }
-                ComponentInner::from_hwmon(&mut self.components, &entry);
             }
         }
     }


### PR DESCRIPTION
Checking to see if `/sys/class/hwmon*` is a directory fails because it is a symbol link to a directory.

Fixes #1245