### PR TITLE
Add missing `mtu` field in `Debug` implementations and `serde`

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -130,6 +130,7 @@ impl std::fmt::Debug for crate::NetworkData {
             .field("total errors income", &self.total_errors_on_received())
             .field("errors outcome", &self.errors_on_transmitted())
             .field("total errors outcome", &self.total_errors_on_transmitted())
+            .field("maximum transfer unit", &self.mtu())
             .finish()
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -343,8 +343,8 @@ impl Serialize for crate::NetworkData {
     where
         S: Serializer,
     {
-        // `13` corresponds to the number of fields.
-        let mut state = serializer.serialize_struct("NetworkData", 13)?;
+        // `14` corresponds to the number of fields.
+        let mut state = serializer.serialize_struct("NetworkData", 14)?;
 
         state.serialize_field("received", &self.received())?;
         state.serialize_field("total_received", &self.total_received())?;
@@ -366,6 +366,7 @@ impl Serialize for crate::NetworkData {
         )?;
         state.serialize_field("mac_address", &self.mac_address())?;
         state.serialize_field("ip_networks", &self.ip_networks())?;
+        state.serialize_field("mtu", &self.mtu())?;
 
         state.end()
     }


### PR DESCRIPTION
Follow-up of  #1367.