### PR TITLE
Add System::distribution_id_like()

### DIFF
--- a/src/common/system.rs
+++ b/src/common/system.rs
@@ -784,6 +784,33 @@ impl System {
         SystemInner::distribution_id()
     }
 
+    /// Returns the distribution ids of operating systems that are closely
+    /// related to the local operating system in regards to packaging and
+    /// programming interfaces, for example listing one or more OS identifiers
+    /// the local OS is a derivative from.
+    ///
+    /// See also
+    /// - <https://www.freedesktop.org/software/systemd/man/latest/os-release.html#ID_LIKE=>
+    ///
+    /// | example platform | value of `System::distribution_id_like()` |
+    /// |---|---|
+    /// | android phone | [] |
+    /// | archlinux laptop | [] |
+    /// | centos server | ["rhel", "fedora"] |
+    /// | ubuntu laptop | ["debian"] |
+    /// | windows laptop | [] |
+    ///
+    /// **Important**: this information is computed every time this function is called.
+    ///
+    /// ```no_run
+    /// use sysinfo::System;
+    ///
+    /// println!("Distribution ID_LIKE: {:?}", System::distribution_id_like());
+    /// ```
+    pub fn distribution_id_like() -> Vec<String> {
+        SystemInner::distribution_id_like()
+    }
+
     /// Returns the system hostname based off DNS.
     ///
     /// **Important**: this information is computed every time this function is called.

--- a/src/unix/apple/system.rs
+++ b/src/unix/apple/system.rs
@@ -497,6 +497,10 @@ impl SystemInner {
         std::env::consts::OS.to_owned()
     }
 
+    pub(crate) fn distribution_id_like() -> Vec<String> {
+        Vec::new()
+    }
+
     pub(crate) fn cpu_arch() -> Option<String> {
         let mut arch_str: [u8; 32] = [0; 32];
         let mut mib = [libc::CTL_HW as _, libc::HW_MACHINE as _];

--- a/src/unix/freebsd/system.rs
+++ b/src/unix/freebsd/system.rs
@@ -247,6 +247,10 @@ impl SystemInner {
         std::env::consts::OS.to_owned()
     }
 
+    pub(crate) fn distribution_id_like() -> Vec<String> {
+        Vec::new()
+    }
+
     pub(crate) fn cpu_arch() -> Option<String> {
         let mut arch_str: [u8; 32] = [0; 32];
         let mib = [libc::CTL_HW as _, libc::HW_MACHINE as _];

--- a/src/unknown/system.rs
+++ b/src/unknown/system.rs
@@ -135,6 +135,10 @@ impl SystemInner {
         std::env::consts::OS.to_owned()
     }
 
+    pub(crate) fn distribution_id_like() -> Vec<String> {
+        Vec::new()
+    }
+
     pub(crate) fn host_name() -> Option<String> {
         None
     }

--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -418,6 +418,11 @@ impl SystemInner {
     pub(crate) fn distribution_id() -> String {
         std::env::consts::OS.to_owned()
     }
+
+    pub(crate) fn distribution_id_like() -> Vec<String> {
+        Vec::new()
+    }
+
     pub(crate) fn cpu_arch() -> Option<String> {
         unsafe {
             // https://docs.microsoft.com/fr-fr/windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info


### PR DESCRIPTION
This is similar to System::distribution_id() but for ID_LIKE. See
<https://www.freedesktop.org/software/systemd/man/latest/os-release.html#ID_LIKE=>.