### PR TITLE
Reduce windows version range

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ serde = { version = "^1.0.190", optional = true, features = ["derive"] }
 ntapi = { version = "0.4", optional = true }
 # Support a range of versions in order to avoid duplication of this crate. Make sure to test all
 # versions when bumping to a new release, and only increase the minimum when absolutely necessary.
-windows = { version = ">=0.59, <0.63", optional = true }
+windows = { version = ">=0.59, <0.62", optional = true }
 
 [target.'cfg(not(any(target_os = "unknown", target_arch = "wasm32")))'.dependencies]
 libc = "^0.2.171"


### PR DESCRIPTION
I believe that making the range >=0.59, <0.63 in #1532 was a mistake as windows 0.62 has not been published yet so this crate can't guarantee compatibility with it.