### PR TITLE
Update to `objc2-core-foundation` v0.3.1 and use `objc2-io-kit`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ component = [
     "objc2-core-foundation/CFDictionary",
     "objc2-core-foundation/CFNumber",
     "objc2-core-foundation/CFString",
+    "objc2-io-kit",
+    "objc2-io-kit/hidsystem",
 ]
 disk = [
     "windows/Win32_Foundation",
@@ -45,6 +47,7 @@ disk = [
     "objc2-core-foundation/CFNumber",
     "objc2-core-foundation/CFString",
     "objc2-core-foundation/CFURL",
+    "objc2-io-kit",
 ]
 system = [
     "windows/Win32_Foundation",
@@ -71,6 +74,7 @@ system = [
     "objc2-core-foundation/CFData",
     "objc2-core-foundation/CFDictionary",
     "objc2-core-foundation/CFString",
+    "objc2-io-kit",
 ]
 network = [
     "windows/Win32_Foundation",
@@ -126,6 +130,10 @@ libc = "^0.2.171"
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 objc2-core-foundation = { version = "0.3.1", optional = true, default-features = false, features = [
     "std",
+] }
+objc2-io-kit = { version = "0.3.1", optional = true, default-features = false, features = [
+    "std",
+    "libc",
 ] }
 
 [target.'cfg(all(target_os = "linux", not(target_os = "android")))'.dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ windows = { version = ">=0.59, <=0.61", optional = true }
 libc = "^0.2.171"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-objc2-core-foundation = { version = "0.3.0", optional = true, default-features = false, features = [
+objc2-core-foundation = { version = "0.3.1", optional = true, default-features = false, features = [
     "std",
 ] }
 

--- a/src/unix/apple/ffi.rs
+++ b/src/unix/apple/ffi.rs
@@ -1,33 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-// Reexport items defined in either macos or ios ffi module.
-#[cfg(all(
-    not(target_os = "ios"),
-    any(
-        feature = "disk",
-        all(
-            not(feature = "apple-sandbox"),
-            any(feature = "component", feature = "system")
-        ),
-    ),
-))]
-pub use crate::sys::inner::ffi::*;
-
 #[cfg(feature = "disk")]
 #[link(name = "objc", kind = "dylib")]
 extern "C" {
     pub fn objc_autoreleasePoolPop(pool: *mut libc::c_void);
     pub fn objc_autoreleasePoolPush() -> *mut libc::c_void;
-}
-
-#[cfg_attr(feature = "debug", derive(Eq, Hash, PartialEq))]
-#[allow(unused)]
-#[allow(non_camel_case_types)]
-#[derive(Clone)]
-#[repr(C)]
-pub struct Val_t {
-    pub key: [i8; 5],
-    pub data_size: u32,
-    pub data_type: [i8; 5], // UInt32Char_t
-    pub bytes: [i8; 32],    // SMCBytes_t
 }

--- a/src/unix/apple/macos/component/arm.rs
+++ b/src/unix/apple/macos/component/arm.rs
@@ -2,9 +2,7 @@
 
 use std::ptr::NonNull;
 
-use objc2_core_foundation::{
-    kCFAllocatorDefault, CFArrayGetCount, CFArrayGetValueAtIndex, CFRetained, CFString,
-};
+use objc2_core_foundation::{kCFAllocatorDefault, CFRetained, CFString};
 
 use crate::sys::inner::ffi::{
     kHIDPage_AppleVendor, kHIDUsage_AppleVendor_TemperatureSensor, kIOHIDEventTypeTemperature,
@@ -77,10 +75,10 @@ impl ComponentsInner {
 
             let key = CFString::from_static_str(HID_DEVICE_PROPERTY_PRODUCT);
 
-            let count = CFArrayGetCount(&services);
+            let count = services.count();
 
             for i in 0..count {
-                let service = CFArrayGetValueAtIndex(&services, i).cast::<IOHIDServiceClient>();
+                let service = services.value_at_index(i).cast::<IOHIDServiceClient>();
                 if service.is_null() {
                     continue;
                 }

--- a/src/unix/apple/macos/component/x86.rs
+++ b/src/unix/apple/macos/component/x86.rs
@@ -4,6 +4,11 @@ use crate::sys::{ffi, macos::utils::IOReleaser};
 use crate::Component;
 
 use libc::{c_char, c_int, c_void};
+use objc2_core_foundation::{CFDictionary, CFRetained};
+use objc2_io_kit::{
+    io_connect_t, io_iterator_t, kIOMasterPortDefault, kIOReturnSuccess, IOConnectCallStructMethod,
+    IOIteratorNext, IOServiceClose, IOServiceGetMatchingServices, IOServiceMatching, IOServiceOpen,
+};
 
 use std::mem;
 
@@ -23,11 +28,11 @@ pub(crate) struct ComponentFFI {
     val: ffi::Val_t,
     /// It is the `System::connection`. We need it to not require an extra argument
     /// in `ComponentInner::refresh`.
-    connection: ffi::io_connect_t,
+    connection: io_connect_t,
 }
 
 impl ComponentFFI {
-    fn new(key: &[i8], connection: ffi::io_connect_t) -> Option<ComponentFFI> {
+    fn new(key: &[i8], connection: io_connect_t) -> Option<ComponentFFI> {
         unsafe {
             get_key_size(connection, key)
                 .ok()
@@ -116,7 +121,7 @@ impl ComponentInner {
         max: Option<f32>,
         critical: Option<f32>,
         key: &[i8],
-        connection: ffi::io_connect_t,
+        connection: io_connect_t,
     ) -> Option<Self> {
         let ffi_part = ComponentFFI::new(key, connection)?;
         ffi_part.temperature().map(|temperature| Self {
@@ -156,19 +161,19 @@ impl ComponentInner {
 }
 
 unsafe fn perform_call(
-    conn: ffi::io_connect_t,
+    conn: io_connect_t,
     index: c_int,
     input_structure: *const ffi::KeyData_t,
     output_structure: *mut ffi::KeyData_t,
 ) -> i32 {
     let mut structure_output_size = mem::size_of::<ffi::KeyData_t>();
 
-    ffi::IOConnectCallStructMethod(
+    IOConnectCallStructMethod(
         conn,
         index as u32,
-        input_structure,
+        input_structure.cast(),
         mem::size_of::<ffi::KeyData_t>(),
-        output_structure,
+        output_structure.cast(),
         &mut structure_output_size,
     )
 }
@@ -193,10 +198,7 @@ unsafe fn ultostr(s: *mut c_char, val: u32) {
     *s.offset(4) = 0;
 }
 
-unsafe fn get_key_size(
-    con: ffi::io_connect_t,
-    key: &[i8],
-) -> Result<(ffi::KeyData_t, ffi::Val_t), i32> {
+unsafe fn get_key_size(con: io_connect_t, key: &[i8]) -> Result<(ffi::KeyData_t, ffi::Val_t), i32> {
     let mut input_structure: ffi::KeyData_t = mem::zeroed::<ffi::KeyData_t>();
     let mut output_structure: ffi::KeyData_t = mem::zeroed::<ffi::KeyData_t>();
     let mut val: ffi::Val_t = mem::zeroed::<ffi::Val_t>();
@@ -210,7 +212,7 @@ unsafe fn get_key_size(
         &input_structure,
         &mut output_structure,
     );
-    if result != ffi::KIO_RETURN_SUCCESS {
+    if result != kIOReturnSuccess {
         return Err(result);
     }
 
@@ -225,19 +227,20 @@ unsafe fn get_key_size(
 }
 
 unsafe fn read_key(
-    con: ffi::io_connect_t,
+    con: io_connect_t,
     input_structure: &ffi::KeyData_t,
     mut val: ffi::Val_t,
 ) -> Result<ffi::Val_t, i32> {
     let mut output_structure: ffi::KeyData_t = mem::zeroed::<ffi::KeyData_t>();
 
+    #[allow(non_upper_case_globals)]
     match perform_call(
         con,
         ffi::KERNEL_INDEX_SMC,
         input_structure,
         &mut output_structure,
     ) {
-        ffi::KIO_RETURN_SUCCESS => {
+        kIOReturnSuccess => {
             libc::memcpy(
                 val.bytes.as_mut_ptr() as *mut c_void,
                 output_structure.bytes.as_mut_ptr() as *mut c_void,
@@ -250,7 +253,7 @@ unsafe fn read_key(
 }
 
 fn get_temperature_inner(
-    con: ffi::io_connect_t,
+    con: io_connect_t,
     input_structure: &ffi::KeyData_t,
     original_val: &ffi::Val_t,
 ) -> Option<f32> {
@@ -268,17 +271,17 @@ fn get_temperature_inner(
     None
 }
 
-fn get_temperature(con: ffi::io_connect_t, key: &[i8]) -> Option<f32> {
+fn get_temperature(con: io_connect_t, key: &[i8]) -> Option<f32> {
     unsafe {
         let (input_structure, val) = get_key_size(con, key).ok()?;
         get_temperature_inner(con, &input_structure, &val)
     }
 }
 
-pub(crate) struct IoService(ffi::io_connect_t);
+pub(crate) struct IoService(io_connect_t);
 
 impl IoService {
-    fn new(obj: ffi::io_connect_t) -> Option<Self> {
+    fn new(obj: io_connect_t) -> Option<Self> {
         if obj == 0 {
             None
         } else {
@@ -286,28 +289,25 @@ impl IoService {
         }
     }
 
-    pub(crate) fn inner(&self) -> ffi::io_connect_t {
+    pub(crate) fn inner(&self) -> io_connect_t {
         self.0
     }
 
     // code from https://github.com/Chris911/iStats
     // Not supported on iOS, or in the default macOS
     pub(crate) fn new_connection() -> Option<Self> {
-        let mut iterator: ffi::io_iterator_t = 0;
+        let mut iterator: io_iterator_t = 0;
 
         unsafe {
-            let Some(matching_dictionary) =
-                ffi::IOServiceMatching(b"AppleSMC\0".as_ptr() as *const i8)
-            else {
+            let Some(matching) = IOServiceMatching(b"AppleSMC\0".as_ptr() as *const i8) else {
                 sysinfo_debug!("IOServiceMatching call failed, `AppleSMC` not found");
                 return None;
             };
-            let result = ffi::IOServiceGetMatchingServices(
-                ffi::kIOMasterPortDefault,
-                matching_dictionary,
-                &mut iterator,
-            );
-            if result != ffi::KIO_RETURN_SUCCESS {
+            let matching = CFRetained::<CFDictionary>::from(&matching);
+
+            let result =
+                IOServiceGetMatchingServices(kIOMasterPortDefault, Some(matching), &mut iterator);
+            if result != kIOReturnSuccess {
                 sysinfo_debug!("Error: IOServiceGetMatchingServices() = {}", result);
                 return None;
             }
@@ -319,7 +319,7 @@ impl IoService {
                 }
             };
 
-            let device = match IOReleaser::new(ffi::IOIteratorNext(iterator.inner())) {
+            let device = match IOReleaser::new(IOIteratorNext(iterator.inner())) {
                 Some(d) => d,
                 None => {
                     sysinfo_debug!("Error: no SMC found");
@@ -328,14 +328,14 @@ impl IoService {
             };
 
             let mut conn = 0;
-            let result = ffi::IOServiceOpen(
+            let result = IOServiceOpen(
                 device.inner(),
                 #[allow(deprecated)]
                 libc::mach_task_self(),
                 0,
                 &mut conn,
             );
-            if result != ffi::KIO_RETURN_SUCCESS {
+            if result != kIOReturnSuccess {
                 sysinfo_debug!("Error: IOServiceOpen() = {}", result);
                 return None;
             }
@@ -352,8 +352,6 @@ impl IoService {
 
 impl Drop for IoService {
     fn drop(&mut self) {
-        unsafe {
-            ffi::IOServiceClose(self.0);
-        }
+        unsafe { IOServiceClose(self.0) };
     }
 }

--- a/src/unix/apple/macos/component/x86.rs
+++ b/src/unix/apple/macos/component/x86.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::sys::{ffi, macos::utils::IOReleaser};
+use crate::sys::macos::{ffi, utils::IOReleaser};
 use crate::Component;
 
 use libc::{c_char, c_int, c_void};

--- a/src/unix/apple/macos/cpu.rs
+++ b/src/unix/apple/macos/cpu.rs
@@ -9,9 +9,7 @@ pub(crate) unsafe fn get_cpu_frequency(_brand: &str) -> u64 {
 pub(crate) unsafe fn get_cpu_frequency(brand: &str) -> u64 {
     use crate::sys::ffi;
     use crate::sys::macos::utils::IOReleaser;
-    use objc2_core_foundation::{
-        kCFAllocatorDefault, CFData, CFDataGetBytes, CFDataGetLength, CFRange, CFRetained, CFString,
-    };
+    use objc2_core_foundation::{kCFAllocatorDefault, CFData, CFRange, CFRetained, CFString};
 
     let Some(matching) = ffi::IOServiceMatching(b"AppleARMIODevice\0".as_ptr() as *const _) else {
         sysinfo_debug!("IOServiceMatching call failed, `AppleARMIODevice` not found");
@@ -76,14 +74,13 @@ pub(crate) unsafe fn get_cpu_frequency(brand: &str) -> u64 {
         return 0;
     };
 
-    let core_length = CFDataGetLength(&core_ref);
+    let core_length = core_ref.length();
     if core_length < 8 {
         sysinfo_debug!("expected `voltage-states5-sram` buffer to have at least size 8");
         return 0;
     }
     let mut max: u64 = 0;
-    CFDataGetBytes(
-        &core_ref,
+    core_ref.bytes(
         CFRange {
             location: core_length - 8,
             length: 4,

--- a/src/unix/apple/macos/disk.rs
+++ b/src/unix/apple/macos/disk.rs
@@ -1,9 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::sys::ffi;
 use crate::sys::{
     disk::{get_int_value, get_str_value},
-    macos::utils::IOReleaser,
+    macos::{ffi, utils::IOReleaser},
 };
 use crate::DiskKind;
 

--- a/src/unix/apple/macos/disk.rs
+++ b/src/unix/apple/macos/disk.rs
@@ -8,24 +8,23 @@ use crate::sys::{
 use crate::DiskKind;
 
 use objc2_core_foundation::{kCFAllocatorDefault, CFDictionary, CFRetained, CFString};
+use objc2_io_kit::{
+    io_iterator_t, io_registry_entry_t, kIOMasterPortDefault, kIOServicePlane, IOBSDNameMatching,
+    IOIteratorNext, IOObjectConformsTo, IORegistryEntryCreateCFProperty,
+    IORegistryEntryGetParentEntry, IOServiceGetMatchingServices,
+};
 
 fn iterate_service_tree<T, F>(bsd_name: &[u8], key: &CFString, eval: F) -> Option<T>
 where
-    F: Fn(ffi::io_registry_entry_t, &CFDictionary) -> Option<T>,
+    F: Fn(io_registry_entry_t, &CFDictionary) -> Option<T>,
 {
-    // We don't need to wrap this in CFRetained because the following call to
-    // `IOServiceGetMatchingServices` will take ownership of one retain reference.
-    let matching =
-        unsafe { ffi::IOBSDNameMatching(ffi::kIOMasterPortDefault, 0, bsd_name.as_ptr().cast()) }?;
+    let matching = unsafe { IOBSDNameMatching(kIOMasterPortDefault, 0, bsd_name.as_ptr().cast()) }?;
+    let matching = CFRetained::<CFDictionary>::from(&matching);
 
-    let mut service_iterator: ffi::io_iterator_t = 0;
+    let mut service_iterator: io_iterator_t = 0;
 
     if unsafe {
-        ffi::IOServiceGetMatchingServices(
-            ffi::kIOMasterPortDefault,
-            matching,
-            &mut service_iterator,
-        )
+        IOServiceGetMatchingServices(kIOMasterPortDefault, Some(matching), &mut service_iterator)
     } != libc::KERN_SUCCESS
     {
         return None;
@@ -34,10 +33,10 @@ where
     // Safety: We checked for success, so there is always a valid iterator, even if its empty.
     let service_iterator = unsafe { IOReleaser::new_unchecked(service_iterator) };
 
-    let mut parent_entry: ffi::io_registry_entry_t = 0;
+    let mut parent_entry: io_registry_entry_t = 0;
 
     while let Some(mut current_service_entry) =
-        IOReleaser::new(unsafe { ffi::IOIteratorNext(service_iterator.inner()) })
+        IOReleaser::new(unsafe { IOIteratorNext(service_iterator.inner()) })
     {
         // Note: This loop is required in a non-obvious way. Due to device properties existing as a tree
         // in IOKit, we may need an arbitrary number of calls to `IORegistryEntryCreateCFProperty` in order to find
@@ -45,9 +44,9 @@ where
         // tree, so we need to continue going from child->parent node until its found.
         loop {
             if unsafe {
-                ffi::IORegistryEntryGetParentEntry(
+                IORegistryEntryGetParentEntry(
                     current_service_entry.inner(),
-                    ffi::kIOServicePlane.as_ptr().cast(),
+                    kIOServicePlane.as_ptr().cast_mut().cast(),
                     &mut parent_entry,
                 )
             } != libc::KERN_SUCCESS
@@ -62,16 +61,15 @@ where
             };
 
             let properties_result = unsafe {
-                ffi::IORegistryEntryCreateCFProperty(
+                IORegistryEntryCreateCFProperty(
                     current_service_entry.inner(),
-                    key,
+                    Some(key),
                     kCFAllocatorDefault,
                     0,
                 )
             };
 
             if let Some(properties) = properties_result {
-                let properties = unsafe { CFRetained::from_raw(properties) };
                 if let Ok(properties) = properties.downcast::<CFDictionary>() {
                     if let Some(result) = eval(parent_entry, &properties) {
                         return Some(result);
@@ -109,10 +107,9 @@ pub(crate) fn get_disk_io(bsd_name: &[u8]) -> Option<(u64, u64)> {
     let stat_string = CFString::from_static_str(ffi::kIOBlockStorageDriverStatisticsKey);
 
     iterate_service_tree(bsd_name, &stat_string, |parent_entry, properties| {
-        if unsafe {
-            ffi::IOObjectConformsTo(parent_entry, b"IOBlockStorageDriver\0".as_ptr() as *const _)
-        } == 0
-        {
+        if !unsafe {
+            IOObjectConformsTo(parent_entry, b"IOBlockStorageDriver\0".as_ptr() as *mut _)
+        } {
             return None;
         }
 

--- a/src/unix/apple/macos/ffi.rs
+++ b/src/unix/apple/macos/ffi.rs
@@ -257,7 +257,7 @@ mod io_service {
 
     use objc2_core_foundation::{
         cf_type, kCFTypeDictionaryKeyCallBacks, kCFTypeDictionaryValueCallBacks, CFAllocator,
-        CFArray, CFDictionary, CFDictionaryCreate, CFNumber, CFRetained, CFString,
+        CFArray, CFDictionary, CFNumber, CFRetained, CFString,
     };
 
     #[repr(C)]
@@ -344,7 +344,7 @@ mod io_service {
 
             let nums = [CFNumber::new_i32(page), CFNumber::new_i32(usage)];
 
-            CFDictionaryCreate(
+            CFDictionary::new(
                 None,
                 &keys as *const _ as *mut _,
                 &nums as *const _ as *mut _,

--- a/src/unix/apple/macos/ffi.rs
+++ b/src/unix/apple/macos/ffi.rs
@@ -30,6 +30,16 @@ cfg_if! {
     ),
 ))]
 mod keydata {
+    #[cfg_attr(feature = "debug", derive(Eq, Hash, PartialEq))]
+    #[derive(Clone)]
+    #[repr(C)]
+    pub struct Val_t {
+        pub key: [i8; 5],
+        pub data_size: u32,
+        pub data_type: [i8; 5], // UInt32Char_t
+        pub bytes: [i8; 32],    // SMCBytes_t
+    }
+
     #[cfg_attr(feature = "debug", derive(Debug, Eq, Hash, PartialEq))]
     #[repr(C)]
     pub struct KeyData_vers_t {

--- a/src/unix/apple/macos/ffi.rs
+++ b/src/unix/apple/macos/ffi.rs
@@ -3,55 +3,8 @@
 // Note: IOKit is only available on macOS up until very recent iOS versions: https://developer.apple.com/documentation/iokit
 
 cfg_if! {
-    if #[cfg(any(
-        feature = "disk",
-        all(
-            not(feature = "apple-sandbox"),
-            any(
-                feature = "system",
-                all(
-                    feature = "component",
-                    any(target_arch = "x86", target_arch = "x86_64")
-                )
-            )
-        ),
-    ))] {
-        #[allow(non_camel_case_types)]
-        pub type io_object_t = libc::mach_port_t;
-        #[allow(non_camel_case_types)]
-        pub type io_iterator_t = io_object_t;
-        // Based on https://github.com/libusb/libusb/blob/bed8d3034eac74a6e1ba123b5c270ea63cb6cf1a/libusb/os/darwin_usb.c#L54-L55,
-        // we can simply set it to 0 (and is the same value as its
-        // replacement `kIOMainPortDefault`).
-        #[allow(non_upper_case_globals)]
-        pub const kIOMasterPortDefault: libc::mach_port_t = 0;
-    }
-
-    if #[cfg(any(
-        all(feature = "system", not(feature = "apple-sandbox")),
-        feature = "disk"
-    ))] {
-        #[allow(non_camel_case_types)]
-        pub type io_registry_entry_t = io_object_t;
-        #[allow(non_camel_case_types)]
-        pub type io_name_t = *const libc::c_char;
-        // This is a hack, `io_name_t` should normally be `[c_char; 128]` but Rust makes it very annoying
-        // to deal with that so we go around it a bit.
-        #[allow(non_camel_case_types, dead_code)]
-        pub type io_name = [libc::c_char; 128];
-    }
-}
-
-#[cfg(any(
-    feature = "disk",
-    all(not(feature = "apple-sandbox"), feature = "system",),
-))]
-pub type IOOptionBits = u32;
-
-cfg_if! {
+    // TODO(madsmtm): Expose this in `objc2-io-kit`.
     if #[cfg(feature = "disk")] {
-        #[allow(non_upper_case_globals)]
-        pub const kIOServicePlane: &[u8] = b"IOService\0";
         #[allow(non_upper_case_globals)]
         pub const kIOPropertyDeviceCharacteristicsKey: &str = "Device Characteristics";
         #[allow(non_upper_case_globals)]
@@ -69,88 +22,6 @@ cfg_if! {
     }
 }
 
-// Note: Obtaining information about disks using IOKIt is allowed inside the default macOS App Sandbox.
-#[cfg(any(
-    feature = "disk",
-    all(
-        not(feature = "apple-sandbox"),
-        any(
-            feature = "system",
-            all(
-                feature = "component",
-                any(target_arch = "x86", target_arch = "x86_64")
-            )
-        )
-    ),
-))]
-#[link(name = "IOKit", kind = "framework")]
-extern "C" {
-    pub fn IOServiceGetMatchingServices(
-        mainPort: libc::mach_port_t,
-        matching: std::ptr::NonNull<objc2_core_foundation::CFMutableDictionary>, // CF_RELEASES_ARGUMENT
-        existing: *mut io_iterator_t,
-    ) -> libc::kern_return_t;
-    #[cfg(all(
-        not(feature = "apple-sandbox"),
-        any(
-            feature = "system",
-            all(
-                feature = "component",
-                any(target_arch = "x86", target_arch = "x86_64")
-            ),
-        ),
-    ))]
-    pub fn IOServiceMatching(
-        a: *const libc::c_char,
-    ) -> Option<std::ptr::NonNull<objc2_core_foundation::CFMutableDictionary>>; // CF_RETURNS_RETAINED
-
-    pub fn IOIteratorNext(iterator: io_iterator_t) -> io_object_t;
-
-    pub fn IOObjectRelease(obj: io_object_t) -> libc::kern_return_t;
-
-    #[cfg(any(feature = "system", feature = "disk"))]
-    pub fn IORegistryEntryCreateCFProperty(
-        entry: io_registry_entry_t,
-        key: &objc2_core_foundation::CFString,
-        allocator: Option<&objc2_core_foundation::CFAllocator>,
-        options: IOOptionBits,
-    ) -> Option<std::ptr::NonNull<objc2_core_foundation::CFType>>;
-    #[cfg(feature = "disk")]
-    pub fn IORegistryEntryGetParentEntry(
-        entry: io_registry_entry_t,
-        plane: io_name_t,
-        parent: *mut io_registry_entry_t,
-    ) -> libc::kern_return_t;
-    #[cfg(feature = "disk")]
-    pub fn IOBSDNameMatching(
-        mainPort: libc::mach_port_t,
-        options: u32,
-        bsdName: *const libc::c_char,
-    ) -> Option<std::ptr::NonNull<objc2_core_foundation::CFMutableDictionary>>; // CF_RETURNS_RETAINED
-    #[cfg(all(feature = "system", not(feature = "apple-sandbox")))]
-    pub fn IORegistryEntryGetName(
-        entry: io_registry_entry_t,
-        name: io_name_t,
-    ) -> libc::kern_return_t;
-    #[cfg(feature = "disk")]
-    pub fn IOObjectConformsTo(
-        object: io_object_t,
-        className: *const libc::c_char,
-    ) -> libc::boolean_t;
-}
-
-#[cfg(all(
-    not(feature = "apple-sandbox"),
-    any(
-        feature = "system",
-        all(
-            feature = "component",
-            any(target_arch = "x86", target_arch = "x86_64")
-        ),
-    ),
-))]
-pub const KIO_RETURN_SUCCESS: i32 = 0;
-
 #[cfg(all(
     not(feature = "apple-sandbox"),
     all(
@@ -158,40 +29,7 @@ pub const KIO_RETURN_SUCCESS: i32 = 0;
         any(target_arch = "x86", target_arch = "x86_64")
     ),
 ))]
-mod io_service {
-    use super::io_object_t;
-    use libc::{kern_return_t, mach_port_t, size_t, task_t};
-
-    #[allow(non_camel_case_types)]
-    pub type io_connect_t = io_object_t;
-
-    #[allow(non_camel_case_types)]
-    pub type io_service_t = io_object_t;
-
-    #[allow(non_camel_case_types)]
-    pub type task_port_t = task_t;
-
-    extern "C" {
-        pub fn IOServiceOpen(
-            device: io_service_t,
-            owning_task: task_port_t,
-            type_: u32,
-            connect: *mut io_connect_t,
-        ) -> kern_return_t;
-
-        pub fn IOServiceClose(a: io_connect_t) -> kern_return_t;
-
-        #[allow(dead_code)]
-        pub fn IOConnectCallStructMethod(
-            connection: mach_port_t,
-            selector: u32,
-            inputStruct: *const KeyData_t,
-            inputStructCnt: size_t,
-            outputStruct: *mut KeyData_t,
-            outputStructCnt: *mut size_t,
-        ) -> kern_return_t;
-    }
-
+mod keydata {
     #[cfg_attr(feature = "debug", derive(Debug, Eq, Hash, PartialEq))]
     #[repr(C)]
     pub struct KeyData_vers_t {
@@ -244,43 +82,31 @@ mod io_service {
     pub const SMC_CMD_READ_BYTES: u8 = 5;
 }
 
-#[cfg(feature = "apple-sandbox")]
-mod io_service {}
+#[cfg(all(
+    not(feature = "apple-sandbox"),
+    all(
+        feature = "component",
+        any(target_arch = "x86", target_arch = "x86_64")
+    ),
+))]
+pub use keydata::*;
 
+/// Private Apple APIs.
 #[cfg(all(
     feature = "component",
     not(feature = "apple-sandbox"),
     target_arch = "aarch64"
 ))]
-mod io_service {
+mod private {
     use std::ptr::NonNull;
 
-    use objc2_core_foundation::{
-        cf_type, kCFTypeDictionaryKeyCallBacks, kCFTypeDictionaryValueCallBacks, CFAllocator,
-        CFArray, CFDictionary, CFNumber, CFRetained, CFString,
-    };
-
-    #[repr(C)]
-    pub struct IOHIDServiceClient(libc::c_void);
-
-    cf_type!(
-        #[encoding_name = "__IOHIDServiceClient"]
-        unsafe impl IOHIDServiceClient {}
-    );
-
-    #[repr(C)]
-    pub struct IOHIDEventSystemClient(libc::c_void);
-
-    cf_type!(
-        #[encoding_name = "__IOHIDEventSystemClient"]
-        unsafe impl IOHIDEventSystemClient {}
-    );
+    use objc2_core_foundation::{CFAllocator, CFDictionary};
+    use objc2_io_kit::{IOHIDEventSystemClient, IOHIDServiceClient};
 
     #[repr(C)]
     pub struct IOHIDEvent(libc::c_void);
 
-    cf_type!(
-        #[encoding_name = "__IOHIDEvent"]
+    objc2_core_foundation::cf_type!(
         unsafe impl IOHIDEvent {}
     );
 
@@ -305,15 +131,6 @@ mod io_service {
             matches: &CFDictionary,
         ) -> i32;
 
-        pub fn IOHIDEventSystemClientCopyServices(
-            client: &IOHIDEventSystemClient,
-        ) -> Option<NonNull<CFArray>>;
-
-        pub fn IOHIDServiceClientCopyProperty(
-            service: &IOHIDServiceClient,
-            key: &CFString,
-        ) -> Option<NonNull<CFString>>;
-
         pub fn IOHIDServiceClientCopyEvent(
             service: &IOHIDServiceClient,
             v0: i64,
@@ -334,31 +151,11 @@ mod io_service {
 
     #[allow(non_upper_case_globals)]
     pub(crate) const kHIDUsage_AppleVendor_TemperatureSensor: i32 = 0x0005;
-
-    pub(crate) fn matching(page: i32, usage: i32) -> Option<CFRetained<CFDictionary>> {
-        unsafe {
-            let keys = [
-                CFString::from_static_str(HID_DEVICE_PROPERTY_PRIMARY_USAGE_PAGE),
-                CFString::from_static_str(HID_DEVICE_PROPERTY_PRIMARY_USAGE),
-            ];
-
-            let nums = [CFNumber::new_i32(page), CFNumber::new_i32(usage)];
-
-            CFDictionary::new(
-                None,
-                &keys as *const _ as *mut _,
-                &nums as *const _ as *mut _,
-                2,
-                &kCFTypeDictionaryKeyCallBacks,
-                &kCFTypeDictionaryValueCallBacks,
-            )
-        }
-    }
 }
 
 #[cfg(all(
     feature = "component",
     not(feature = "apple-sandbox"),
-    any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
+    target_arch = "aarch64"
 ))]
-pub use io_service::*;
+pub use private::*;

--- a/src/unix/apple/macos/utils.rs
+++ b/src/unix/apple/macos/utils.rs
@@ -2,6 +2,8 @@
 
 use std::num::NonZeroU32;
 
+use objc2_io_kit::IOObjectRelease;
+
 type IoObject = NonZeroU32;
 
 pub(crate) struct IOReleaser(IoObject);
@@ -26,6 +28,6 @@ impl IOReleaser {
 
 impl Drop for IOReleaser {
     fn drop(&mut self) {
-        unsafe { super::ffi::IOObjectRelease(self.0.get() as _) };
+        unsafe { IOObjectRelease(self.0.get() as _) };
     }
 }


### PR DESCRIPTION
The new version of `objc2-core-foundation` moves a bunch of functions to be associated functions/methods on the relevant type instead (see first commit). This is a non-breaking change, as the functions are still available, though they've been deprecated, so you'll likely start seeing errors in CI without this fix.

Additionally, I've added a new crate `objc2-io-kit`, which contains auto-generated bindings to IOKit, which allows reducing `sysinfo`'s need for custom `ffi` declarations quite substantially.

Spiritual follow-up to https://github.com/GuillaumeGomez/sysinfo/pull/1461.