### PR TITLE
Add real-time CPU frequency fn on WinOS

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -6,6 +6,7 @@
 
 use std::io::{self, BufRead, Write};
 use std::str::FromStr;
+
 use sysinfo::{Components, Disks, Networks, Pid, Signal, System, Users};
 
 const signals: &[Signal] = &[
@@ -256,6 +257,13 @@ fn interpret_input(
                     cpu.frequency(),
                 );
             }
+        }
+        "rt_freq" => {
+           writeln!(
+               &mut io::stdout(),
+               "cpu realtime frequency: {:.2}GHz",
+               sys.cpu_realtime_freq()
+           );
         }
         "vendor_id" => {
             writeln!(

--- a/src/common/system.rs
+++ b/src/common/system.rs
@@ -449,6 +449,25 @@ impl System {
         self.inner.cpus()
     }
 
+    /// Returns the CPU realtime frequency, GHz
+    /// you should refresh CPU first
+    ///
+    /// ```no_run
+    /// use sysinfo::{CpuRefreshKind, RefreshKind, System};
+    ///
+    /// let mut s = System::new_with_specifics(
+    ///     RefreshKind::new().with_cpu(CpuRefreshKind::everything()),
+    /// );
+    /// print!("{:.2}GHz", s.cpu_realtime_freq());
+    /// ```
+    pub fn cpu_realtime_freq(&self) -> f64 {
+        match self.inner.cpus().iter().next() {
+            Some(cpu) => self.inner.cpu_realtime_freq() * cpu.frequency() as f64,
+            None => 0.
+        }
+    }
+
+
     /// Returns the number of physical cores on the CPU or `None` if it couldn't get it.
     ///
     /// In case there are multiple CPUs, it will combine the physical core count of all the CPUs.
@@ -2381,8 +2400,9 @@ impl Cpu {
 
 #[cfg(test)]
 mod test {
-    use crate::*;
     use std::str::FromStr;
+
+    use crate::*;
 
     // In case `Process::updated` is misused, `System::refresh_processes` might remove them
     // so this test ensures that it doesn't happen.

--- a/src/unix/apple/system.rs
+++ b/src/unix/apple/system.rs
@@ -1,12 +1,5 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::sys::cpu::*;
-#[cfg(all(target_os = "macos", not(feature = "apple-sandbox")))]
-use crate::sys::process::*;
-use crate::sys::utils::{get_sys_value, get_sys_value_by_name};
-
-use crate::{Cpu, CpuRefreshKind, LoadAvg, MemoryRefreshKind, Pid, Process, ProcessesToUpdate, ProcessRefreshKind};
-
 #[cfg(all(target_os = "macos", not(feature = "apple-sandbox")))]
 use std::cell::UnsafeCell;
 use std::collections::HashMap;
@@ -17,9 +10,15 @@ use std::time::Duration;
 use std::time::SystemTime;
 
 use libc::{
-    c_int, c_void, host_statistics64, mach_port_t, sysconf, sysctl, timeval, vm_statistics64,
-    _SC_PAGESIZE,
+    _SC_PAGESIZE, c_int, c_void, host_statistics64, mach_port_t, sysconf, sysctl, timeval,
+    vm_statistics64,
 };
+
+use crate::{Cpu, CpuRefreshKind, LoadAvg, MemoryRefreshKind, Pid, Process, ProcessesToUpdate, ProcessRefreshKind};
+use crate::sys::cpu::*;
+#[cfg(all(target_os = "macos", not(feature = "apple-sandbox")))]
+use crate::sys::process::*;
+use crate::sys::utils::{get_sys_value, get_sys_value_by_name};
 
 #[cfg(all(target_os = "macos", not(feature = "apple-sandbox")))]
 declare_signals! {
@@ -326,6 +325,10 @@ impl SystemInner {
 
     pub(crate) fn cpus(&self) -> &[Cpu] {
         &self.cpus.cpus
+    }
+
+    pub(crate) fn cpu_realtime_freq(&self) -> f64 {
+        0.
     }
 
     pub(crate) fn physical_core_count(&self) -> Option<usize> {

--- a/src/unix/freebsd/system.rs
+++ b/src/unix/freebsd/system.rs
@@ -1,9 +1,5 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::{
-    Cpu, CpuRefreshKind, LoadAvg, MemoryRefreshKind, Pid, Process, ProcessesToUpdate, ProcessInner, ProcessRefreshKind,
-};
-
 use std::cell::UnsafeCell;
 use std::collections::HashMap;
 use std::ffi::CStr;
@@ -13,14 +9,17 @@ use std::ptr::NonNull;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, SystemTime};
 
-use crate::sys::cpu::{physical_core_count, CpusWrapper};
+use libc::c_int;
+
+use crate::{
+    Cpu, CpuRefreshKind, LoadAvg, MemoryRefreshKind, Pid, Process, ProcessesToUpdate, ProcessInner, ProcessRefreshKind,
+};
+use crate::sys::cpu::{CpusWrapper, physical_core_count};
 use crate::sys::process::get_exe;
 use crate::sys::utils::{
     self, boot_time, c_buf_to_os_string, c_buf_to_utf8_string, from_cstr_array, get_sys_value,
     get_sys_value_by_name, init_mib,
 };
-
-use libc::c_int;
 
 declare_signals! {
     c_int,
@@ -141,6 +140,10 @@ impl SystemInner {
 
     pub(crate) fn cpus(&self) -> &[Cpu] {
         &self.cpus.cpus
+    }
+
+    pub(crate) fn cpu_realtime_freq(&self) -> f64 {
+        0.
     }
 
     pub(crate) fn physical_core_count(&self) -> Option<usize> {

--- a/src/unknown/system.rs
+++ b/src/unknown/system.rs
@@ -1,9 +1,9 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::{Cpu, CpuRefreshKind, LoadAvg, MemoryRefreshKind, Pid, Process, ProcessesToUpdate, ProcessRefreshKind};
-
 use std::collections::HashMap;
 use std::time::Duration;
+
+use crate::{Cpu, CpuRefreshKind, LoadAvg, MemoryRefreshKind, Pid, Process, ProcessesToUpdate, ProcessRefreshKind};
 
 declare_signals! {
     (),
@@ -62,6 +62,10 @@ impl SystemInner {
 
     pub(crate) fn cpus(&self) -> &[Cpu] {
         &[]
+    }
+
+    pub(crate) fn cpu_realtime_freq(&self) -> f64 {
+        0.
     }
 
     pub(crate) fn physical_core_count(&self) -> Option<usize> {

--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -1,12 +1,5 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::{Cpu, CpuRefreshKind, LoadAvg, MemoryRefreshKind, Pid, ProcessesToUpdate, ProcessRefreshKind};
-
-use crate::sys::cpu::*;
-use crate::{Process, ProcessInner};
-
-use crate::utils::into_iter;
-
 use std::cell::UnsafeCell;
 use std::collections::HashMap;
 use std::ffi::{OsStr, OsString};
@@ -22,7 +15,7 @@ use windows::Wdk::System::SystemInformation::{NtQuerySystemInformation, SystemPr
 use windows::Win32::Foundation::{self, HANDLE, STATUS_INFO_LENGTH_MISMATCH, STILL_ACTIVE};
 use windows::Win32::System::ProcessStatus::{K32GetPerformanceInfo, PERFORMANCE_INFORMATION};
 use windows::Win32::System::Registry::{
-    RegCloseKey, RegOpenKeyExW, RegQueryValueExW, HKEY, HKEY_LOCAL_MACHINE, KEY_READ, REG_NONE,
+    HKEY, HKEY_LOCAL_MACHINE, KEY_READ, REG_NONE, RegCloseKey, RegOpenKeyExW, RegQueryValueExW,
 };
 use windows::Win32::System::SystemInformation::{self, GetSystemInfo};
 use windows::Win32::System::SystemInformation::{
@@ -30,6 +23,11 @@ use windows::Win32::System::SystemInformation::{
     MEMORYSTATUSEX, SYSTEM_INFO,
 };
 use windows::Win32::System::Threading::GetExitCodeProcess;
+
+use crate::{Cpu, CpuRefreshKind, LoadAvg, MemoryRefreshKind, Pid, ProcessesToUpdate, ProcessRefreshKind};
+use crate::{Process, ProcessInner};
+use crate::sys::cpu::*;
+use crate::utils::into_iter;
 
 declare_signals! {
     (),
@@ -360,6 +358,10 @@ impl SystemInner {
 
     pub(crate) fn cpus(&self) -> &[Cpu] {
         self.cpus.cpus()
+    }
+
+    pub(crate) fn cpu_realtime_freq(&self) -> f64 {
+        get_realtime_freq()
     }
 
     pub(crate) fn physical_core_count(&self) -> Option<usize> {

--- a/tests/cpu.rs
+++ b/tests/cpu.rs
@@ -51,3 +51,14 @@ fn test_too_rapid_cpu_refresh() {
 
     assert!(s.cpus().iter().any(|c| !c.cpu_usage().is_nan()));
 }
+
+#[test]
+fn test_cpu_realtime_freq() {
+    use sysinfo::{CpuRefreshKind, RefreshKind, System};
+    let s = System::new_with_specifics(
+        RefreshKind::new().with_cpu(CpuRefreshKind::everything()),
+    );
+    let freq = s.cpu_realtime_freq();
+    print!("{:.2}GHz", freq);
+    assert!(freq.is_sign_positive());
+}


### PR DESCRIPTION
Adds a function to return the CPU's real-time frequency on Windows OS.

![Screenshot 2024-08-03 225824](https://github.com/user-attachments/assets/f6500e03-8dc0-4b6d-94f6-32848bf5cd68)
I added function to the library that return the CPU's actual operating frequency. This returns a CPU speed value similar to that found in Windows Task Manager.

I implemented and tested this feature only on the Windows OS platform.

As a beginner and a graduate who just started to work, I hope my PR can receive your reply. It would be my pleasure if my work could help you and other contributors.（Jetbrains' Rust Rover IDE optimizes imports automatically, which hopefully won't bother you.）