### PR TITLE
Update to windows 0.58

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,9 +97,7 @@ serde = { version = "^1.0.190", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 ntapi = { version = "0.4", optional = true }
-# Support a range of versions in order to avoid duplication of this crate. Make sure to test all
-# versions when bumping to a new release, and only increase the minimum when absolutely necessary.
-windows = { version = ">=0.54, <=0.57", optional = true }
+windows = { version = "0.58", optional = true }
 
 [target.'cfg(not(any(target_os = "unknown", target_arch = "wasm32")))'.dependencies]
 libc = "^0.2.153"

--- a/src/windows/sid.rs
+++ b/src/windows/sid.rs
@@ -3,10 +3,10 @@
 use std::{fmt::Display, str::FromStr};
 
 use windows::core::{PCWSTR, PWSTR};
-use windows::Win32::Foundation::{LocalFree, ERROR_INSUFFICIENT_BUFFER, HLOCAL, PSID};
+use windows::Win32::Foundation::{LocalFree, ERROR_INSUFFICIENT_BUFFER, HLOCAL};
 use windows::Win32::Security::Authorization::{ConvertSidToStringSidW, ConvertStringSidToSidW};
 use windows::Win32::Security::{
-    CopySid, GetLengthSid, IsValidSid, LookupAccountSidW, SidTypeUnknown,
+    CopySid, GetLengthSid, IsValidSid, LookupAccountSidW, SidTypeUnknown, PSID
 };
 
 use crate::sys::utils::to_utf8_str;


### PR DESCRIPTION
Not the cleanest upgrade but some smaller things have changed in windows-rs that are backwards incompatible (HANDLE is now *const c_void rather then isize so we can't hide the query in there anymore, and PSID changed namespace).