### PR TITLE
Fix wait_process cfg

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -211,12 +211,20 @@ jobs:
           command: check
           args: --features apple-sandbox --target=${{ matrix.triple.target }} --manifest-path=Cargo.toml
           use-cross: ${{ matrix.triple.cross }}
+
       - name: Check without multithreading (Apple app store restrictions)
         if: matrix.triple.os == 'macos-latest'
         uses: ClementTsang/cargo-action@v0.0.6
         with:
           command: check
           args: --features apple-sandbox --target=${{ matrix.triple.target }} --manifest-path=Cargo.toml --no-default-features
+          use-cross: ${{ matrix.triple.cross }}
+
+      - name: Check features (system with Apple app store restrictions)
+        uses: ClementTsang/cargo-action@v0.0.6
+        with:
+          command: check
+          args: --target=${{ matrix.triple.target }} --manifest-path=Cargo.toml --no-default-features --features system,apple-sandbox
           use-cross: ${{ matrix.triple.cross }}
 
   tests:

--- a/src/unix/apple/ffi.rs
+++ b/src/unix/apple/ffi.rs
@@ -3,7 +3,13 @@
 // Reexport items defined in either macos or ios ffi module.
 #[cfg(all(
     not(target_os = "ios"),
-    any(feature = "component", feature = "disk", feature = "system"),
+    any(
+        feature = "disk",
+        all(
+            not(feature = "apple-sandbox"),
+            any(feature = "component", feature = "system")
+        ),
+    ),
 ))]
 pub use crate::sys::inner::ffi::*;
 

--- a/src/unix/apple/macos/ffi.rs
+++ b/src/unix/apple/macos/ffi.rs
@@ -1,46 +1,75 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 #[cfg(any(
-    feature = "system",
     feature = "disk",
     all(
-        feature = "component",
-        any(target_arch = "x86", target_arch = "x86_64")
+        not(feature = "apple-sandbox"),
+        any(
+            feature = "system",
+            all(
+                feature = "component",
+                any(target_arch = "x86", target_arch = "x86_64")
+            )
+        )
     ),
 ))]
 use libc::mach_port_t;
-#[cfg(any(feature = "system", feature = "disk"))]
+#[cfg(any(
+    all(feature = "system", not(feature = "apple-sandbox")),
+    feature = "disk"
+))]
 use objc2_core_foundation::CFAllocator;
 #[cfg(any(
-    feature = "system",
     feature = "disk",
     all(
-        feature = "component",
-        any(target_arch = "x86", target_arch = "x86_64")
+        not(feature = "apple-sandbox"),
+        any(
+            feature = "system",
+            all(
+                feature = "component",
+                any(target_arch = "x86", target_arch = "x86_64")
+            )
+        )
     ),
 ))]
 use objc2_core_foundation::CFMutableDictionary;
-#[cfg(any(feature = "system", feature = "disk"))]
+#[cfg(any(
+    all(feature = "system", not(feature = "apple-sandbox")),
+    feature = "disk"
+))]
 use objc2_core_foundation::CFString;
-#[cfg(any(feature = "system", feature = "disk"))]
+#[cfg(any(
+    all(feature = "system", not(feature = "apple-sandbox")),
+    feature = "disk"
+))]
 use objc2_core_foundation::CFType;
 #[cfg(any(
-    feature = "system",
     feature = "disk",
     all(
-        feature = "component",
-        any(target_arch = "x86", target_arch = "x86_64")
+        not(feature = "apple-sandbox"),
+        any(
+            feature = "system",
+            all(
+                feature = "component",
+                any(target_arch = "x86", target_arch = "x86_64")
+            )
+        )
     ),
 ))]
 use std::ptr::NonNull;
 
 use libc::c_char;
 #[cfg(any(
-    feature = "system",
     feature = "disk",
     all(
-        feature = "component",
-        any(target_arch = "x86", target_arch = "x86_64")
+        not(feature = "apple-sandbox"),
+        any(
+            feature = "system",
+            all(
+                feature = "component",
+                any(target_arch = "x86", target_arch = "x86_64")
+            )
+        )
     ),
 ))]
 use libc::kern_return_t;
@@ -48,38 +77,57 @@ use libc::kern_return_t;
 // Note: IOKit is only available on macOS up until very recent iOS versions: https://developer.apple.com/documentation/iokit
 
 #[cfg(any(
-    feature = "system",
     feature = "disk",
     all(
-        feature = "component",
-        any(target_arch = "x86", target_arch = "x86_64")
+        not(feature = "apple-sandbox"),
+        any(
+            feature = "system",
+            all(
+                feature = "component",
+                any(target_arch = "x86", target_arch = "x86_64")
+            )
+        )
     ),
 ))]
 #[allow(non_camel_case_types)]
 pub type io_object_t = mach_port_t;
 
 #[cfg(any(
-    feature = "system",
     feature = "disk",
     all(
-        feature = "component",
-        any(target_arch = "x86", target_arch = "x86_64")
+        not(feature = "apple-sandbox"),
+        any(
+            feature = "system",
+            all(
+                feature = "component",
+                any(target_arch = "x86", target_arch = "x86_64")
+            )
+        )
     ),
 ))]
 #[allow(non_camel_case_types)]
 pub type io_iterator_t = io_object_t;
-#[cfg(any(feature = "system", feature = "disk"))]
+#[cfg(any(
+    all(feature = "system", not(feature = "apple-sandbox")),
+    feature = "disk"
+))]
 #[allow(non_camel_case_types)]
 pub type io_registry_entry_t = io_object_t;
 // This is a hack, `io_name_t` should normally be `[c_char; 128]` but Rust makes it very annoying
 // to deal with that so we go around it a bit.
 #[allow(non_camel_case_types, dead_code)]
 pub type io_name = [c_char; 128];
-#[cfg(any(feature = "system", feature = "disk"))]
+#[cfg(any(
+    all(feature = "system", not(feature = "apple-sandbox")),
+    feature = "disk"
+))]
 #[allow(non_camel_case_types)]
 pub type io_name_t = *const c_char;
 
-#[cfg(any(feature = "system", feature = "disk"))]
+#[cfg(any(
+    all(feature = "system", not(feature = "apple-sandbox")),
+    feature = "disk"
+))]
 pub type IOOptionBits = u32;
 
 cfg_if! {
@@ -107,22 +155,32 @@ cfg_if! {
 // we can simply set it to 0 (and is the same value as its replacement `kIOMainPortDefault`).
 #[allow(non_upper_case_globals)]
 #[cfg(any(
-    feature = "system",
     feature = "disk",
     all(
-        feature = "component",
-        any(target_arch = "x86", target_arch = "x86_64")
+        not(feature = "apple-sandbox"),
+        any(
+            feature = "system",
+            all(
+                feature = "component",
+                any(target_arch = "x86", target_arch = "x86_64")
+            )
+        )
     ),
 ))]
 pub const kIOMasterPortDefault: mach_port_t = 0;
 
 // Note: Obtaining information about disks using IOKIt is allowed inside the default macOS App Sandbox.
 #[cfg(any(
-    feature = "system",
     feature = "disk",
     all(
-        feature = "component",
-        any(target_arch = "x86", target_arch = "x86_64")
+        not(feature = "apple-sandbox"),
+        any(
+            feature = "system",
+            all(
+                feature = "component",
+                any(target_arch = "x86", target_arch = "x86_64")
+            )
+        )
     ),
 ))]
 #[link(name = "IOKit", kind = "framework")]

--- a/src/unix/apple/macos/mod.rs
+++ b/src/unix/apple/macos/mod.rs
@@ -12,11 +12,19 @@ cfg_if! {
         pub use crate::sys::app_store::process;
     }
 
+
     if #[cfg(any(
-            feature = "system",
             feature = "disk",
-            target_arch = "x86",
-            target_arch = "x86_64",
+            all(
+                not(feature = "apple-sandbox"),
+                any(
+                    feature = "system",
+                    all(
+                        feature = "component",
+                        any(target_arch = "x86", target_arch = "x86_64")
+                    )
+                )
+            ),
         ))]
     {
         pub(crate) mod utils;

--- a/src/unix/utils.rs
+++ b/src/unix/utils.rs
@@ -37,7 +37,10 @@ pub(crate) fn cstr_to_rust_with_size(
 
 #[cfg(all(
     feature = "system",
-    not(any(target_os = "ios", feature = "apple-sandbox"))
+    not(any(
+        target_os = "ios",
+        all(target_os = "macos", feature = "apple-sandbox",)
+    ))
 ))]
 pub(crate) fn wait_process(pid: crate::Pid) -> Option<std::process::ExitStatus> {
     use std::os::unix::process::ExitStatusExt;


### PR DESCRIPTION
Fixes https://github.com/GuillaumeGomez/sysinfo/issues/1475

Rewrites the `wait_process` cfg so that the function is available on all platforms except on iOS and macOS when the `apple-sandbox` feature is enabled.

Adds an additional CI check as requested.