### PR TITLE
fix(win): inconsistent boot_time

### DIFF
--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -63,7 +63,14 @@ unsafe impl<T> Sync for Wrap<T> {}
 
 unsafe fn boot_time() -> u64 {
     match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
-        Ok(n) => n.as_secs().saturating_sub(GetTickCount64() / 1_000),
+        Ok(n) => {
+            let system_time_ns = n.as_nanos();
+            // milliseconds to nanoseconds
+            let tick_count_ns = GetTickCount64() as u128 * 1_000_000;
+            // nanoseconds to seconds
+            let boot_time_sec = system_time_ns.saturating_sub(tick_count_ns) / 1_000_000_000;
+            boot_time_sec.try_into().unwrap_or(u64::MAX)
+        }
         Err(_e) => {
             sysinfo_debug!("Failed to compute boot time: {:?}", _e);
             0


### PR DESCRIPTION
I noticed inconsistent boot times when using the `System::boot_time()` function on Windows. This PR aims to fix this.

Refines the `boot_time` function on Windows to improve consistency by enhancing precision in the uptime calculation. The updated version uses nanoseconds throughout to avoid rounding errors, and it caps the result safely within u64 limits.