### PR TITLE
fix: cargo clippy warning and error

### DIFF
--- a/src/c_interface.rs
+++ b/src/c_interface.rs
@@ -352,11 +352,7 @@ pub extern "C" fn sysinfo_processes(
             let len = {
                 let entries = system.processes();
                 for (pid, process) in entries {
-                    if !fn_pointer(
-                        pid.0 as _,
-                        process as *const Process as CProcess,
-                        data,
-                    ) {
+                    if !fn_pointer(pid.0 as _, process as *const Process as CProcess, data) {
                         break;
                     }
                 }

--- a/src/c_interface.rs
+++ b/src/c_interface.rs
@@ -108,7 +108,7 @@ pub extern "C" fn sysinfo_refresh_process(system: CSystem, pid: PID) {
         let mut system: Box<System> = Box::from_raw(system as *mut System);
         {
             let system: &mut System = system.borrow_mut();
-            system.refresh_process(Pid(pid.try_into().unwrap()));
+            system.refresh_process(Pid(pid as _));
         }
         Box::into_raw(system);
     }
@@ -353,7 +353,7 @@ pub extern "C" fn sysinfo_processes(
                 let entries = system.processes();
                 for (pid, process) in entries {
                     if !fn_pointer(
-                        pid.0.try_into().unwrap(),
+                        pid.0 as _,
                         process as *const Process as CProcess,
                         data,
                     ) {
@@ -381,7 +381,7 @@ pub extern "C" fn sysinfo_process_by_pid(system: CSystem, pid: PID) -> CProcess 
     assert!(!system.is_null());
     unsafe {
         let system: Box<System> = Box::from_raw(system as *mut System);
-        let ret = if let Some(process) = system.process(Pid(pid.try_into().unwrap())) {
+        let ret = if let Some(process) = system.process(Pid(pid as _)) {
             process as *const Process as CProcess
         } else {
             std::ptr::null()
@@ -408,7 +408,7 @@ pub extern "C" fn sysinfo_process_tasks(
             let process = process as *const Process;
             if let Some(tasks) = (*process).tasks() {
                 for pid in tasks {
-                    if !fn_pointer(pid.0.try_into().unwrap(), data) {
+                    if !fn_pointer(pid.0 as _, data) {
                         break;
                     }
                 }
@@ -427,7 +427,7 @@ pub extern "C" fn sysinfo_process_tasks(
 pub extern "C" fn sysinfo_process_pid(process: CProcess) -> PID {
     assert!(!process.is_null());
     let process = process as *const Process;
-    unsafe { (*process).pid().0.try_into().unwrap() }
+    unsafe { (*process).pid().0 as _ }
 }
 
 /// Equivalent of [`Process::parent()`][crate::Process#method.parent].
@@ -437,7 +437,7 @@ pub extern "C" fn sysinfo_process_pid(process: CProcess) -> PID {
 pub extern "C" fn sysinfo_process_parent_pid(process: CProcess) -> PID {
     assert!(!process.is_null());
     let process = process as *const Process;
-    unsafe { (*process).parent().unwrap_or(Pid(0)).0.try_into().unwrap() }
+    unsafe { (*process).parent().unwrap_or(Pid(0)).0 as _ }
 }
 
 /// Equivalent of [`Process::cpu_usage()`][crate::Process#method.cpu_usage].


### PR DESCRIPTION
clippy tips:
```
error[E0308]: mismatched types
   --> src/c_interface.rs:436:14
    |
433 | pub extern "C" fn sysinfo_process_parent_pid(process: CProcess) -> PID {
    |                                                                    --- expected `i32` because of return type
...
436 |     unsafe { (*process).parent().unwrap_or(Pid(0)).0 }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `i32`, found `usize`
    |
help: you can convert a `usize` to an `i32` and panic if the converted value doesn't fit
    |
436 |     unsafe { (*process).parent().unwrap_or(Pid(0)).0.try_into().unwrap() }
    |                                                     ++++++++++++++++++++

For more information about this error, try `rustc --explain E0308`.

```

and :
```
warning: returning the result of a `let` binding from a block
   --> src/c_interface.rs:638:5
    |
633 | /     let c_string = if let Some(c) = System::long_os_version().and_then(|c| CString::new(c).ok()) {
634 | |         c.into_raw() as _
635 | |     } else {
636 | |         std::ptr::null()
637 | |     };
    | |______- unnecessary `let` binding
638 |       c_string
    |       ^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#let_and_return
    = note: `#[warn(clippy::let_and_return)]` on by default
help: return the expression directly
    |
633 ~     
634 ~     if let Some(c) = System::long_os_version().and_then(|c| CString::new(c).ok()) {
635 +         c.into_raw() as _
636 +     } else {
637 +         std::ptr::null()
638 +     }
    |
```