### PR TITLE
fix(linux/cpu): fix `get_cpu_frequency` on loongarch64 machine

### DIFF
--- a/src/unix/linux/cpu.rs
+++ b/src/unix/linux/cpu.rs
@@ -437,6 +437,7 @@ pub(crate) fn get_cpu_frequency(cpu_core_index: usize) -> u64 {
     }
     let find_cpu_mhz = s.split('\n').find(|line| {
         line.starts_with("cpu MHz\t")
+            || line.starts_with("CPU MHz\t")
             || line.starts_with("BogoMIPS")
             || line.starts_with("clock\t")
             || line.starts_with("bogomips per cpu")


### PR DESCRIPTION
In loongarch64 machine, `/proc/cpuinfo` frequency line starts with "CPU MHz", not "cpu MHz"