### PR TITLE
fix(win): fix HSTRING being dropped, causing NERR_UserNotFound errors

### DIFF
--- a/src/windows/utils.rs
+++ b/src/windows/utils.rs
@@ -17,15 +17,6 @@ pub(crate) unsafe fn to_utf8_str(p: windows::core::PWSTR) -> String {
     })
 }
 
-#[cfg(any(feature = "user", feature = "system"))]
-pub(crate) unsafe fn to_pcwstr(v: Vec<u16>) -> windows::core::PCWSTR {
-    if v.is_empty() {
-        return windows::core::PCWSTR::null();
-    }
-    let string = String::from_utf16(&v).unwrap_or_default();
-    windows::core::PCWSTR(windows::core::HSTRING::from(&format!("{}\0", string)).as_ptr())
-}
-
 cfg_if! {
     if #[cfg(any(feature = "disk", feature = "system"))] {
         use windows::Win32::Foundation::{CloseHandle, HANDLE};


### PR DESCRIPTION
In an attempt to fix #1233, a pull request #1359 was made which introduced broken code into the repo, shown below:

```rust
#[cfg(any(feature = "user", feature = "system"))]
pub(crate) unsafe fn to_pcwstr(v: Vec<u16>) -> windows::core::PCWSTR {
    if v.is_empty() {
        return windows::core::PCWSTR::null();
    }
    let string = String::from_utf16(&v).unwrap_or_default();
    // New string allocated here with format!(), but data in the HSTRING is also dropped here (tested with breakpoints)
    windows::core::PCWSTR(windows::core::HSTRING::from(&format!("{}\0", string)).as_ptr())
}
```

This caused inconsistent behavior when returning groups for users, as the data in the HSTRING was freed before it could be used in the `get_groups_for_user` function. Additionally, HSTRING internals already terminate given strings with a null byte, making the code above irrelevant.

This PR ensures that the Vec data is appropriately null terminated and the heap memory it points to will last for the duration of the `get_groups_for_user` function, as expected.
