### PR TITLE
Add support for cgroup memory.stat

### DIFF
--- a/src/common/system.rs
+++ b/src/common/system.rs
@@ -987,6 +987,8 @@ pub struct CGroupLimits {
     pub free_memory: u64,
     /// Free swap (in bytes) for the current cgroup.
     pub free_swap: u64,
+    /// Resident Set Size (RSS) (in bytes) for the current cgroup.
+    pub rss: u64
 }
 
 /// Type containing read and written bytes.

--- a/src/common/system.rs
+++ b/src/common/system.rs
@@ -988,7 +988,7 @@ pub struct CGroupLimits {
     /// Free swap (in bytes) for the current cgroup.
     pub free_swap: u64,
     /// Resident Set Size (RSS) (in bytes) for the current cgroup.
-    pub rss: u64
+    pub rss: u64,
 }
 
 /// Type containing read and written bytes.

--- a/src/unix/linux/system.rs
+++ b/src/unix/linux/system.rs
@@ -587,13 +587,13 @@ fn read_table_key(filename: &str, target_key: &str, colsep: char) -> Option<u64>
             .find_map(|line| {
                 let mut split = line.split(colsep);
                 let key = split.next()?;
-                if key == target_key {
-                    let value = split.next()?;
-                    let value0 = value.trim_start().split(' ').next()?;
-                    return u64::from_str(value0).ok();
+                if key != target_key {
+                    return None;
                 }
 
-                None
+                let value = split.next()?;
+                let value0 = value.trim_start().split(' ').next()?;
+                u64::from_str(value0).ok()
             });
     }
 

--- a/src/unix/linux/system.rs
+++ b/src/unix/linux/system.rs
@@ -747,6 +747,7 @@ mod test {
     #[cfg(not(target_os = "android"))]
     use super::get_system_info_linux;
     use super::InfoType;
+    use super::read_table;
     use super::read_table_key;
     use std::io::Write;
     use tempfile::NamedTempFile;

--- a/src/unix/linux/system.rs
+++ b/src/unix/linux/system.rs
@@ -580,10 +580,7 @@ where
     }
 }
 
-fn read_table_key<F>(filename: &str, target_key: &str, colsep: char) -> Option<u64>
-where
-    F: FnMut(&str, u64),
-{
+fn read_table_key(filename: &str, target_key: &str, colsep: char) -> Option<u64> {
     if let Ok(content) = get_all_utf8_data(filename, 16_635) {
         return content
             .split('\n')

--- a/src/unix/linux/system.rs
+++ b/src/unix/linux/system.rs
@@ -749,6 +749,7 @@ mod test {
     use super::InfoType;
     use super::read_table;
     use super::read_table_key;
+    use std::collections::HashMap;
     use std::io::Write;
     use tempfile::NamedTempFile;
 

--- a/src/unix/linux/system.rs
+++ b/src/unix/linux/system.rs
@@ -631,7 +631,7 @@ impl crate::CGroupLimits {
             // cgroups v1
             read_u64("/sys/fs/cgroup/memory/memory.usage_in_bytes"),
             read_u64("/sys/fs/cgroup/memory/memory.limit_in_bytes"),
-            read_table_key("/sys/fs/cgroup/memory/memory.stat", "rss", ' ')
+            read_table_key("/sys/fs/cgroup/memory/memory.stat", "total_rss", ' ')
         ) {
             let mut limits = Self {
                 total_memory: sys.mem_total,

--- a/src/unix/linux/system.rs
+++ b/src/unix/linux/system.rs
@@ -580,7 +580,7 @@ where
     }
 }
 
-fn read_table_key<F>(filename: &str, target_key: &str, colsep: char, mut f: F) -> Option<u64>
+fn read_table_key<F>(filename: &str, target_key: &str, colsep: char) -> Option<u64>
 where
     F: FnMut(&str, u64),
 {
@@ -613,7 +613,7 @@ impl crate::CGroupLimits {
             // cgroups v2
             read_u64("/sys/fs/cgroup/memory.current"),
             read_u64("/sys/fs/cgroup/memory.max"),
-            read_table_key("/sys/fs/cgroup/memory.stat", "anon"," ")
+            read_table_key("/sys/fs/cgroup/memory.stat", "anon",' ')
         ) {
             let mut limits = Self {
                 total_memory: sys.mem_total,
@@ -634,7 +634,7 @@ impl crate::CGroupLimits {
             // cgroups v1
             read_u64("/sys/fs/cgroup/memory/memory.usage_in_bytes"),
             read_u64("/sys/fs/cgroup/memory/memory.limit_in_bytes"),
-            read_table_key("/sys/fs/cgroup/memory/memory.stat", "rss"," ")
+            read_table_key("/sys/fs/cgroup/memory/memory.stat", "rss",' ')
         ) {
             let mut limits = Self {
                 total_memory: sys.mem_total,

--- a/src/unix/linux/system.rs
+++ b/src/unix/linux/system.rs
@@ -613,7 +613,7 @@ impl crate::CGroupLimits {
             // cgroups v2
             read_u64("/sys/fs/cgroup/memory.current"),
             read_u64("/sys/fs/cgroup/memory.max"),
-            read_table_key("/sys/fs/cgroup/memory.stat", "anon",' ')
+            read_table_key("/sys/fs/cgroup/memory.stat", "anon", ' ')
         ) {
             let mut limits = Self {
                 total_memory: sys.mem_total,
@@ -634,7 +634,7 @@ impl crate::CGroupLimits {
             // cgroups v1
             read_u64("/sys/fs/cgroup/memory/memory.usage_in_bytes"),
             read_u64("/sys/fs/cgroup/memory/memory.limit_in_bytes"),
-            read_table_key("/sys/fs/cgroup/memory/memory.stat", "rss",' ')
+            read_table_key("/sys/fs/cgroup/memory/memory.stat", "rss", ' ')
         ) {
             let mut limits = Self {
                 total_memory: sys.mem_total,

--- a/src/unix/linux/system.rs
+++ b/src/unix/linux/system.rs
@@ -628,7 +628,7 @@ impl crate::CGroupLimits {
             }
 
             Some(limits)
-        } else if let (Some(mem_cur), Some(mem_max)) = (
+        } else if let (Some(mem_cur), Some(mem_max), Some(mem_rss)) = (
             // cgroups v1
             read_u64("/sys/fs/cgroup/memory/memory.usage_in_bytes"),
             read_u64("/sys/fs/cgroup/memory/memory.limit_in_bytes"),

--- a/src/unix/linux/system.rs
+++ b/src/unix/linux/system.rs
@@ -585,9 +585,9 @@ where
     F: FnMut(&str, u64),
 {
     if let Ok(content) = get_all_utf8_data(filename, 16_635) {
-        content
+        return content
             .split('\n')
-            .find(|line| {
+            .find_map(|line| {
                 let mut split = line.split(colsep);
                 let key = split.next()?;
                 if key == target_key {
@@ -597,8 +597,10 @@ where
                 }
 
                 None
-            })
+            });
     }
+
+    None
 }
 
 impl crate::CGroupLimits {

--- a/src/unix/linux/system.rs
+++ b/src/unix/linux/system.rs
@@ -754,7 +754,6 @@ mod test {
     use tempfile::NamedTempFile;
 
     #[test]
-    #[cfg(target_os = "linux")]
     fn test_read_table() {
         // Create a temporary file with test content
         let mut file = NamedTempFile::new().unwrap();
@@ -814,7 +813,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(target_os = "linux")]
     fn test_read_table_key() {
         // Create a temporary file with test content
         let mut file = NamedTempFile::new().unwrap();


### PR DESCRIPTION
This PR aims at reading RSS memory information of cgroups via the `memory.stat` file.

The logic of this PR is inspired by the implementation in https://github.com/google/cadvisor/blob/1f17a6cfb8af89df396fe97c97cb5c1ec8ae6a3a/container/libcontainer/handler.go#L808.