### PR TITLE
feat(win32): query physical memory POC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,7 @@ ntapi = { version = "0.4", optional = true }
 # Support a range of versions in order to avoid duplication of this crate. Make sure to test all
 # versions when bumping to a new release, and only increase the minimum when absolutely necessary.
 windows = { version = ">=0.59, <0.62", optional = true }
+wmi = { version = ">=0.17.0" }
 
 [target.'cfg(not(any(target_os = "unknown", target_arch = "wasm32")))'.dependencies]
 libc = "^0.2.171"


### PR DESCRIPTION
**Note: This code does NOT compile or pass any sort of tests.**

## Description
Below is a **proof of concept** to obtain detailed information regarding the installed physical memory for **Windows only**. This feature utilizes the [WMI crate](https://crates.io/crates/wmi) to establish a connection with the COM library, then the Windows Management Instrumentation (WMI), and then query the WMI for all information regarding the [Win32_PhysicalMemory](https://learn.microsoft.com/en-us/windows/win32/cimwin32prov/win32-physicalmemory) class.

In theory, this works amazingly. You can view the original idea [here](https://github.com/provrb/mem-info-test/blob/master/src/main.rs) (can't do a Rust playground unfortunately due to external crates). This concept was also referenced in issue #1260  

However, we're met with a problem. 

## Problem
The function `raw_query` from the WMI crate requires that the template return value implement the trait `serde::de::DeserializeOwned`. Using `#[cfg_attr(feature = "serde", derive(Deserialize)])`, as implemented in other parts of the codebase, does not suffice, and the error persists.

## Possible solutions and questions
As a result, I have a couple of questions for this feature to be implemented:
1. Do we make `serde` mandatory in the `cargo.toml` file?
2. Should we remove the `WMI` crate entirely and use the Windows API instead? Removing the entire `serde` problem.
3. Do we make this feature optional alongside `serde`?

Let me know, and I can start working on this right away!
Excuse me if there is an obvious workaround I've missed.

