### PR TITLE
Add mtu information for interfaces

### DIFF
--- a/src/common/network.rs
+++ b/src/common/network.rs
@@ -410,6 +410,20 @@ impl NetworkData {
     pub fn ip_networks(&self) -> &[IpNetwork] {
         self.inner.ip_networks()
     }
+
+    /// Returns the Maximum Transfer Unit (MTU) of the interface.
+    ///
+    /// ```no_run
+    /// use sysinfo::Networks;
+    ///
+    /// let mut networks = Networks::new_with_refreshed_list();
+    /// for (interface_name, network) in &networks {
+    ///     println!("mtu: {}", network.mtu());
+    /// }
+    /// ```
+    pub fn mtu(&self) -> u64 {
+        self.inner.mtu()
+    }
 }
 
 /// MAC address for network interface.

--- a/src/unix/apple/network.rs
+++ b/src/unix/apple/network.rs
@@ -96,6 +96,7 @@ impl NetworksInner {
                     }
                     name.set_len(libc::strlen(pname));
                     let name = String::from_utf8_unchecked(name);
+                    let mtu = (*if2m).ifm_data.ifi_mtu as u64;
                     match self.interfaces.entry(name) {
                         hash_map::Entry::Occupied(mut e) => {
                             let interface = e.get_mut();
@@ -137,6 +138,7 @@ impl NetworksInner {
                                 old_errors_out,
                                 (*if2m).ifm_data.ifi_oerrors
                             );
+                            if interface.mtu != mtu { interface.mtu = mtu }
                             interface.updated = true;
                         }
                         hash_map::Entry::Vacant(e) => {
@@ -167,6 +169,7 @@ impl NetworksInner {
                                     updated: true,
                                     mac_addr: MacAddr::UNSPECIFIED,
                                     ip_networks: vec![],
+                                    mtu,
                                 },
                             });
                         }
@@ -196,6 +199,8 @@ pub(crate) struct NetworkDataInner {
     pub(crate) mac_addr: MacAddr,
     /// IP networks
     pub(crate) ip_networks: Vec<IpNetwork>,
+    /// Interface Maximum Transfer Unit (MTU)
+    mtu: u64,
 }
 
 impl NetworkDataInner {
@@ -253,5 +258,9 @@ impl NetworkDataInner {
 
     pub(crate) fn ip_networks(&self) -> &[IpNetwork] {
         &self.ip_networks
+    }
+
+    pub(crate) fn mtu(&self) -> u64 {
+        self.mtu
     }
 }

--- a/src/unix/freebsd/network.rs
+++ b/src/unix/freebsd/network.rs
@@ -80,6 +80,7 @@ impl NetworksInner {
             }
             if let Some(name) = utils::c_buf_to_utf8_string(&data.ifmd_name) {
                 let data = &data.ifmd_data;
+                let mtu = data.ifi_mtu as u64;
                 match self.interfaces.entry(name) {
                     hash_map::Entry::Occupied(mut e) => {
                         let interface = e.get_mut();
@@ -91,6 +92,7 @@ impl NetworksInner {
                         old_and_new!(interface, ifi_opackets, old_ifi_opackets, data);
                         old_and_new!(interface, ifi_ierrors, old_ifi_ierrors, data);
                         old_and_new!(interface, ifi_oerrors, old_ifi_oerrors, data);
+                        if interface.mtu != mtu { interface.mtu = mtu }
                         interface.updated = true;
                     }
                     hash_map::Entry::Vacant(e) => {
@@ -115,6 +117,7 @@ impl NetworksInner {
                                 updated: true,
                                 mac_addr: MacAddr::UNSPECIFIED,
                                 ip_networks: vec![],
+                                mtu,
                             },
                         });
                     }
@@ -151,6 +154,8 @@ pub(crate) struct NetworkDataInner {
     pub(crate) mac_addr: MacAddr,
     /// IP networks
     pub(crate) ip_networks: Vec<IpNetwork>,
+    /// Interface Maximum Transfer Unit (MTU)
+    mtu: u64,
 }
 
 impl NetworkDataInner {
@@ -208,5 +213,9 @@ impl NetworkDataInner {
 
     pub(crate) fn ip_networks(&self) -> &[IpNetwork] {
         &self.ip_networks
+    }
+
+    pub(crate) fn mtu(&self) -> u64 {
+        self.mtu
     }
 }

--- a/src/unknown/network.rs
+++ b/src/unknown/network.rs
@@ -82,4 +82,8 @@ impl NetworkDataInner {
     pub(crate) fn ip_networks(&self) -> &[IpNetwork] {
         &[]
     }
+
+    pub(crate) fn mtu(&self) -> u64 {
+        0
+    }
 }

--- a/src/windows/network.rs
+++ b/src/windows/network.rs
@@ -94,6 +94,8 @@ impl NetworksInner {
                     Ok(s) => s,
                     _ => continue,
                 };
+
+                let mtu = ptr.Mtu as u64;
                 match self.interfaces.entry(interface_name) {
                     hash_map::Entry::Occupied(mut e) => {
                         let interface = e.get_mut();
@@ -114,6 +116,7 @@ impl NetworksInner {
                         );
                         old_and_new!(interface, errors_in, old_errors_in, ptr.InErrors);
                         old_and_new!(interface, errors_out, old_errors_out, ptr.OutErrors);
+                        if interface.mtu != mtu { interface.mtu = mtu }
                         interface.updated = true;
                     }
                     hash_map::Entry::Vacant(e) => {
@@ -137,6 +140,7 @@ impl NetworksInner {
                                 old_errors_out: ptr.OutErrors,
                                 mac_addr: MacAddr::UNSPECIFIED,
                                 ip_networks: vec![],
+                                mtu,
                                 updated: true,
                             },
                         });
@@ -179,6 +183,7 @@ impl NetworksInner {
                 );
                 old_and_new!(interface, errors_in, old_errors_in, entry.InErrors);
                 old_and_new!(interface, errors_out, old_errors_out, entry.OutErrors);
+                if interface.mtu != entry.Mtu as u64 { interface.mtu = entry.Mtu as u64 }
             }
         }
     }
@@ -201,6 +206,8 @@ pub(crate) struct NetworkDataInner {
     updated: bool,
     pub(crate) mac_addr: MacAddr,
     pub(crate) ip_networks: Vec<IpNetwork>,
+    /// Interface Maximum Transfer Unit (MTU)
+    mtu: u64,
 }
 
 impl NetworkDataInner {
@@ -258,5 +265,9 @@ impl NetworkDataInner {
 
     pub(crate) fn ip_networks(&self) -> &[IpNetwork] {
         &self.ip_networks
+    }
+
+    pub(crate) fn mtu(&self) -> u64 {
+        self.mtu
     }
 }


### PR DESCRIPTION
This PR add mtu value for `Network`. This value can be useful to understand network issue. 