### PR TITLE
Fix M4 frequency calculation

### DIFF
--- a/src/unix/apple/cpu.rs
+++ b/src/unix/apple/cpu.rs
@@ -42,7 +42,7 @@ impl CpusWrapper {
             return;
         }
         if refresh_kind.frequency() && !self.got_cpu_frequency {
-            let frequency = unsafe { get_cpu_frequency() };
+            let frequency = unsafe { get_cpu_frequency(cpus.first().map_or("", |c| c.brand())) };
             for proc_ in cpus.iter_mut() {
                 proc_.inner.set_frequency(frequency);
             }
@@ -200,7 +200,7 @@ impl CpuInner {
     }
 }
 
-pub(crate) unsafe fn get_cpu_frequency() -> u64 {
+pub(crate) unsafe fn get_cpu_frequency(#[allow(unused_variables)] brand: &str) -> u64 {
     let mut speed: u64 = 0;
     let mut len = std::mem::size_of::<u64>();
     if libc::sysctlbyname(
@@ -220,7 +220,7 @@ pub(crate) unsafe fn get_cpu_frequency() -> u64 {
     }
     #[cfg(not(any(target_os = "ios", feature = "apple-sandbox")))]
     {
-        crate::sys::inner::cpu::get_cpu_frequency()
+        crate::sys::inner::cpu::get_cpu_frequency(brand)
     }
 }
 
@@ -324,7 +324,7 @@ pub(crate) fn init_cpus(
 
     let (vendor_id, brand) = get_vendor_id_and_brand();
     let frequency = if refresh_kind.frequency() {
-        unsafe { get_cpu_frequency() }
+        unsafe { get_cpu_frequency(&brand) }
     } else {
         global_cpu.frequency
     };

--- a/src/unix/apple/macos/cpu.rs
+++ b/src/unix/apple/macos/cpu.rs
@@ -1,12 +1,12 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 #[cfg(feature = "apple-sandbox")]
-pub(crate) unsafe fn get_cpu_frequency() -> u64 {
+pub(crate) unsafe fn get_cpu_frequency(_brand: &str) -> u64 {
     0
 }
 
 #[cfg(not(feature = "apple-sandbox"))]
-pub(crate) unsafe fn get_cpu_frequency() -> u64 {
+pub(crate) unsafe fn get_cpu_frequency(brand: &str) -> u64 {
     use crate::sys::ffi;
     use crate::sys::macos::utils::IOReleaser;
     use objc2_core_foundation::{
@@ -90,5 +90,12 @@ pub(crate) unsafe fn get_cpu_frequency() -> u64 {
         },
         &mut max as *mut _ as *mut _,
     );
-    max / 1_000_000
+
+    // Check taken from https://github.com/vladkens/macmon/commit/9e05a6f6e9aee01c4cd6e01e0639ac23f5820f18.
+    // Not sure if there is a better way to differentiate this.
+    if brand.contains("M1") || brand.contains("M2") | brand.contains("M3") {
+        max / 1_000_000
+    } else {
+        max / 1_000
+    }
 }


### PR DESCRIPTION
Hey,
the current version reports a frequency of 4 Mhz for my M4 Max.

According to https://github.com/vladkens/macmon/issues/11#issuecomment-2509396677 the meaning of the value changed for the M4 generation. This applies the same fix.

I am not sure whether this would work for a M3 Ultra (M3 in the name but  might be a more modern chip). There might be a better way to check for the intended meaning of the value.