### PR TITLE
Deal with libc 0.2.165's removal of array size hacks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ ntapi = { version = "0.4", optional = true }
 windows = { version = ">=0.54, <=0.57", optional = true }
 
 [target.'cfg(not(any(target_os = "unknown", target_arch = "wasm32")))'.dependencies]
-libc = "^0.2.153"
+libc = "^0.2.165"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 core-foundation-sys = "0.8.7"

--- a/src/unix/apple/cpu.rs
+++ b/src/unix/apple/cpu.rs
@@ -3,7 +3,9 @@
 use crate::sys::utils::{get_sys_value, get_sys_value_by_name};
 use crate::{Cpu, CpuRefreshKind};
 
-use libc::{c_char, c_void, host_processor_info, mach_port_t, mach_task_self};
+#[allow(deprecated)]
+use libc::mach_task_self;
+use libc::{c_char, c_void, host_processor_info, mach_port_t};
 use std::mem;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -97,6 +99,7 @@ impl Drop for CpuData {
             let prev_cpu_info_size = std::mem::size_of::<i32>() as u32 * self.num_cpu_info;
             unsafe {
                 libc::vm_deallocate(
+                    #[allow(deprecated)]
                     mach_task_self(),
                     self.cpu_info.0 as _,
                     prev_cpu_info_size as _,

--- a/src/unix/apple/macos/component/x86.rs
+++ b/src/unix/apple/macos/component/x86.rs
@@ -321,7 +321,13 @@ impl IoService {
             };
 
             let mut conn = 0;
-            let result = ffi::IOServiceOpen(device.inner(), libc::mach_task_self(), 0, &mut conn);
+            let result = ffi::IOServiceOpen(
+                device.inner(),
+                #[allow(deprecated)]
+                libc::mach_task_self(),
+                0,
+                &mut conn,
+            );
             if result != ffi::KIO_RETURN_SUCCESS {
                 sysinfo_debug!("Error: IOServiceOpen() = {}", result);
                 return None;

--- a/src/unix/apple/macos/process.rs
+++ b/src/unix/apple/macos/process.rs
@@ -433,7 +433,7 @@ unsafe fn convert_node_path_info(node: &libc::vnode_info_path) -> Option<PathBuf
     }
     cstr_to_rust_with_size(
         node.vip_path.as_ptr() as _,
-        Some(node.vip_path.len() * node.vip_path[0].len()),
+        Some(mem::size_of_val(&node.vip_path)),
     )
     .map(PathBuf::from)
 }

--- a/src/unix/apple/macos/system.rs
+++ b/src/unix/apple/macos/system.rs
@@ -162,6 +162,7 @@ mod test {
             return;
         }
 
+        #[allow(deprecated)]
         let port = unsafe { libc::mach_host_self() };
         let mut info = SystemTimeInfo::new(port).unwrap();
         info.get_time_interval(port);

--- a/src/unix/apple/system.rs
+++ b/src/unix/apple/system.rs
@@ -129,6 +129,7 @@ fn get_now() -> u64 {
 impl SystemInner {
     pub(crate) fn new() -> Self {
         unsafe {
+            #[allow(deprecated)]
             let port = libc::mach_host_self();
 
             Self {


### PR DESCRIPTION
Closes https://github.com/GuillaumeGomez/sysinfo/issues/1392.

Libc changed the representation of `libc::vnode_info_path::vip_path`.

- https://docs.rs/libc/0.2.164/aarch64-apple-darwin/libc/struct.vnode_info_path.html
- https://docs.rs/libc/0.2.165/aarch64-apple-darwin/libc/struct.vnode_info_path.html