### PR TITLE
Make disks show info about unmounted disks as well, first effort

### DIFF
--- a/src/unix/linux/disk.rs
+++ b/src/unix/linux/disk.rs
@@ -355,7 +355,7 @@ fn get_all_list(container: &mut Vec<Disk>, content: &str, refresh_kind: DiskRefr
     };
 
     let procfs_disk_stats = disk_stats(&refresh_kind);
-    
+
     // The list of unmounted disks, initially it include all disks
     let mut unmounted = procfs_disk_stats
         .keys()
@@ -429,26 +429,25 @@ fn get_all_list(container: &mut Vec<Disk>, content: &str, refresh_kind: DiskRefr
             &procfs_disk_stats,
             refresh_kind,
         ));
-        
+
         // If the disk is mounted, remove it from the list
         unmounted.retain(|disk| disk != fs_spec);
     }
-    
+
     // Process the unmounted disks
     for disk in unmounted {
-        
         // The mount point should be left empty unless it is ZRAM
         let mount_point = match disk.contains("zram") {
             true => "[SWAP]",
             _ => "",
         };
         let mount_point = Path::new(mount_point);
-        
+
         // File system is Unknown or swap
         // TODO: Find a way to figure out the file system (like lsblk)
         let file_system = match disk.contains("zram") {
             true => "swap",
-            _ => "Unknown"
+            _ => "Unknown",
         };
 
         container.push(new_disk(
@@ -460,7 +459,7 @@ fn get_all_list(container: &mut Vec<Disk>, content: &str, refresh_kind: DiskRefr
             refresh_kind,
         ));
     }
-    
+
     // Sort the container to make the output looks better
     container.sort_by(|a, b| a.name().cmp(b.name()));
 }


### PR DESCRIPTION
We clone the keys of `procfs_disk_stats` to create a list of all disks, including unmounted ones, and let's call that `unmounted`. Then after adding the mounted disks (and at the same time removing those disks from the `unmounted`), we can iterate over unmounted and add the remaining disks.

Unmounted disks will have "Unknown" file system and empty mount point, except Zram, which has "swap" file system and "[SWAP]" mount point (like lsblk).