### PR TITLE
feat(win): process.kill / kill_with - add /t to kill tree (inc child …

### DIFF
--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -326,7 +326,7 @@ impl ProcessInner {
     pub(crate) fn kill_with(&self, signal: Signal) -> Option<bool> {
         crate::sys::system::convert_signal(signal)?;
         let mut kill = process::Command::new("taskkill.exe");
-        kill.arg("/PID").arg(self.pid.to_string()).arg("/F");
+        kill.arg("/PID").arg(self.pid.to_string()).arg("/F").arg("/T");
         kill.creation_flags(CREATE_NO_WINDOW.0);
         match kill.output() {
             Ok(o) => Some(o.status.success()),


### PR DESCRIPTION
…processes)

See related thread https://github.com/pact-foundation/pact-plugins/issues/73#issuecomment-2302556324

We use sysinfo to kill child processes (plugins invoked from our framework written in rust), across platforms.

plugins on windows may use a batch script to invoke the plugin (my case in reference was a java project). When using this project and `process.kill`, only the parent process is removed, and not any child processes invoked from the batch script

Taskkill has an option `/t`


> /t   : Specifies to terminate all child processes along with the parent process, commonly known as a tree kill.


https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-xp/bb491009(v=technet.10)?redirectedfrom=MSDN

Passing this flag, allows child processes to also be killed and doesn't appear to have any detrimental effect on existing behaviour (if there are no child processes)