### PR TITLE
Fix  wrong logic in from_hwmon() function

### DIFF
--- a/src/unix/linux/component.rs
+++ b/src/unix/linux/component.rs
@@ -271,7 +271,7 @@ impl ComponentInner {
         let dir = read_dir(folder).ok()?;
         let mut matchings: HashMap<u32, Component> = HashMap::with_capacity(10);
         for entry in dir.flatten() {
-            if !entry.file_type().is_ok_and(|file_type| file_type.is_dir()) {
+            if !entry.file_type().is_ok_and(|file_type| !file_type.is_dir()) {
                 continue;
             }
 


### PR DESCRIPTION
In the `from_hwmon()` function, the loop should skip the entry if it is a directory, but the current code will skip the entry if it is NOT a directory. This PR just fix that logic.