### PR TITLE
fix(win):  user.groupps()  multiple times doesn't return the same output

### DIFF
--- a/src/windows/users.rs
+++ b/src/windows/users.rs
@@ -16,6 +16,8 @@ use windows::Win32::Security::Authentication::Identity::{
     SECURITY_LOGON_SESSION_DATA, SECURITY_LOGON_TYPE,
 };
 
+use super::utils::to_pcwstr;
+
 pub(crate) struct UserInner {
     pub(crate) uid: Uid,
     pub(crate) gid: Gid,
@@ -54,7 +56,8 @@ impl UserInner {
 
     pub(crate) fn groups(&self) -> Vec<Group> {
         if let (Some(c_user_name), true) = (&self.c_user_name, self.is_local) {
-            unsafe { get_groups_for_user(PCWSTR(c_user_name.as_ptr())) }
+            // [this issue](https://github.com/GuillaumeGomez/sysinfo/issues/2222) is fixed.
+            unsafe { get_groups_for_user(to_pcwstr(c_user_name.to_vec())) }
         } else {
             Vec::new()
         }

--- a/src/windows/utils.rs
+++ b/src/windows/utils.rs
@@ -17,6 +17,15 @@ pub(crate) unsafe fn to_utf8_str(p: windows::core::PWSTR) -> String {
     })
 }
 
+#[cfg(any(feature = "user", feature = "system"))]
+pub(crate) unsafe fn to_pcwstr(v: Vec<u16>) -> windows::core::PCWSTR {
+    if v.is_empty() {
+        return windows::core::PCWSTR::null();
+    }
+    let string = String::from_utf16(&v).unwrap_or_default();
+    windows::core::PCWSTR(windows::core::HSTRING::from(&format!("{}\0", string)).as_ptr())
+}
+
 cfg_if! {
     if #[cfg(any(feature = "disk", feature = "system"))] {
         use windows::Win32::Foundation::{CloseHandle, HANDLE};

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -20,14 +20,14 @@ fn test_users() {
         users.refresh_list();
         assert!(users.iter().count() > 0);
         //my first gruoup is Administrator
-        let count = users.first().unwrap().groups().iter().count();
+        let count = users.first().unwrap().groups().iter().len();
         for _ in 1..10 {
             // println!(
             //     "user: {} group:{:?}",
             //     users.first().unwrap().name(),
             //     users.first().unwrap().groups()
             // );
-            assert!(users.first().unwrap().groups().iter().count() == count)
+            assert!(users.first().unwrap().groups().iter().len() == count)
         }
     }
 }

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -1,0 +1,33 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+// This test is used to ensure that the users are not loaded by default.
+
+// users.groupps()  multiple times doesn't return the same output https://github.com/GuillaumeGomez/sysinfo/issues/1233
+// Example:
+// ---- test_users 1 stdout ----
+// user: Administrator group:[Group { inner: GroupInner { id: Gid(0), name: "Administrators" } }]
+// ---- test_users 2 stdout ----
+// user: Administrator group:[]
+// ....
+#[cfg(feature = "user")]
+#[test]
+fn test_users() {
+    use sysinfo::Users;
+
+    if sysinfo::IS_SUPPORTED_SYSTEM {
+        let mut users = Users::new();
+        assert_eq!(users.iter().count(), 0);
+        users.refresh_list();
+        assert!(users.iter().count() > 0);
+        //my first gruoup is Administrator
+        let count = users.first().unwrap().groups().iter().count();
+        for _ in 1..10 {
+            // println!(
+            //     "user: {} group:{:?}",
+            //     users.first().unwrap().name(),
+            //     users.first().unwrap().groups()
+            // );
+            assert!(users.first().unwrap().groups().iter().count() == count)
+        }
+    }
+}


### PR DESCRIPTION
fix:   #1233
pcwstr cannot be directly converted from Vec<u16>,  and direct conversion may cause loss of information. 