### PR TITLE
Improve CPU usage efficiency

### DIFF
--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -992,6 +992,7 @@ pub(crate) fn compute_cpu_usage(p: &mut ProcessInner, nb_cpus: u64) {
             user = filetime_to_u64(fuser);
             global_kernel_time = filetime_to_u64(fglobal_kernel_time);
             global_user_time = filetime_to_u64(fglobal_user_time);
+            p.cpu_calc_values.last_update = Instant::now();
         }
 
         let delta_global_kernel_time =
@@ -1005,7 +1006,6 @@ pub(crate) fn compute_cpu_usage(p: &mut ProcessInner, nb_cpus: u64) {
         p.cpu_calc_values.old_process_sys_cpu = sys;
         p.cpu_calc_values.old_system_user_cpu = global_user_time;
         p.cpu_calc_values.old_system_sys_cpu = global_kernel_time;
-        p.cpu_calc_values.last_update = Instant::now();
 
         let denominator = delta_global_user_time.saturating_add(delta_global_kernel_time) as f32;
 

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -956,6 +956,11 @@ fn check_sub(a: u64, b: u64) -> u64 {
 /// Before changing this function, you must consider the following:
 /// <https://github.com/GuillaumeGomez/sysinfo/issues/459>
 pub(crate) fn compute_cpu_usage(p: &mut ProcessInner, nb_cpus: u64) {
+    if p.cpu_calc_values.last_update.elapsed() <= MINIMUM_CPU_UPDATE_INTERVAL {
+        // cpu usage hasn't updated. p.cpu_usage remains the same
+        return;
+    }
+
     unsafe {
         let mut ftime: FILETIME = zeroed();
         let mut fsys: FILETIME = zeroed();
@@ -966,11 +971,6 @@ pub(crate) fn compute_cpu_usage(p: &mut ProcessInner, nb_cpus: u64) {
 
         if let Some(handle) = p.get_handle() {
             let _err = GetProcessTimes(handle, &mut ftime, &mut ftime, &mut fsys, &mut fuser);
-        }
-
-        if p.cpu_calc_values.last_update.elapsed() <= MINIMUM_CPU_UPDATE_INTERVAL {
-            // cpu usage hasn't updated. p.cpu_usage remains the same
-            return;
         }
 
         // system times have changed, we need to get most recent system times


### PR DESCRIPTION
## Problem
The ```compute_cpu_usage``` function relied on redundant operations and inefficient handling of cached system times. This could lead to unnecessary updates to system times, resulting in reduced efficiency and increased overhead.

## Solution
I updated the function to use cached values unless the time elapsed since the previous values were cached exceeds MINIMUM_CPU_UPDATE_INTERVAL, ensuring system times are only refreshed when necessary. 
- Specifically minimizes the amount of calls to ```GetSystemTimes```, and ```filetime_to_u64```.

Now, after each call to ```compute_cpu_usage``` if the last time these values were retrieved ( a call to ```GetSystemTimes``` took place ) is less than MINIMUM_CPU_UPDATE_INTERVAL ( system values haven't updated ) the function will use the values used previously. Otherwise, ```GetSystemTimes``` will be called, values will be retrieved, and an Instant::now() value will be saved in cpu_calc_values to determine the time ```GetSystemTimes``` was last called.

## Tests
- All 237 existing tests passed and ran with ```cargo test```.

## Other
- Both ```cargo fmt``` and ```cargo clippy``` were ran successfully.
