### PR TITLE
feat: improve reading of cpu brand in multiple architectures

### DIFF
--- a/src/unix/linux/cpu.rs
+++ b/src/unix/linux/cpu.rs
@@ -828,7 +828,7 @@ pub(crate) fn get_vendor_id_and_brand() -> HashMap<usize, (String, String)> {
             while let Some(line) = lines.next() {
                 if line.starts_with("vendor_id\t") {
                     info.vendor_id = Some(get_value(line));
-                } else if line.starts_with("model name\t") {
+                } else if line.starts_with("model name\t") || line.starts_with("Model Name\t") {
                     info.brand = Some(get_value(line));
                 } else if line.starts_with("CPU implementer\t") {
                     info.implementer = Some(get_hex_value(line));


### PR DESCRIPTION
In some architectures (like loongarch64), the key in `/proc/cpuinfo` is recorded in uppercase. (like: "model name" -> "Model Name" in loongarch64