### PR TITLE
Use CreateToolhelp32Snapshot, Process32FirstW and Process32NextW

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ disk = [
 ]
 system = [
     "windows/Win32_Foundation",
+    "windows/Win32_System_Diagnostics_ToolHelp",
     "windows/Wdk_System_SystemInformation",
     "windows/Wdk_System_SystemServices",
     "windows/Wdk_System_Threading",
@@ -100,7 +101,7 @@ serde = { version = "^1.0.190", optional = true }
 ntapi = { version = "0.4", optional = true }
 # Support a range of versions in order to avoid duplication of this crate. Make sure to test all
 # versions when bumping to a new release, and only increase the minimum when absolutely necessary.
-windows = { version = ">=0.54, <=0.57", optional = true, features = ["Win32_Foundation", "Win32_System_Diagnostics_ToolHelp"] }
+windows = { version = ">=0.54, <=0.57", optional = true }
 
 [target.'cfg(not(any(target_os = "unknown", target_arch = "wasm32")))'.dependencies]
 libc = "^0.2.164"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ serde = { version = "^1.0.190", optional = true }
 ntapi = { version = "0.4", optional = true }
 # Support a range of versions in order to avoid duplication of this crate. Make sure to test all
 # versions when bumping to a new release, and only increase the minimum when absolutely necessary.
-windows = { version = ">=0.54, <=0.57", optional = true }
+windows = { version = ">=0.54, <=0.57", optional = true, features = ["Win32_Foundation", "Win32_System_Diagnostics_ToolHelp"] }
 
 [target.'cfg(not(any(target_os = "unknown", target_arch = "wasm32")))'.dependencies]
 libc = "^0.2.164"

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -992,6 +992,7 @@ pub(crate) fn compute_cpu_usage(p: &mut ProcessInner, nb_cpus: u64) {
             user = filetime_to_u64(fuser);
             global_kernel_time = filetime_to_u64(fglobal_kernel_time);
             global_user_time = filetime_to_u64(fglobal_user_time);
+            p.cpu_calc_values.last_update = Instant::now();
         }
 
         let delta_global_kernel_time =
@@ -1005,7 +1006,6 @@ pub(crate) fn compute_cpu_usage(p: &mut ProcessInner, nb_cpus: u64) {
         p.cpu_calc_values.old_process_sys_cpu = sys;
         p.cpu_calc_values.old_system_user_cpu = global_user_time;
         p.cpu_calc_values.old_system_sys_cpu = global_kernel_time;
-        p.cpu_calc_values.last_update = Instant::now();
 
         let denominator = delta_global_user_time.saturating_add(delta_global_kernel_time) as f32;
 

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -325,7 +325,9 @@ impl ProcessInner {
 
     pub(crate) fn from_process_entry(entry: &PROCESSENTRY32W, now: u64) -> Self {
         let pid = Pid::from_u32(entry.th32ProcessID);
-        let name = match OsString::from_str(String::from_utf16_lossy(&entry.szExeFile).trim_end_matches('\0')) {
+        let name = match OsString::from_str(
+            String::from_utf16_lossy(&entry.szExeFile).trim_end_matches('\0'),
+        ) {
             Ok(name) => name,
             Err(_) => format!("<no name> Process {pid}").into(),
         };

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -326,12 +326,8 @@ impl ProcessInner {
     pub(crate) fn from_process_entry(entry: &PROCESSENTRY32W, now: u64) -> Self {
         let pid = Pid::from_u32(entry.th32ProcessID);
         let name = match OsString::from_str(String::from_utf16_lossy(&entry.szExeFile).trim_end_matches('\0')) {
-            Some(name) => name,
-            None => match pid.0 {
-                0 => OsString::from_str("Idle"),
-                4 => OsString::from_str("System"),
-                _ => format!("<no name> Process {process_id}").into(),
-            },
+            Ok(name) => name,
+            Err(_) => format!("<no name> Process {pid}").into(),
         };
         let ppid = {
             if entry.th32ParentProcessID == 0 {

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -956,6 +956,11 @@ fn check_sub(a: u64, b: u64) -> u64 {
 /// Before changing this function, you must consider the following:
 /// <https://github.com/GuillaumeGomez/sysinfo/issues/459>
 pub(crate) fn compute_cpu_usage(p: &mut ProcessInner, nb_cpus: u64) {
+    if p.cpu_calc_values.last_update.elapsed() <= MINIMUM_CPU_UPDATE_INTERVAL {
+        // cpu usage hasn't updated. p.cpu_usage remains the same
+        return;
+    }
+
     unsafe {
         let mut ftime: FILETIME = zeroed();
         let mut fsys: FILETIME = zeroed();
@@ -966,11 +971,6 @@ pub(crate) fn compute_cpu_usage(p: &mut ProcessInner, nb_cpus: u64) {
 
         if let Some(handle) = p.get_handle() {
             let _err = GetProcessTimes(handle, &mut ftime, &mut ftime, &mut fsys, &mut fuser);
-        }
-
-        if p.cpu_calc_values.last_update.elapsed() <= MINIMUM_CPU_UPDATE_INTERVAL {
-            // cpu usage hasn't updated. p.cpu_usage remains the same
-            return;
         }
 
         // system times have changed, we need to get most recent system times

--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -254,9 +254,11 @@ impl SystemInner {
         let process_list = &mut self.process_list;
 
         // process the first process
-        if unsafe { Process32FirstW(snapshot, &mut process_entry).is_err() } {
-            // Error with Process32FirstW
-            sysinfo_debug!("Process32FirstW has failed :(");
+        unsafe {
+            if let Err(_error) = Process32FirstW(snapshot, &mut process_entry) {
+                sysinfo_debug!("Process32FirstW has failed: {_error:?}");
+                return 0;
+            }
         }
 
         // Iterate over processes in the snapshot.


### PR DESCRIPTION
Fixes https://github.com/GuillaumeGomez/sysinfo/issues/1450.

Happy weekend.

## Content
Rather than using `NtQueryInformationProcess` in `refresh_processes_specifics`, I use the documented WinAPI functions `CreateToolhelp32Snapshot`, `Process32FirstW`, and `Process32NextW` with `PROCESSENTRY32W` instead of some weird buffers and scary memory operations :o. This function greatly increases the safety and potential performance of the call. 

Furthermore, determining memory usage has been changed from using `SYSTEM_PROCESS_INFORMATION` to using `PROCESS_MEMORY_COUNTERS_EX`. Virtual memory usage has abnormally large values (e.g., 2205843243008 bytes). At the time of posting this draft, I'm still not sure if this is intentional, but using `PROCESS_MEMORY_COUNTERS_EX`'s `PrivateUsage` field seems to give a correct result, fixing this phenomenon. 

Finally, without using `NtQuerySystemInformation` to iterate through processes, it **might** fix the Windows Defender false positive. However, there are calls to `NtQueryInformationProcess` which may influence a false positive. If so, I may open another pull request.

## Tests, clippy, fmt...
Currently, all tests have passed and `cargo fmt` has been used. --`cargo clippy` does complain about two lines that are harmless though :(-- Edit: Clippy errors have been fixed. Not sure why Ubuntu is complaining though when I never touched it.

## Example output
Output from my version:
```
[src/main.rs:14:9] process = Process {
    pid: Pid(
        58420,
    ),
    parent: Some(
        Pid(
            23156,
        ),
    ),
    name: "firefox.exe",
    environ: [
        "=::=::\\",
        "ALLUSERSPROFILE=C:\\ProgramData",
        "APPDATA=C:\\Users\\ethan\\AppData\\Roaming",
        "CommonProgramFiles=C:\\Program Files\\Common Files",
        "CommonProgramFiles(x86)=C:\\Program Files (x86)\\Common Files",
        "CommonProgramW6432=C:\\Program Files\\Common Files",
        "COMPUTERNAME=DESKTOP-JB5KIF9",
        "ComSpec=C:\\Windows\\system32\\cmd.exe",
        "DriverData=C:\\Windows\\System32\\Drivers\\DriverData",
        "FPS_BROWSER_APP_PROFILE_STRING=Internet Explorer",
        "FPS_BROWSER_USER_PROFILE_STRING=Default",
        "GOPATH=C:\\Users\\ethan\\go",
        "HOMEDRIVE=C:",
        "HOMEPATH=\\Users\\ethan",
        "LOCALAPPDATA=C:\\Users\\ethan\\AppData\\Local",
        "LOGONSERVER=\\\\DESKTOP-JB5KIF9",
        "MOZ_CRASHREPORTER_DATA_DIRECTORY=C:\\Users\\ethan\\AppData\\Roaming\\Mozilla\\Firefox\\Crash Reports",
        "MOZ_CRASHREPORTER_EVENTS_DIRECTORY=C:\\Users\\ethan\\AppData\\Roaming\\Mozilla\\Firefox\\Profiles\\d0cdofwq.default-release\\crashes\\events",
        "MOZ_CRASHREPORTER_PING_DIRECTORY=C:\\Users\\ethan\\AppData\\Roaming\\Mozilla\\Firefox\\Pending Pings",
        "MOZ_CRASHREPORTER_STRINGS_OVERRIDE=C:\\Program Files\\Mozilla Firefox\\browser\\crashreporter-override.ini",
        "NUMBER_OF_PROCESSORS=16",
        "OneDrive=C:\\Users\\ethan\\OneDrive",
        "OPENSSL_ia32cap=~0x20000000",
        "OS=Windows_NT",
        "Path=C:\\Program Files\\Mozilla Firefox;C:\\Program Files (x86)\\Razer Chroma SDK\\bin;C:\\Program Files\\Razer Chroma SDK\\bin;C:\\Program Files (x86)\\Common Files\\Oracle\\Java\\java8path;C:\\Program Files (x86)\\Common Files\\Oracle\\Java\\javapath;C:\\Program Files (x86)\\Razer\\ChromaBroadcast\\bin;C:\\Program Files\\Razer\\ChromaBroadcast\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files (x86)\\NVIDIA Corporation\\PhysX\\Common;C:\\Program Files\\NVIDIA Corporation\\NVIDIA NvDLISR;C:\\Program Files (x86)\\Windows Kits\\10\\Windows Performance Toolkit\\;C:\\MinGW\\bin;C:\\Users\\ethan\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Program Files\\Git\\cmd;C:\\Windows\\system32\\config\\systemprofile\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Strawberry\\c\\bin;C:\\Strawberry\\perl\\site\\bin;C:\\Strawberry\\perl\\bin;C:\\Program Files\\Go\\bin;C:\\Program Files\\MATLAB\\R2024b\\bin;;C:\\Program Files\\Docker\\Docker\\resources\\bin;C:\\Users\\ethan\\.cargo\\bin;C:\\Users\\ethan\\AppData\\Local\\Programs\\Python\\Python313\\Scripts\\;C:\\Users\\ethan\\AppData\\Local\\Programs\\Python\\Python313\\;C:\\Users\\ethan\\scoop\\shims;C:\\Users\\ethan\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Users\\ethan\\AppData\\Local\\Programs\\Microsoft VS Code\\bin;C:\\Users\\ethan\\go\\bin;C:\\msys64\\ucrt64\\bin;;C:\\Program Files\\mitmproxy\\bin;C:\\Program Files (x86)\\Nmap",
        "PATHEXT=.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC",
        "PROCESSOR_ARCHITECTURE=AMD64",
        "PROCESSOR_IDENTIFIER=AMD64 Family 25 Model 80 Stepping 0, AuthenticAMD",
        "PROCESSOR_LEVEL=25",
        "PROCESSOR_REVISION=5000",
        "ProgramData=C:\\ProgramData",
        "ProgramFiles=C:\\Program Files",
        "ProgramFiles(x86)=C:\\Program Files (x86)",
        "ProgramW6432=C:\\Program Files",
        "PSModulePath=C:\\Program Files\\WindowsPowerShell\\Modules;C:\\Windows\\system32\\WindowsPowerShell\\v1.0\\Modules",
        "PUBLIC=C:\\Users\\Public",
        "QtMsBuild=C:\\Users\\ethan\\AppData\\Local\\QtMsBuild",
        "SESSIONNAME=Console",
        "SystemDrive=C:",
        "SystemRoot=C:\\Windows",
        "TEMP=C:\\Users\\ethan\\AppData\\Local\\Temp",
        "TMP=C:\\Users\\ethan\\AppData\\Local\\Temp",
        "USERDOMAIN=DESKTOP-JB5KIF9",
        "USERDOMAIN_ROAMINGPROFILE=DESKTOP-JB5KIF9",
        "USERNAME=ethan",
        "USERPROFILE=C:\\Users\\ethan",
        "VBOX_MSI_INSTALL_PATH=C:\\Program Files\\Oracle\\VirtualBox\\",
        "windir=C:\\Windows",
        "WXWIN=C:\\wxWidgets-3.2.6",
        "MALLOC_OPTIONS=r",
    ],
    command: [
        "C:\\Program Files\\Mozilla Firefox\\firefox.exe",
        "-contentproc",
        "-isForBrowser",
        "-prefsHandle",
        "9896",
        "-prefsLen",
        "40468",
        "-prefMapHandle",
        "11220",
        "-prefMapSize",
        "270902",
        "-jsInitHandle",
        "10448",
        "-jsInitLen",
        "254356",
        "-parentBuildID",
        "20241230151726",
        "-ipcHandle",
        "11040",
        "-initialChannelId",
        "{f34f9332-265b-4006-b6f8-6ecfab56fc1c}",
        "-parentPid",
        "23156",
        "-crashReporter",
        "\\\\.\\pipe\\gecko-crash-server-pipe.23156",
        "-win32kLockedDown",
        "-appDir",
        "C:\\Program Files\\Mozilla Firefox\\browser",
        "-",
        "43",
        "tab",
    ],
    executable path: Some(
        "C:\\Program Files\\Mozilla Firefox\\firefox.exe",
    ),
    current working directory: Some(
        "C:\\Program Files\\Mozilla Firefox\\",
    ),
    memory usage: 121282560,
    virtual memory usage: 107905024,
    CPU usage: 0.00015954098,
    status: Run,
    root: Some(
        "C:\\",
    ),
    disk_usage: DiskUsage {
        total_written_bytes: 586648,
        written_bytes: 0,
        total_read_bytes: 776895,
        read_bytes: 0,
    },
    user_id: Some(
        Uid(
            Sid {
                sid: [
                    1,
                    5,
                    0,
                    0,
                    0,
                    0,
                    0,
                    5,
                    21,
                    0,
                    0,
                    0,
                    221,
                    122,
                    134,
                    23,
                    120,
                    185,
                    86,
                    178,
                    191,
                    105,
                    29,
                    233,
                    3,
                    0,
                    0,
                ],
            },
        ),
    ),
    effective_user_id: None,
}
```

## Output from current implementation
```
[src/main.rs:6:9] process = Process {
    pid: Pid(
        58420,
    ),
    parent: Some(
        Pid(
            23156,
        ),
    ),
    name: "firefox.exe",
    environ: [
        "=::=::\\",
        "ALLUSERSPROFILE=C:\\ProgramData",
        "APPDATA=C:\\Users\\ethan\\AppData\\Roaming",
        "CommonProgramFiles=C:\\Program Files\\Common Files",
        "CommonProgramFiles(x86)=C:\\Program Files (x86)\\Common Files",
        "CommonProgramW6432=C:\\Program Files\\Common Files",
        "COMPUTERNAME=DESKTOP-JB5KIF9",
        "ComSpec=C:\\Windows\\system32\\cmd.exe",
        "DriverData=C:\\Windows\\System32\\Drivers\\DriverData",
        "FPS_BROWSER_APP_PROFILE_STRING=Internet Explorer",
        "FPS_BROWSER_USER_PROFILE_STRING=Default",
        "GOPATH=C:\\Users\\ethan\\go",
        "HOMEDRIVE=C:",
        "HOMEPATH=\\Users\\ethan",
        "LOCALAPPDATA=C:\\Users\\ethan\\AppData\\Local",
        "LOGONSERVER=\\\\DESKTOP-JB5KIF9",
        "MOZ_CRASHREPORTER_DATA_DIRECTORY=C:\\Users\\ethan\\AppData\\Roaming\\Mozilla\\Firefox\\Crash Reports",
        "MOZ_CRASHREPORTER_EVENTS_DIRECTORY=C:\\Users\\ethan\\AppData\\Roaming\\Mozilla\\Firefox\\Profiles\\d0cdofwq.default-release\\crashes\\events",
        "MOZ_CRASHREPORTER_PING_DIRECTORY=C:\\Users\\ethan\\AppData\\Roaming\\Mozilla\\Firefox\\Pending Pings",
        "MOZ_CRASHREPORTER_STRINGS_OVERRIDE=C:\\Program Files\\Mozilla Firefox\\browser\\crashreporter-override.ini",
        "NUMBER_OF_PROCESSORS=16",
        "OneDrive=C:\\Users\\ethan\\OneDrive",
        "OPENSSL_ia32cap=~0x20000000",
        "OS=Windows_NT",
        "Path=C:\\Program Files\\Mozilla Firefox;C:\\Program Files (x86)\\Razer Chroma SDK\\bin;C:\\Program Files\\Razer Chroma SDK\\bin;C:\\Program Files (x86)\\Common Files\\Oracle\\Java\\java8path;C:\\Program Files (x86)\\Common Files\\Oracle\\Java\\javapath;C:\\Program Files (x86)\\Razer\\ChromaBroadcast\\bin;C:\\Program Files\\Razer\\ChromaBroadcast\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files (x86)\\NVIDIA Corporation\\PhysX\\Common;C:\\Program Files\\NVIDIA Corporation\\NVIDIA NvDLISR;C:\\Program Files (x86)\\Windows Kits\\10\\Windows Performance Toolkit\\;C:\\MinGW\\bin;C:\\Users\\ethan\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Program Files\\Git\\cmd;C:\\Windows\\system32\\config\\systemprofile\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Strawberry\\c\\bin;C:\\Strawberry\\perl\\site\\bin;C:\\Strawberry\\perl\\bin;C:\\Program Files\\Go\\bin;C:\\Program Files\\MATLAB\\R2024b\\bin;;C:\\Program Files\\Docker\\Docker\\resources\\bin;C:\\Users\\ethan\\.cargo\\bin;C:\\Users\\ethan\\AppData\\Local\\Programs\\Python\\Python313\\Scripts\\;C:\\Users\\ethan\\AppData\\Local\\Programs\\Python\\Python313\\;C:\\Users\\ethan\\scoop\\shims;C:\\Users\\ethan\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Users\\ethan\\AppData\\Local\\Programs\\Microsoft VS Code\\bin;C:\\Users\\ethan\\go\\bin;C:\\msys64\\ucrt64\\bin;;C:\\Program Files\\mitmproxy\\bin;C:\\Program Files (x86)\\Nmap",
        "PATHEXT=.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC",
        "PROCESSOR_ARCHITECTURE=AMD64",
        "PROCESSOR_IDENTIFIER=AMD64 Family 25 Model 80 Stepping 0, AuthenticAMD",
        "PROCESSOR_LEVEL=25",
        "PROCESSOR_REVISION=5000",
        "ProgramData=C:\\ProgramData",
        "ProgramFiles=C:\\Program Files",
        "ProgramFiles(x86)=C:\\Program Files (x86)",
        "ProgramW6432=C:\\Program Files",
        "PSModulePath=C:\\Program Files\\WindowsPowerShell\\Modules;C:\\Windows\\system32\\WindowsPowerShell\\v1.0\\Modules",
        "PUBLIC=C:\\Users\\Public",
        "QtMsBuild=C:\\Users\\ethan\\AppData\\Local\\QtMsBuild",
        "SESSIONNAME=Console",
        "SystemDrive=C:",
        "SystemRoot=C:\\Windows",
        "TEMP=C:\\Users\\ethan\\AppData\\Local\\Temp",
        "TMP=C:\\Users\\ethan\\AppData\\Local\\Temp",
        "USERDOMAIN=DESKTOP-JB5KIF9",
        "USERDOMAIN_ROAMINGPROFILE=DESKTOP-JB5KIF9",
        "USERNAME=ethan",
        "USERPROFILE=C:\\Users\\ethan",
        "VBOX_MSI_INSTALL_PATH=C:\\Program Files\\Oracle\\VirtualBox\\",
        "windir=C:\\Windows",
        "WXWIN=C:\\wxWidgets-3.2.6",
        "MALLOC_OPTIONS=r",
    ],
    command: [
        "C:\\Program Files\\Mozilla Firefox\\firefox.exe",
        "-contentproc",
        "-isForBrowser",
        "-prefsHandle",
        "9896",
        "-prefsLen",
        "40468",
        "-prefMapHandle",
        "11220",
        "-prefMapSize",
        "270902",
        "-jsInitHandle",
        "10448",
        "-jsInitLen",
        "254356",
        "-parentBuildID",
        "20241230151726",
        "-ipcHandle",
        "11040",
        "-initialChannelId",
        "{f34f9332-265b-4006-b6f8-6ecfab56fc1c}",
        "-parentPid",
        "23156",
        "-crashReporter",
        "\\\\.\\pipe\\gecko-crash-server-pipe.23156",
        "-win32kLockedDown",
        "-appDir",
        "C:\\Program Files\\Mozilla Firefox\\browser",
        "-",
        "43",
        "tab",
    ],
    executable path: Some(
        "C:\\Program Files\\Mozilla Firefox\\firefox.exe",
    ),
    current working directory: Some(
        "C:\\Program Files\\Mozilla Firefox\\",
    ),
    memory usage: 29417472,
    virtual memory usage: 2205842980864,
    CPU usage: 5.705234e-6,
    status: Run,
    root: Some(
        "C:\\",
    ),
    disk_usage: DiskUsage {
        total_written_bytes: 32464,
        written_bytes: 32464,
        total_read_bytes: 66151,
        read_bytes: 66151,
    },
    user_id: Some(
        Uid(
            Sid {
                sid: [
                    1,
                    5,
                    0,
                    0,
                    0,
                    0,
                    0,
                    5,
                    21,
                    0,
                    0,
                    0,
                    221,
                    122,
                    134,
                    23,
                    120,
                    185,
                    86,
                    178,
                    102,
                    191,
                    105,
                    29,
                    233,
                    3,
                    0,
                    0,
                ],
            },
        ),
    ),
    effective_user_id: None,
}
```

**Note: some values may have changed in between testing, though they are relatively the same. Tested on a Firefox process. (Hopefully I didn't leak anything crazy and sorry for the absurd amount of commits :/)