### PR TITLE
Wrap Apple disk refreshing in autorelease pool to avoid system caching

### DIFF
--- a/src/unix/apple/ffi.rs
+++ b/src/unix/apple/ffi.rs
@@ -13,6 +13,7 @@ cfg_if! {
             array::CFArrayRef, dictionary::CFDictionaryRef, error::CFErrorRef, string::CFStringRef,
             url::CFURLRef,
         };
+        use std::ffi::c_void;
 
         #[link(name = "CoreFoundation", kind = "framework")]
         extern "C" {
@@ -31,6 +32,12 @@ cfg_if! {
             pub static kCFURLVolumeIsLocalKey: CFStringRef;
             pub static kCFURLVolumeIsInternalKey: CFStringRef;
             pub static kCFURLVolumeIsBrowsableKey: CFStringRef;
+        }
+
+        #[link(name = "objc", kind = "dylib")]
+        extern "C" {
+            pub fn objc_autoreleasePoolPop(pool: *mut c_void);
+            pub fn objc_autoreleasePoolPush() -> *mut c_void;
         }
     }
 }


### PR DESCRIPTION
This PR implements a solution for #1282 by adding an Objective-C autorelease pool around the `CoreFoundation` FFI calls `sysinfo` uses to obtain disk information. This was chosen over a tempoary thread because spawning a thread is a much heavier operation (shared memory, stack allocations, etc). It also seems better then a worker thread because longer-lived apps that don't call this operation much might not want an extra thread living forever. In addition to all these approaches, if people are using `sysinfo` code in a traditional cocoa app then this thread would be extra pointless as the built-in runloops would be clearing autorelease'd values out already.

In the future this pool _could_ be moved to a more reusable context to support multiple refreshes before draining, but this is a performance issue and not a correctness one. Therefore, it is left as future work.

Closes #1282