### PR TITLE
Resolve dead code warnings on various platforms

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.head_ref }}
   cancel-in-progress: true
 
+env:
+  RUSTFLAGS: -Dwarnings
+
 jobs:
   rustfmt:
     runs-on: ubuntu-latest

--- a/src/unix/apple/disk.rs
+++ b/src/unix/apple/disk.rs
@@ -25,6 +25,7 @@ use std::ptr;
 pub(crate) struct DiskInner {
     pub(crate) type_: DiskKind,
     pub(crate) name: OsString,
+    #[cfg(target_os = "macos")]
     bsd_name: Option<Vec<u8>>,
     pub(crate) file_system: OsString,
     pub(crate) mount_point: PathBuf,
@@ -338,6 +339,7 @@ unsafe fn get_list(container: &mut Vec<Disk>, refresh_kind: DiskRefreshKind) {
 type RetainedCFArray = CFReleaser<core_foundation_sys::array::__CFArray>;
 pub(crate) type RetainedCFDictionary = CFReleaser<core_foundation_sys::dictionary::__CFDictionary>;
 type RetainedCFURL = CFReleaser<core_foundation_sys::url::__CFURL>;
+#[cfg(target_os = "macos")]
 pub(crate) type RetainedCFString = CFReleaser<core_foundation_sys::string::__CFString>;
 
 unsafe fn build_requested_properties(properties: &[CFStringRef]) -> Option<RetainedCFArray> {
@@ -527,6 +529,7 @@ unsafe fn new_disk(
         )
     };
 
+    #[cfg(target_os = "macos")]
     let bsd_name = get_bsd_name(&c_disk);
 
     // IOKit is not available on any but the most recent (16+) iOS and iPadOS versions.
@@ -565,6 +568,7 @@ unsafe fn new_disk(
     let mut disk = DiskInner {
         type_: DiskKind::Unknown(-1),
         name,
+        #[cfg(target_os = "macos")]
         bsd_name,
         file_system,
         mount_point,
@@ -619,6 +623,7 @@ unsafe fn with_autorelease<T, F: FnOnce() -> T>(call: F) -> T {
     // Pool is drained here before returning
 }
 
+#[cfg(target_os = "macos")]
 fn get_bsd_name(disk: &libc::statfs) -> Option<Vec<u8>> {
     // Removes `/dev/` from the value.
     unsafe {

--- a/src/unix/apple/macos/ffi.rs
+++ b/src/unix/apple/macos/ffi.rs
@@ -123,11 +123,14 @@ extern "C" {
         matching: CFMutableDictionaryRef,
         existing: *mut io_iterator_t,
     ) -> kern_return_t;
-    #[cfg(any(
-        feature = "system",
-        all(
-            feature = "component",
-            any(target_arch = "x86", target_arch = "x86_64")
+    #[cfg(all(
+        not(feature = "apple-sandbox"),
+        any(
+            feature = "system",
+            all(
+                feature = "component",
+                any(target_arch = "x86", target_arch = "x86_64")
+            ),
         ),
     ))]
     pub fn IOServiceMatching(a: *const c_char) -> CFMutableDictionaryRef;
@@ -155,17 +158,20 @@ extern "C" {
         options: u32,
         bsdName: *const c_char,
     ) -> CFMutableDictionaryRef;
-    #[cfg(feature = "system")]
+    #[cfg(all(feature = "system", not(feature = "apple-sandbox")))]
     pub fn IORegistryEntryGetName(entry: io_registry_entry_t, name: io_name_t) -> kern_return_t;
     #[cfg(feature = "disk")]
     pub fn IOObjectConformsTo(object: io_object_t, className: *const c_char) -> libc::boolean_t;
 }
 
-#[cfg(any(
-    feature = "system",
-    all(
-        feature = "component",
-        any(target_arch = "x86", target_arch = "x86_64")
+#[cfg(all(
+    not(feature = "apple-sandbox"),
+    any(
+        feature = "system",
+        all(
+            feature = "component",
+            any(target_arch = "x86", target_arch = "x86_64")
+        ),
     ),
 ))]
 pub const KIO_RETURN_SUCCESS: i32 = 0;

--- a/src/unix/apple/mod.rs
+++ b/src/unix/apple/mod.rs
@@ -10,7 +10,7 @@ cfg_if! {
     if #[cfg(all(target_os = "macos", any(feature = "disk", feature = "system", feature = "component")))] {
         pub(crate) mod macos;
         pub(crate) use self::macos as inner;
-    } else if #[cfg(all(target_os = "ios", any(feature = "disk", feature = "system", feature = "component")))] {
+    } else if #[cfg(all(target_os = "ios", any(feature = "system", feature = "component")))] {
         pub(crate) mod ios;
         pub(crate) use self::ios as inner;
     }

--- a/src/unix/apple/system.rs
+++ b/src/unix/apple/system.rs
@@ -231,7 +231,7 @@ impl SystemInner {
     #[cfg(any(target_os = "ios", feature = "apple-sandbox"))]
     pub(crate) fn refresh_processes_specifics(
         &mut self,
-        processes_to_update: ProcessesToUpdate<'_>,
+        _processes_to_update: ProcessesToUpdate<'_>,
         _refresh_kind: ProcessRefreshKind,
     ) -> usize {
         0

--- a/src/unix/linux/utils.rs
+++ b/src/unix/linux/utils.rs
@@ -1,7 +1,10 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+#[cfg(any(feature = "disk", feature = "system"))]
 use std::fs::File;
+#[cfg(any(feature = "disk", feature = "system"))]
 use std::io::{self, Read, Seek};
+#[cfg(any(feature = "disk", feature = "system"))]
 use std::path::Path;
 
 #[cfg(feature = "system")]
@@ -12,6 +15,7 @@ pub(crate) fn get_all_data_from_file(file: &mut File, size: usize) -> io::Result
     Ok(buf)
 }
 
+#[cfg(any(feature = "disk", feature = "system"))]
 pub(crate) fn get_all_utf8_data_from_file(file: &mut File, size: usize) -> io::Result<String> {
     let mut buf = String::with_capacity(size);
     file.rewind()?;
@@ -19,6 +23,7 @@ pub(crate) fn get_all_utf8_data_from_file(file: &mut File, size: usize) -> io::R
     Ok(buf)
 }
 
+#[cfg(any(feature = "disk", feature = "system"))]
 pub(crate) fn get_all_utf8_data<P: AsRef<Path>>(file_path: P, size: usize) -> io::Result<String> {
     let mut file = File::open(file_path.as_ref())?;
     get_all_utf8_data_from_file(&mut file, size)
@@ -85,6 +90,7 @@ pub(crate) fn to_u64(v: &[u8]) -> u64 {
 }
 
 /// Converts a path to a NUL-terminated `Vec<u8>` suitable for use with C functions.
+#[cfg(feature = "disk")]
 pub(crate) fn to_cpath(path: &std::path::Path) -> Vec<u8> {
     use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
 

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -225,17 +225,6 @@ fn windows_8_1_or_newer() -> &'static bool {
     })
 }
 
-#[cfg(feature = "debug")]
-unsafe fn display_ntstatus_error(ntstatus: windows::core::HRESULT) {
-    let code = ntstatus.0;
-    let message = ntstatus.message();
-    sysinfo_debug!(
-        "Couldn't get process infos: NtQuerySystemInformation returned {}: {}",
-        code,
-        message
-    );
-}
-
 unsafe fn get_exe(process_handler: &HandleWrapper) -> Option<PathBuf> {
     let mut exe_buf = [0u16; MAX_PATH as usize + 1];
     GetModuleFileNameExW(

--- a/src/windows/sid.rs
+++ b/src/windows/sid.rs
@@ -3,11 +3,13 @@
 use std::{fmt::Display, str::FromStr};
 
 use windows::core::{PCWSTR, PWSTR};
-use windows::Win32::Foundation::{LocalFree, ERROR_INSUFFICIENT_BUFFER, HLOCAL, PSID};
+#[cfg(feature = "user")]
+use windows::Win32::Foundation::ERROR_INSUFFICIENT_BUFFER;
+use windows::Win32::Foundation::{LocalFree, HLOCAL, PSID};
 use windows::Win32::Security::Authorization::{ConvertSidToStringSidW, ConvertStringSidToSidW};
-use windows::Win32::Security::{
-    CopySid, GetLengthSid, IsValidSid, LookupAccountSidW, SidTypeUnknown,
-};
+use windows::Win32::Security::{CopySid, GetLengthSid, IsValidSid};
+#[cfg(feature = "user")]
+use windows::Win32::Security::{LookupAccountSidW, SidTypeUnknown};
 
 use crate::sys::utils::to_utf8_str;
 
@@ -56,6 +58,7 @@ impl Sid {
     }
 
     /// Retrieves the account name of this SID.
+    #[cfg(feature = "user")]
     pub(crate) fn account_name(&self) -> Option<String> {
         unsafe {
             let mut name_len = 0;


### PR DESCRIPTION
```console
warning: unused variable: `processes_to_update`
   --> src/unix/apple/system.rs:234:9
    |
234 |         processes_to_update: ProcessesToUpdate<'_>,
    |         ^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_processes_to_update`
    |
    = note: `#[warn(unused_variables)]` on by default

warning: field `bsd_name` is never read
  --> src/unix/apple/disk.rs:28:5
   |
25 | pub(crate) struct DiskInner {
   |                   --------- field in this struct
...
28 |     bsd_name: Option<Vec<u8>>,
   |     ^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: type alias `RetainedCFString` is never used
   --> src/unix/apple/disk.rs:341:17
    |
341 | pub(crate) type RetainedCFString = CFReleaser<core_foundation_sys::string::__CFString>;
    |                 ^^^^^^^^^^^^^^^^

warning: constant `KIO_RETURN_SUCCESS` is never used
   --> src/unix/apple/macos/ffi.rs:171:11
    |
171 | pub const KIO_RETURN_SUCCESS: i32 = 0;
    |           ^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: function `IOServiceMatching` is never used
   --> src/unix/apple/macos/ffi.rs:133:12
    |
133 |     pub fn IOServiceMatching(a: *const c_char) -> CFMutableDictionaryRef;
    |            ^^^^^^^^^^^^^^^^^

warning: function `IORegistryEntryGetName` is never used
   --> src/unix/apple/macos/ffi.rs:159:12
    |
159 |     pub fn IORegistryEntryGetName(entry: io_registry_entry_t, name: io_name_t) -> kern_return_t;
    |            ^^^^^^^^^^^^^^^^^^^^^^

warning: function `get_all_utf8_data_from_file` is never used
  --> src/unix/linux/utils.rs:15:15
   |
15 | pub(crate) fn get_all_utf8_data_from_file(file: &mut File, size: usize) -> io::Result<String> {
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: function `get_all_utf8_data` is never used
  --> src/unix/linux/utils.rs:22:15
   |
22 | pub(crate) fn get_all_utf8_data<P: AsRef<Path>>(file_path: P, size: usize) -> io::Result<String> {
   |               ^^^^^^^^^^^^^^^^^

warning: function `to_cpath` is never used
  --> src/unix/linux/utils.rs:88:15
   |
88 | pub(crate) fn to_cpath(path: &std::path::Path) -> Vec<u8> {
   |               ^^^^^^^^

warning: unused import: `self::ios as inner`
  --> src/unix/apple/mod.rs:15:24
   |
15 |         pub(crate) use self::ios as inner;
   |                        ^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: function `display_ntstatus_error` is never used
   --> src/windows/process.rs:229:11
    |
229 | unsafe fn display_ntstatus_error(ntstatus: windows::core::HRESULT) {
    |           ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: method `account_name` is never used
  --> src/windows/sid.rs:59:19
   |
20 | impl Sid {
   | -------- method in this implementation
...
59 |     pub(crate) fn account_name(&self) -> Option<String> {
   |                   ^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default
```