### PR TITLE
Remove debug output on macOS

### DIFF
--- a/src/unix/apple/macos/process.rs
+++ b/src/unix/apple/macos/process.rs
@@ -370,7 +370,6 @@ unsafe fn create_new_process(
                 get_cwd_root(&mut p, refresh_kind);
                 return Ok(Some(Process { inner: p }));
             }
-            eprintln!("No name, let's leave");
             // If we can't even have the name, no point in keeping it.
             return Err(());
         }


### PR DESCRIPTION
In our CI, I noticed some output on macOS that appears to be a leftover from debugging, recently introduced with https://github.com/GuillaumeGomez/sysinfo/pull/1491.