### PR TITLE
Use `objc2-core-foundation`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,11 @@ component = [
     "windows/Win32_System_Rpc",
     "windows/Win32_System_Variant",
     "windows/Win32_System_Wmi",
+    "objc2-core-foundation/CFArray",
+    "objc2-core-foundation/CFBase",
+    "objc2-core-foundation/CFDictionary",
+    "objc2-core-foundation/CFNumber",
+    "objc2-core-foundation/CFString",
 ]
 disk = [
     "windows/Win32_Foundation",
@@ -32,6 +37,13 @@ disk = [
     "windows/Win32_System_Ioctl",
     "windows/Win32_System_SystemServices",
     "windows/Win32_System_WindowsProgramming",
+    "objc2-core-foundation/CFArray",
+    "objc2-core-foundation/CFBase",
+    "objc2-core-foundation/CFDictionary",
+    "objc2-core-foundation/CFError",
+    "objc2-core-foundation/CFNumber",
+    "objc2-core-foundation/CFString",
+    "objc2-core-foundation/CFURL",
 ]
 system = [
     "windows/Win32_Foundation",
@@ -54,6 +66,10 @@ system = [
     "windows/Win32_UI_Shell",
     "dep:ntapi",
     "dep:memchr",
+    "objc2-core-foundation/CFBase",
+    "objc2-core-foundation/CFData",
+    "objc2-core-foundation/CFDictionary",
+    "objc2-core-foundation/CFString",
 ]
 network = [
     "windows/Win32_Foundation",
@@ -107,7 +123,9 @@ windows = { version = ">=0.54, <=0.57", optional = true }
 libc = "^0.2.164"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-core-foundation-sys = "0.8.7"
+objc2-core-foundation = { version = "0.3.0", optional = true, default-features = false, features = [
+    "std",
+] }
 
 [target.'cfg(all(target_os = "linux", not(target_os = "android")))'.dev-dependencies]
 tempfile = "3.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,7 +320,7 @@ mod test {
         }
     }
 
-    #[cfg(feature = "system")]
+    #[cfg(all(feature = "system", feature = "user"))]
     #[test]
     fn check_all_process_uids_resolvable() {
         // On linux, some user IDs don't have an associated user (no idea why though).

--- a/src/unix/apple/ffi.rs
+++ b/src/unix/apple/ffi.rs
@@ -9,30 +9,7 @@ pub use crate::sys::inner::ffi::*;
 
 cfg_if! {
     if #[cfg(feature = "disk")] {
-        use core_foundation_sys::{
-            array::CFArrayRef, dictionary::CFDictionaryRef, error::CFErrorRef, string::CFStringRef,
-            url::CFURLRef,
-        };
         use std::ffi::c_void;
-
-        #[link(name = "CoreFoundation", kind = "framework")]
-        extern "C" {
-            pub fn CFURLCopyResourcePropertiesForKeys(
-                url: CFURLRef,
-                keys: CFArrayRef,
-                error: *mut CFErrorRef,
-            ) -> CFDictionaryRef;
-
-            pub static kCFURLVolumeIsEjectableKey: CFStringRef;
-            pub static kCFURLVolumeIsRemovableKey: CFStringRef;
-            pub static kCFURLVolumeAvailableCapacityKey: CFStringRef;
-            pub static kCFURLVolumeAvailableCapacityForImportantUsageKey: CFStringRef;
-            pub static kCFURLVolumeTotalCapacityKey: CFStringRef;
-            pub static kCFURLVolumeNameKey: CFStringRef;
-            pub static kCFURLVolumeIsLocalKey: CFStringRef;
-            pub static kCFURLVolumeIsInternalKey: CFStringRef;
-            pub static kCFURLVolumeIsBrowsableKey: CFStringRef;
-        }
 
         #[link(name = "objc", kind = "dylib")]
         extern "C" {

--- a/src/unix/apple/macos/component/arm.rs
+++ b/src/unix/apple/macos/component/arm.rs
@@ -1,26 +1,23 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use std::ffi::CStr;
+use std::ptr::NonNull;
 
-use core_foundation_sys::array::{CFArrayGetCount, CFArrayGetValueAtIndex};
-use core_foundation_sys::base::kCFAllocatorDefault;
-use core_foundation_sys::string::{
-    kCFStringEncodingUTF8, CFStringCreateWithBytes, CFStringGetCStringPtr,
+use objc2_core_foundation::{
+    kCFAllocatorDefault, CFArrayGetCount, CFArrayGetValueAtIndex, CFRetained, CFString,
 };
 
 use crate::sys::inner::ffi::{
     kHIDPage_AppleVendor, kHIDUsage_AppleVendor_TemperatureSensor, kIOHIDEventTypeTemperature,
     matching, IOHIDEventFieldBase, IOHIDEventGetFloatValue, IOHIDEventSystemClientCopyServices,
     IOHIDEventSystemClientCreate, IOHIDEventSystemClientSetMatching, IOHIDServiceClientCopyEvent,
-    IOHIDServiceClientCopyProperty, __IOHIDEventSystemClient, __IOHIDServiceClient,
-    HID_DEVICE_PROPERTY_PRODUCT,
+    IOHIDServiceClientCopyProperty, HID_DEVICE_PROPERTY_PRODUCT,
 };
-use crate::sys::utils::CFReleaser;
+use crate::unix::apple::ffi::{IOHIDEventSystemClient, IOHIDServiceClient};
 use crate::Component;
 
 pub(crate) struct ComponentsInner {
     pub(crate) components: Vec<Component>,
-    client: Option<CFReleaser<__IOHIDEventSystemClient>>,
+    client: Option<CFRetained<IOHIDEventSystemClient>>,
 }
 
 impl ComponentsInner {
@@ -53,68 +50,49 @@ impl ComponentsInner {
     #[allow(unreachable_code)]
     pub(crate) fn refresh(&mut self) {
         unsafe {
-            let matches = match CFReleaser::new(matching(
+            let matches = match matching(
                 kHIDPage_AppleVendor,
                 kHIDUsage_AppleVendor_TemperatureSensor,
-            )) {
+            ) {
                 Some(m) => m,
                 None => return,
             };
 
             if self.client.is_none() {
-                let client =
-                    match CFReleaser::new(IOHIDEventSystemClientCreate(kCFAllocatorDefault)) {
-                        Some(c) => c,
-                        None => return,
-                    };
+                let client = match IOHIDEventSystemClientCreate(kCFAllocatorDefault) {
+                    Some(c) => CFRetained::from_raw(c),
+                    None => return,
+                };
                 self.client = Some(client);
             }
 
             let client = self.client.as_ref().unwrap();
 
-            let _ = IOHIDEventSystemClientSetMatching(client.inner(), matches.inner());
+            let _ = IOHIDEventSystemClientSetMatching(client, &matches);
 
-            let services = match CFReleaser::new(IOHIDEventSystemClientCopyServices(client.inner()))
-            {
-                Some(s) => s,
+            let services = match IOHIDEventSystemClientCopyServices(client) {
+                Some(s) => CFRetained::from_raw(s),
                 None => return,
             };
 
-            let key_ref = match CFReleaser::new(CFStringCreateWithBytes(
-                kCFAllocatorDefault,
-                HID_DEVICE_PROPERTY_PRODUCT.as_ptr(),
-                HID_DEVICE_PROPERTY_PRODUCT.len() as _,
-                kCFStringEncodingUTF8,
-                false as _,
-            )) {
-                Some(r) => r,
-                None => return,
-            };
+            let key = CFString::from_static_str(HID_DEVICE_PROPERTY_PRODUCT);
 
-            let count = CFArrayGetCount(services.inner());
+            let count = CFArrayGetCount(&services);
 
             for i in 0..count {
-                // The 'service' should never be freed since it is returned by a 'Get' call.
-                // See issue https://github.com/GuillaumeGomez/sysinfo/issues/1279
-                let service = CFArrayGetValueAtIndex(services.inner(), i);
+                let service = CFArrayGetValueAtIndex(&services, i).cast::<IOHIDServiceClient>();
                 if service.is_null() {
                     continue;
                 }
+                // The 'service' should never be freed since it is returned by a 'Get' call.
+                // See issue https://github.com/GuillaumeGomez/sysinfo/issues/1279
+                let service = CFRetained::retain(NonNull::from(&*service));
 
-                let Some(name) = CFReleaser::new(IOHIDServiceClientCopyProperty(
-                    service as *const _,
-                    key_ref.inner(),
-                )) else {
+                let Some(name) = IOHIDServiceClientCopyProperty(&service, &key) else {
                     continue;
                 };
-
-                let name_ptr =
-                    CFStringGetCStringPtr(name.inner() as *const _, kCFStringEncodingUTF8);
-                if name_ptr.is_null() {
-                    continue;
-                }
-
-                let name_str = CStr::from_ptr(name_ptr).to_string_lossy().to_string();
+                let name = CFRetained::from_raw(name);
+                let name_str = name.to_string();
 
                 if let Some(c) = self
                     .components
@@ -126,7 +104,7 @@ impl ComponentsInner {
                     continue;
                 }
 
-                let mut component = ComponentInner::new(name_str, None, None, service as *mut _);
+                let mut component = ComponentInner::new(name_str, None, None, service);
                 component.refresh();
 
                 self.components.push(Component { inner: component });
@@ -136,7 +114,7 @@ impl ComponentsInner {
 }
 
 pub(crate) struct ComponentInner {
-    service: *mut __IOHIDServiceClient,
+    service: CFRetained<IOHIDServiceClient>,
     temperature: Option<f32>,
     label: String,
     max: f32,
@@ -152,7 +130,7 @@ impl ComponentInner {
         label: String,
         max: Option<f32>,
         critical: Option<f32>,
-        service: *mut __IOHIDServiceClient,
+        service: CFRetained<IOHIDServiceClient>,
     ) -> Self {
         Self {
             service,
@@ -182,20 +160,17 @@ impl ComponentInner {
 
     pub(crate) fn refresh(&mut self) {
         unsafe {
-            let Some(event) = CFReleaser::new(IOHIDServiceClientCopyEvent(
-                self.service as *const _,
-                kIOHIDEventTypeTemperature,
-                0,
-                0,
-            )) else {
+            let Some(event) =
+                IOHIDServiceClientCopyEvent(&self.service, kIOHIDEventTypeTemperature, 0, 0)
+            else {
                 self.temperature = None;
                 return;
             };
+            let event = CFRetained::from_raw(event);
 
-            let temperature = IOHIDEventGetFloatValue(
-                event.inner(),
-                IOHIDEventFieldBase(kIOHIDEventTypeTemperature),
-            ) as _;
+            let temperature =
+                IOHIDEventGetFloatValue(&event, IOHIDEventFieldBase(kIOHIDEventTypeTemperature))
+                    as _;
             self.temperature = Some(temperature);
             if temperature > self.max {
                 self.max = temperature;

--- a/src/unix/apple/macos/component/x86.rs
+++ b/src/unix/apple/macos/component/x86.rs
@@ -296,11 +296,12 @@ impl IoService {
         let mut iterator: ffi::io_iterator_t = 0;
 
         unsafe {
-            let matching_dictionary = ffi::IOServiceMatching(b"AppleSMC\0".as_ptr() as *const i8);
-            if matching_dictionary.is_null() {
+            let Some(matching_dictionary) =
+                ffi::IOServiceMatching(b"AppleSMC\0".as_ptr() as *const i8)
+            else {
                 sysinfo_debug!("IOServiceMatching call failed, `AppleSMC` not found");
                 return None;
-            }
+            };
             let result = ffi::IOServiceGetMatchingServices(
                 ffi::kIOMasterPortDefault,
                 matching_dictionary,

--- a/src/unix/apple/macos/process.rs
+++ b/src/unix/apple/macos/process.rs
@@ -329,7 +329,7 @@ unsafe fn get_bsd_info(pid: Pid) -> Option<libc::proc_bsdinfo> {
         0,
         &mut info as *mut _ as *mut _,
         mem::size_of::<libc::proc_bsdinfo>() as _,
-    ) != mem::size_of::<libc::proc_bsdinfo>() as _
+    ) != mem::size_of::<libc::proc_bsdinfo>() as c_int
     {
         None
     } else {

--- a/src/unix/apple/utils.rs
+++ b/src/unix/apple/utils.rs
@@ -1,51 +1,5 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use core_foundation_sys::base::CFRelease;
-use std::ptr::NonNull;
-
-// A helper using to auto release the resource got from CoreFoundation.
-// More information about the ownership policy for CoreFoundation pelease refer the link below:
-// https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/Concepts/Ownership.html#//apple_ref/doc/uid/20001148-CJBEJBHH
-#[repr(transparent)]
-#[allow(dead_code)]
-pub(crate) struct CFReleaser<T>(NonNull<T>);
-
-#[allow(dead_code)]
-impl<T> CFReleaser<T> {
-    pub(crate) fn new(ptr: *const T) -> Option<Self> {
-        // This cast is OK because `NonNull` is a transparent wrapper
-        // over a `*const T`. Additionally, mutability doesn't matter with
-        // pointers here.
-        NonNull::new(ptr as *mut T).map(Self)
-    }
-
-    pub(crate) fn inner(&self) -> *const T {
-        self.0.as_ptr().cast()
-    }
-}
-
-impl<T> Drop for CFReleaser<T> {
-    fn drop(&mut self) {
-        unsafe { CFRelease(self.0.as_ptr().cast()) }
-    }
-}
-
-// Safety: These are safe to implement because we only wrap non-mutable
-// CoreFoundation types, which are generally threadsafe unless noted
-// otherwise.
-unsafe impl<T> Send for CFReleaser<T> {}
-unsafe impl<T> Sync for CFReleaser<T> {}
-
-#[cfg(feature = "disk")]
-pub(crate) fn vec_to_rust(buf: Vec<i8>) -> Option<String> {
-    String::from_utf8(
-        buf.into_iter()
-            .flat_map(|b| if b > 0 { Some(b as u8) } else { None })
-            .collect(),
-    )
-    .ok()
-}
-
 #[cfg(feature = "system")]
 pub(crate) unsafe fn get_sys_value(
     mut len: usize,


### PR DESCRIPTION
Use `objc2-core-foundation`, which is a (mostly) auto-generated version of `core-foundation-sys`.

This avoids error-prone use of `CFReleaser::new` (called `CFRetained::from_raw` in `objc2-core-foundation`) in many cases, since `objc2-core-foundation` handles that correctly according to the memory management rules. Additionally, we use the `CFString` conversions in `objc2-core-foundation` to avoid re-implementing them in this crate.