### PR TITLE
[Windows] relax max version restriction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ serde = { version = "^1.0.190", optional = true, features = ["derive"] }
 ntapi = { version = "0.4", optional = true }
 # Support a range of versions in order to avoid duplication of this crate. Make sure to test all
 # versions when bumping to a new release, and only increase the minimum when absolutely necessary.
-windows = { version = ">=0.59, <=0.61", optional = true }
+windows = { version = ">=0.59, <=0.61.1", optional = true }
 
 [target.'cfg(not(any(target_os = "unknown", target_arch = "wasm32")))'.dependencies]
 libc = "^0.2.171"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ serde = { version = "^1.0.190", optional = true, features = ["derive"] }
 ntapi = { version = "0.4", optional = true }
 # Support a range of versions in order to avoid duplication of this crate. Make sure to test all
 # versions when bumping to a new release, and only increase the minimum when absolutely necessary.
-windows = { version = ">=0.59, <=0.61.1", optional = true }
+windows = { version = ">=0.59, <=0.62", optional = true }
 
 [target.'cfg(not(any(target_os = "unknown", target_arch = "wasm32")))'.dependencies]
 libc = "^0.2.171"


### PR DESCRIPTION
I tested this with no problems reported 

```
test result: ok. 249 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 50.09s
```