### PR TITLE
Fix minor typo in doc comment

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -823,7 +823,7 @@ impl System {
     /// ```no_run
     /// use sysinfo::System;
     ///
-    /// println!("CPU Archicture: {:?}", System::cpu_arch());
+    /// println!("CPU Architecture: {:?}", System::cpu_arch());
     /// ```
     pub fn cpu_arch() -> Option<String> {
         SystemInner::cpu_arch()


### PR DESCRIPTION
This pull request fixes a minor typo (Archicture → Architecture).