### PR TITLE
Fallback to u64::MAX when memory.max is not a number

### DIFF
--- a/src/unix/linux/system.rs
+++ b/src/unix/linux/system.rs
@@ -558,9 +558,15 @@ impl SystemInner {
 }
 
 fn read_u64(filename: &str) -> Option<u64> {
-    get_all_utf8_data(filename, 16_635)
+    let result = get_all_utf8_data(filename, 16_635)
         .ok()
-        .and_then(|d| u64::from_str(d.trim()).ok())
+        .and_then(|d| u64::from_str(d.trim()).ok());
+
+    if result.is_none() {
+        sysinfo_debug!("Failed to read u64 in filename {}", filename);
+    }
+
+    result
 }
 
 fn read_table<F>(filename: &str, colsep: char, mut f: F)

--- a/src/unix/linux/system.rs
+++ b/src/unix/linux/system.rs
@@ -606,7 +606,7 @@ impl crate::CGroupLimits {
             sys.mem_total != 0,
             "You need to call System::refresh_memory before trying to get cgroup limits!",
         );
-        if let (Some(mem_cur), mem_max, Some(mem_rss)) = (
+        if let (Some(mem_cur), Some(mem_max), Some(mem_rss)) = (
             // cgroups v2
             read_u64("/sys/fs/cgroup/memory.current"),
             // memory.max contains `max` when no limit is set.

--- a/src/unix/linux/system.rs
+++ b/src/unix/linux/system.rs
@@ -609,7 +609,8 @@ impl crate::CGroupLimits {
         if let (Some(mem_cur), Some(mem_max), Some(mem_rss)) = (
             // cgroups v2
             read_u64("/sys/fs/cgroup/memory.current"),
-            read_u64("/sys/fs/cgroup/memory.max"),
+            // memory.max contains `max` when no limit is set.
+            read_u64("/sys/fs/cgroup/memory.max").unwrap_or(u64::MAX),
             read_table_key("/sys/fs/cgroup/memory.stat", "anon", ' '),
         ) {
             let mut limits = Self {

--- a/src/unix/linux/system.rs
+++ b/src/unix/linux/system.rs
@@ -606,11 +606,11 @@ impl crate::CGroupLimits {
             sys.mem_total != 0,
             "You need to call System::refresh_memory before trying to get cgroup limits!",
         );
-        if let (Some(mem_cur), Some(mem_max), Some(mem_rss)) = (
+        if let (Some(mem_cur), mem_max, Some(mem_rss)) = (
             // cgroups v2
             read_u64("/sys/fs/cgroup/memory.current"),
             // memory.max contains `max` when no limit is set.
-            read_u64("/sys/fs/cgroup/memory.max").unwrap_or(u64::MAX),
+            read_u64("/sys/fs/cgroup/memory.max").or(Some(u64::MAX)),
             read_table_key("/sys/fs/cgroup/memory.stat", "anon", ' '),
         ) {
             let mut limits = Self {


### PR DESCRIPTION
This PR fixes an edge case where the `memory.max` file contains `max` when no limit is set for the container. If the value was `max`, the `read_u64` function would fail, causing cgroup limits to not be returned.