### PR TITLE
Adopt windows version range >=0.54, <=0.57

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ serde = { version = "^1.0.190", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 ntapi = "0.4"
-windows = { version = "0.56", features = [
+windows = { version = ">=0.54, <=0.57", features = [
     "Win32_Foundation",
     "Win32_NetworkManagement_IpHelper",
     "Win32_NetworkManagement_NetManagement",


### PR DESCRIPTION
`windows` is a "heavy" crate. Duplicate `windows` versions in a tree can add precious seconds to compile times (or even _minutes_ by some Bevy user reports). On the Bevy side, we are trying to ensure that `windows` is only compiled once. We also believe it is in the ecosystem's best interest (and in the interest of crate owners that consume `windows`) to align their versioning with the rest of ecosystem. Therefore, I would like to encourage crate owners to adopt the following approach to `windows` crate usage:

1. Adopt "range versioning" for windows instead of locking to a specific version.
2. Before adding a new version to the range, test that each previous version in the range still compiles.
3. Only remove old versions from the range when _absolutely necessary_. Try your hardest to ensure that your version support aligns with other ecosystem crates.

We've picked 0.54 as a baseline because breaking API changes were made to use Rust Results instead of HRESULT.

I have personally tested that sysinfo compiles with 0.54, 0.56 (0.55 does not exist), and 0.57.