### PR TITLE
Bump windows to 0.59-0.61

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ component = [
     "windows/Win32_Foundation",
     "windows/Win32_Security",
     "windows/Win32_System_Com",
+    "windows/Win32_System_Ole",
     "windows/Win32_System_Rpc",
     "windows/Win32_System_Variant",
     "windows/Win32_System_Wmi",
@@ -117,7 +118,7 @@ serde = { version = "^1.0.190", optional = true, features = ["derive"] }
 ntapi = { version = "0.4", optional = true }
 # Support a range of versions in order to avoid duplication of this crate. Make sure to test all
 # versions when bumping to a new release, and only increase the minimum when absolutely necessary.
-windows = { version = ">=0.54, <=0.57", optional = true }
+windows = { version = ">=0.59, <=0.61", optional = true }
 
 [target.'cfg(not(any(target_os = "unknown", target_arch = "wasm32")))'.dependencies]
 libc = "^0.2.171"
@@ -134,7 +135,7 @@ tempfile = "3.9"
 serde_json = "1.0" # Used in documentation tests.
 bstr = "1.9.0"
 tempfile = "3.9"
-itertools = "0.13.0"
+itertools = "0.14.0"
 
 [[example]]
 name = "simple"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can still use `sysinfo` on non-supported OSes, it'll simply do nothing and a
 empty values. You can check in your program directly if an OS is supported by checking the
 [`IS_SUPPORTED_SYSTEM`] constant.
 
-The minimum-supported version of `rustc` is **1.74**.
+The minimum-supported version of `rustc` is **1.75**.
 
 ## Usage
 

--- a/src/windows/component.rs
+++ b/src/windows/component.rs
@@ -2,7 +2,7 @@
 
 use crate::Component;
 
-use windows::core::{w, VARIANT};
+use windows::core::w;
 use windows::Win32::Foundation::{SysAllocString, SysFreeString};
 use windows::Win32::Security::PSECURITY_DESCRIPTOR;
 use windows::Win32::System::Com::{
@@ -11,7 +11,7 @@ use windows::Win32::System::Com::{
     RPC_C_IMP_LEVEL_IMPERSONATE,
 };
 use windows::Win32::System::Rpc::{RPC_C_AUTHN_WINNT, RPC_C_AUTHZ_NONE};
-use windows::Win32::System::Variant::VariantClear;
+use windows::Win32::System::Variant::{VariantClear, VARIANT};
 use windows::Win32::System::Wmi::{
     IEnumWbemClassObject, IWbemLocator, IWbemServices, WbemLocator, WBEM_FLAG_FORWARD_ONLY,
     WBEM_FLAG_NONSYSTEM_ONLY, WBEM_FLAG_RETURN_IMMEDIATELY, WBEM_INFINITE,
@@ -163,7 +163,7 @@ unsafe fn initialize_connection() -> Result<(), ()> {
 
 unsafe fn initialize_security() -> Result<(), ()> {
     if CoInitializeSecurity(
-        PSECURITY_DESCRIPTOR::default(),
+        Some(PSECURITY_DESCRIPTOR::default()),
         -1,
         None,
         None,
@@ -311,7 +311,7 @@ impl Connection {
             let mut variant = variant.assume_init();
 
             // temperature is given in tenth of degrees Kelvin
-            let temp = (variant.as_raw().Anonymous.decVal.Anonymous2.Lo64 / 10) as f32 - 273.15;
+            let temp = (variant.Anonymous.decVal.Anonymous2.Lo64 / 10) as f32 - 273.15;
             let _r = VariantClear(&mut variant);
 
             let mut critical = None;
@@ -321,8 +321,7 @@ impl Connection {
                     .ok()?;
 
                 // temperature is given in tenth of degrees Kelvin
-                critical =
-                    Some((variant.as_raw().Anonymous.decVal.Anonymous2.Lo64 / 10) as f32 - 273.15);
+                critical = Some((variant.Anonymous.decVal.Anonymous2.Lo64 / 10) as f32 - 273.15);
                 let _r = VariantClear(&mut variant);
             }
 

--- a/src/windows/disk.rs
+++ b/src/windows/disk.rs
@@ -396,7 +396,7 @@ unsafe fn get_disk_kind(handle: &HandleWrapper) -> DiskKind {
     if !device_io_control || dw_size != size_of::<DEVICE_SEEK_PENALTY_DESCRIPTOR>() as _ {
         DiskKind::Unknown(-1)
     } else {
-        let is_hdd = result.IncursSeekPenalty.as_bool();
+        let is_hdd = result.IncursSeekPenalty;
         if is_hdd {
             DiskKind::HDD
         } else {

--- a/src/windows/process.rs
+++ b/src/windows/process.rs
@@ -29,7 +29,7 @@ use windows::Wdk::System::Threading::{
     ProcessWow64Information, PROCESSINFOCLASS,
 };
 use windows::Win32::Foundation::{
-    LocalFree, ERROR_INSUFFICIENT_BUFFER, FILETIME, HANDLE, HINSTANCE, HLOCAL, MAX_PATH,
+    LocalFree, ERROR_INSUFFICIENT_BUFFER, FILETIME, HANDLE, HLOCAL, HMODULE, MAX_PATH,
     STATUS_BUFFER_OVERFLOW, STATUS_BUFFER_TOO_SMALL, STATUS_INFO_LENGTH_MISMATCH, UNICODE_STRING,
 };
 use windows::Win32::Security::{GetTokenInformation, TokenUser, TOKEN_QUERY, TOKEN_USER};
@@ -240,8 +240,8 @@ fn windows_8_1_or_newer() -> &'static bool {
 unsafe fn get_exe(process_handler: &HandleWrapper) -> Option<PathBuf> {
     let mut exe_buf = [0u16; MAX_PATH as usize + 1];
     GetModuleFileNameExW(
-        **process_handler,
-        HINSTANCE::default(),
+        Some(**process_handler),
+        Some(HMODULE::default()),
         exe_buf.as_mut_slice(),
     );
 
@@ -641,7 +641,7 @@ unsafe fn get_cmdline_from_buffer(buffer: PCWSTR) -> Vec<OsString> {
         res.push(OsString::from_wide(arg.as_wide()));
     }
 
-    let _err = LocalFree(HLOCAL(argv_p as _));
+    let _err = LocalFree(Some(HLOCAL(argv_p as _)));
 
     res
 }

--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -487,11 +487,7 @@ fn get_dns_hostname() -> Option<String> {
     // setting the `lpBuffer` to null will return the buffer size
     // https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getcomputernameexw
     unsafe {
-        let _err = GetComputerNameExW(
-            ComputerNamePhysicalDnsHostname,
-            PWSTR::null(),
-            &mut buffer_size,
-        );
+        let _err = GetComputerNameExW(ComputerNamePhysicalDnsHostname, None, &mut buffer_size);
 
         // Setting the buffer with the new length
         let mut buffer = vec![0_u16; buffer_size as usize];
@@ -499,7 +495,7 @@ fn get_dns_hostname() -> Option<String> {
         // https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/ne-sysinfoapi-computer_name_format
         if GetComputerNameExW(
             ComputerNamePhysicalDnsHostname,
-            PWSTR::from_raw(buffer.as_mut_ptr()),
+            Some(PWSTR::from_raw(buffer.as_mut_ptr())),
             &mut buffer_size,
         )
         .is_ok()
@@ -551,7 +547,7 @@ impl RegKey {
         if RegOpenKeyExW(
             hkey,
             PCWSTR::from_raw(path.as_ptr()),
-            0,
+            Some(0),
             KEY_READ,
             &mut new_hkey,
         )

--- a/src/windows/utils.rs
+++ b/src/windows/utils.rs
@@ -47,7 +47,7 @@ cfg_if! {
                     None,
                     OPEN_EXISTING,
                     Default::default(),
-                    HANDLE::default(),
+                    Some(HANDLE::default()),
                 )
                 .ok()?;
                 if handle.is_invalid() {


### PR DESCRIPTION
Replaces and closes #1338 

Checked that all these three versions are working (0.58 had not yet used the option arguments), as in tests working. Some structs and functions are now feature gated.

Admittedly, I am not really sure what I am doing, but it seems to work. (The first test run for each version did fail for unknown reasons, a single test, often `test_wait_child`, but on the second test run it passed.)

Also bumped itertools for the sake of it. 

Edit: updated MSRV in README. I also realized that I should add the new features to the corresponding sysinfo fetures.
