### PR TITLE
feat: add support for retrieving motherboard information

### DIFF
--- a/src/c_interface.rs
+++ b/src/c_interface.rs
@@ -602,3 +602,43 @@ pub extern "C" fn sysinfo_system_long_version() -> RString {
 pub extern "C" fn sysinfo_cpu_physical_cores() -> u32 {
     System::physical_core_count().unwrap_or(0) as u32
 }
+
+/// Equivalent of [`system::motherboard_name()`].
+#[no_mangle]
+pub extern "C" fn sysinfo_motherboard_name() -> RString {
+    if let Some(c) = System::motherboard_name().and_then(|c| CString::new(c).ok()) {
+        c.into_raw() as _
+    } else {
+        std::ptr::null()
+    }
+}
+
+/// Equivalent of [`system::motherboard_vendor()`].
+#[no_mangle]
+pub extern "C" fn sysinfo_motherboard_vendor() -> RString {
+    if let Some(c) = System::motherboard_vendor().and_then(|c| CString::new(c).ok()) {
+        c.into_raw() as _
+    } else {
+        std::ptr::null()
+    }
+}
+
+/// Equivalent of [`system::motherboard_version()`].
+#[no_mangle]
+pub extern "C" fn sysinfo_motherboard_version() -> RString {
+    if let Some(c) = System::motherboard_version().and_then(|c| CString::new(c).ok()) {
+        c.into_raw() as _
+    } else {
+        std::ptr::null()
+    }
+}
+
+/// Equivalent of [`system::motherboard_serial()`].
+#[no_mangle]
+pub extern "C" fn sysinfo_motherboard_serial() -> RString {
+    if let Some(c) = System::motherboard_serial().and_then(|c| CString::new(c).ok()) {
+        c.into_raw() as _
+    } else {
+        std::ptr::null()
+    }
+}

--- a/src/common/system.rs
+++ b/src/common/system.rs
@@ -899,6 +899,71 @@ impl System {
         SystemInner::physical_core_count()
     }
 
+    /// Returns the motherboard name.
+    ///
+    /// This corresponds to the model identifier assigned by the motherboard's
+    /// manufacturer (e.g. "20BE0061MC").
+    ///
+    /// **Important**: this information is computed every time this function is called.
+    ///
+    /// ```no_run
+    /// use sysinfo::System;
+    ///
+    /// println!("Motherboard name: {:?}", System::motherboard_name());
+    /// ```
+    pub fn motherboard_name() -> Option<String> {
+        SystemInner::motherboard_name()
+    }
+
+    /// Returns the motherboard vendor.
+    ///
+    /// This corresponds to the name of the motherboard's manufacturer (e.g. "LENOVO").
+    ///
+    /// **Important**: this information is computed every time this function is called.
+    ///
+    /// ```no_run
+    /// use sysinfo::System;
+    ///
+    /// println!("Motherboard vendor: {:?}", System::motherboard_vendor());
+    /// ```
+    pub fn motherboard_vendor() -> Option<String> {
+        SystemInner::motherboard_vendor()
+    }
+
+    /// Returns the motherboard version.
+    ///
+    /// This corresponds to the version or model number assigned by the motherboard's
+    /// manufacturer (e.g. "0B98401 Pro").
+    ///
+    ///
+    /// **Important**: this information is computed every time this function is called.
+    ///
+    /// ```no_run
+    /// use sysinfo::System;
+    ///
+    /// println!("Motherboard version: {:?}", System::motherboard_version());
+    /// ```
+    pub fn motherboard_version() -> Option<String> {
+        SystemInner::motherboard_version()
+    }
+
+    /// Returns the motherboard serial number.
+    ///
+    /// This corresponds to the serial number assigned by the motherboard's
+    /// manufacturer (e.g. "W1KS427111E").
+    ///
+    ///
+    /// **Important**: this information is computed every time this function is called.
+    ///
+    /// ```no_run
+    /// use sysinfo::System;
+    ///
+    /// println!("Motherboard serial number: {:?}", System::motherboard_serial());
+    /// ```
+    pub fn motherboard_serial() -> Option<String> {
+        SystemInner::motherboard_serial()
+    }
+
     /// Returns the (default) maximum number of open files for a process.
     ///
     /// Returns `None` if it failed retrieving the information or if the current system is not

--- a/src/common/system.rs
+++ b/src/common/system.rs
@@ -903,6 +903,7 @@ impl System {
     ///
     /// This corresponds to the model identifier assigned by the motherboard's
     /// manufacturer (e.g. "20BE0061MC").
+    /// This information isn't available on ARM-based macOS systems.
     ///
     /// **Important**: this information is computed every time this function is called.
     ///
@@ -934,7 +935,7 @@ impl System {
     ///
     /// This corresponds to the version or model number assigned by the motherboard's
     /// manufacturer (e.g. "0B98401 Pro").
-    ///
+    /// This information isn't available on ARM-based macOS systems.
     ///
     /// **Important**: this information is computed every time this function is called.
     ///
@@ -951,7 +952,6 @@ impl System {
     ///
     /// This corresponds to the serial number assigned by the motherboard's
     /// manufacturer (e.g. "W1KS427111E").
-    ///
     ///
     /// **Important**: this information is computed every time this function is called.
     ///

--- a/src/sysinfo.h
+++ b/src/sysinfo.h
@@ -70,5 +70,9 @@ RString     sysinfo_system_version();
 RString     sysinfo_system_host_name();
 RString     sysinfo_system_long_version();
 uint32_t    sysinfo_cpu_physical_cores();
+RString     sysinfo_motherboard_name();
+RString     sysinfo_motherboard_vendor();
+RString     sysinfo_motherboard_version();
+RString     sysinfo_motherboard_serial();
 
 void        sysinfo_rstring_free(RString str);

--- a/src/unix/apple/macos/system.rs
+++ b/src/unix/apple/macos/system.rs
@@ -177,7 +177,7 @@ pub(crate) fn get_io_platform_property(key: &str) -> Option<String> {
         IOServiceGetMatchingService(kIOMasterPortDefault, Some(matching.as_opaque().into()))
     };
     if result == 0 {
-        sysinfo_debug!("Error: IOServiceGetMatchingService() = {}", result);
+        sysinfo_debug!("IOServiceGetMatchingService failed");
         return None;
     }
 

--- a/src/unix/apple/macos/system.rs
+++ b/src/unix/apple/macos/system.rs
@@ -165,11 +165,12 @@ pub(crate) fn get_io_platform_property(key: &str) -> Option<String> {
     };
     use std::ffi::CStr;
 
-    let Some(matching) =
-        (unsafe { IOServiceMatching(b"IOPlatformExpertDevice\0".as_ptr().cast()) })
-    else {
-        sysinfo_debug!("IOServiceMatching call failed, `IOPlatformExpertDevice` not found");
-        return None;
+    let matching = match unsafe { IOServiceMatching(b"IOPlatformExpertDevice\0".as_ptr().cast()) } {
+        Some(matching) => matching,
+        None => {
+            sysinfo_debug!("IOServiceMatching call failed, `IOPlatformExpertDevice` not found");
+            return None;
+        }
     };
 
     let result = unsafe {

--- a/src/unix/apple/system.rs
+++ b/src/unix/apple/system.rs
@@ -533,44 +533,44 @@ impl SystemInner {
         physical_core_count()
     }
 
-    #[cfg(all(target_os = "macos", not(feature = "apple-sandbox")))]
     pub(crate) fn motherboard_name() -> Option<String> {
-        get_io_platform_property("board-id")
+        cfg_if! {
+            if #[cfg(all(target_os = "macos", not(feature = "apple-sandbox")))] {
+                get_io_platform_property("board-id")
+            } else {
+                None
+            }
+        }
     }
 
-    #[cfg(all(target_os = "macos", not(feature = "apple-sandbox")))]
     pub(crate) fn motherboard_vendor() -> Option<String> {
-        get_io_platform_property("manufacturer")
+        cfg_if! {
+            if #[cfg(all(target_os = "macos", not(feature = "apple-sandbox")))] {
+                get_io_platform_property("manufacturer")
+            } else {
+                None
+            }
+        }
     }
 
-    #[cfg(all(target_os = "macos", not(feature = "apple-sandbox")))]
     pub(crate) fn motherboard_version() -> Option<String> {
-        get_io_platform_property("version")
+        cfg_if! {
+            if #[cfg(all(target_os = "macos", not(feature = "apple-sandbox")))] {
+                get_io_platform_property("version")
+            } else {
+                None
+            }
+        }
     }
 
-    #[cfg(all(target_os = "macos", not(feature = "apple-sandbox")))]
     pub(crate) fn motherboard_serial() -> Option<String> {
-        get_io_platform_property("IOPlatformSerialNumber")
-    }
-
-    #[cfg(any(target_os = "ios", feature = "apple-sandbox"))]
-    pub(crate) fn motherboard_name() -> Option<String> {
-        None
-    }
-
-    #[cfg(any(target_os = "ios", feature = "apple-sandbox"))]
-    pub(crate) fn motherboard_vendor() -> Option<String> {
-        None
-    }
-
-    #[cfg(any(target_os = "ios", feature = "apple-sandbox"))]
-    pub(crate) fn motherboard_version() -> Option<String> {
-        None
-    }
-
-    #[cfg(any(target_os = "ios", feature = "apple-sandbox"))]
-    pub(crate) fn motherboard_serial() -> Option<String> {
-        None
+        cfg_if! {
+            if #[cfg(all(target_os = "macos", not(feature = "apple-sandbox")))] {
+                get_io_platform_property("IOPlatformSerialNumber")
+            } else {
+                None
+            }
+        }
     }
 
     // FIXME: Would be better to query this information instead of using a "default" value like this.

--- a/src/unix/apple/system.rs
+++ b/src/unix/apple/system.rs
@@ -2,6 +2,8 @@
 
 use crate::sys::cpu::*;
 #[cfg(all(target_os = "macos", not(feature = "apple-sandbox")))]
+use crate::sys::macos::system::get_io_platform_property;
+#[cfg(all(target_os = "macos", not(feature = "apple-sandbox")))]
 use crate::sys::process::*;
 use crate::sys::utils::{get_sys_value, get_sys_value_by_name};
 
@@ -529,6 +531,46 @@ impl SystemInner {
 
     pub(crate) fn physical_core_count() -> Option<usize> {
         physical_core_count()
+    }
+
+    #[cfg(all(target_os = "macos", not(feature = "apple-sandbox")))]
+    pub(crate) fn motherboard_name() -> Option<String> {
+        get_io_platform_property("board-id")
+    }
+
+    #[cfg(all(target_os = "macos", not(feature = "apple-sandbox")))]
+    pub(crate) fn motherboard_vendor() -> Option<String> {
+        get_io_platform_property("manufacturer")
+    }
+
+    #[cfg(all(target_os = "macos", not(feature = "apple-sandbox")))]
+    pub(crate) fn motherboard_version() -> Option<String> {
+        get_io_platform_property("version")
+    }
+
+    #[cfg(all(target_os = "macos", not(feature = "apple-sandbox")))]
+    pub(crate) fn motherboard_serial() -> Option<String> {
+        get_io_platform_property("IOPlatformSerialNumber")
+    }
+
+    #[cfg(any(target_os = "ios", feature = "apple-sandbox"))]
+    pub(crate) fn motherboard_name() -> Option<String> {
+        None
+    }
+
+    #[cfg(any(target_os = "ios", feature = "apple-sandbox"))]
+    pub(crate) fn motherboard_vendor() -> Option<String> {
+        None
+    }
+
+    #[cfg(any(target_os = "ios", feature = "apple-sandbox"))]
+    pub(crate) fn motherboard_version() -> Option<String> {
+        None
+    }
+
+    #[cfg(any(target_os = "ios", feature = "apple-sandbox"))]
+    pub(crate) fn motherboard_serial() -> Option<String> {
+        None
     }
 
     // FIXME: Would be better to query this information instead of using a "default" value like this.

--- a/src/unix/freebsd/ffi.rs
+++ b/src/unix/freebsd/ffi.rs
@@ -20,11 +20,23 @@ use libc::{c_int, c_void};
 pub(crate) const DEVSTAT_READ: usize = 0x01;
 pub(crate) const DEVSTAT_WRITE: usize = 0x02;
 
+// definition come from https://github.com/freebsd/freebsd-src/blob/main/sys/sys/kenv.h
+pub(crate) const KENV_GET: c_int = 0;
+pub(crate) const KENV_MVALLEN: usize = 128;
+
 // pub(crate) const DSM_NONE: c_int = 0;
 // pub(crate) const DSM_TOTAL_BYTES_READ: c_int = 2;
 // pub(crate) const DSM_TOTAL_BYTES_WRITE: c_int = 3;
 
 extern "C" {
+    // definition come from: https://github.com/freebsd/freebsd-src/blob/main/include/kenv.h
+    pub(crate) fn kenv(
+        action: libc::c_int,
+        name: *const libc::c_char,
+        value: *mut libc::c_char,
+        len: libc::c_int,
+    ) -> libc::c_int;
+
     // pub(crate) fn devstat_compute_statistics(current: *mut devstat, previous: *mut devstat, etime: c_long_double, ...) -> c_int;
 }
 

--- a/src/unix/freebsd/system.rs
+++ b/src/unix/freebsd/system.rs
@@ -14,6 +14,7 @@ use std::ptr::NonNull;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, SystemTime};
 
+use super::ffi::{kenv, KENV_GET, KENV_MVALLEN};
 use crate::sys::cpu::{physical_core_count, CpusWrapper};
 use crate::sys::process::get_exe;
 use crate::sys::utils::{
@@ -279,6 +280,7 @@ impl SystemInner {
     pub(crate) fn physical_core_count() -> Option<usize> {
         physical_core_count()
     }
+
     pub(crate) fn motherboard_name() -> Option<String> {
         get_kenv_var(b"smbios.planar.product\0")
     }
@@ -751,20 +753,6 @@ fn get_system_info(mib: &[c_int], default: Option<&str>) -> Option<String> {
             }
         }
     }
-}
-
-// Retrieved from https://github.com/freebsd/freebsd-src/blob/main/sys/sys/kenv.h
-const KENV_GET: c_int = 0;
-const KENV_MVALLEN: usize = 128;
-
-// Retrieved from https://github.com/freebsd/freebsd-src/blob/main/include/kenv.h
-extern "C" {
-    pub fn kenv(
-        action: libc::c_int,
-        name: *const libc::c_char,
-        value: *mut libc::c_char,
-        len: libc::c_int,
-    ) -> libc::c_int;
 }
 
 // Get the value of a kernel environment variable.

--- a/src/unix/linux/system.rs
+++ b/src/unix/linux/system.rs
@@ -560,6 +560,36 @@ impl SystemInner {
         get_physical_core_count()
     }
 
+    pub(crate) fn motherboard_name() -> Option<String> {
+        std::fs::read_to_string("/sys/devices/virtual/dmi/id/board_name")
+            .ok()
+            .or_else(|| {
+                std::fs::read_to_string("/proc/device-tree/board")
+                    .ok()
+                    .or_else(|| Some(parse_device_tree_compatible()?.1))
+            })
+            .map(|s| s.trim().to_owned())
+    }
+
+    pub(crate) fn motherboard_vendor() -> Option<String> {
+        std::fs::read_to_string("/sys/devices/virtual/dmi/id/board_vendor")
+            .ok()
+            .or_else(|| Some(parse_device_tree_compatible()?.0))
+            .map(|s| s.trim().to_owned())
+    }
+
+    pub(crate) fn motherboard_version() -> Option<String> {
+        std::fs::read_to_string("/sys/devices/virtual/dmi/id/board_version")
+            .ok()
+            .map(|s| s.trim().to_owned())
+    }
+
+    pub(crate) fn motherboard_serial() -> Option<String> {
+        std::fs::read_to_string("/sys/devices/virtual/dmi/id/board_serial")
+            .ok()
+            .map(|s| s.trim().to_owned())
+    }
+
     pub(crate) fn refresh_cpu_list(&mut self, refresh_kind: CpuRefreshKind) {
         self.cpus = CpusWrapper::new();
         self.refresh_cpu_specifics(refresh_kind);
@@ -788,6 +818,20 @@ fn get_system_info_android(info: InfoType) -> Option<String> {
             None
         }
     }
+}
+
+// Parses the first entry of the file /proc/device-tree/compatible, to extract the vendor and
+// motherboard name. This file contains several \0 separated strings; the first one include the
+// vendor and the motherboard name, separated by a comma.
+// According to the specification: https://github.com/devicetree-org/devicetree-specification
+// a compatible string must contain only one comma.
+fn parse_device_tree_compatible() -> Option<(String, String)> {
+    let bytes = std::fs::read("/proc/device-tree/compatible").ok()?;
+    let first_line = bytes.split(|&b| b == 0).next()?;
+    std::str::from_utf8(first_line)
+        .ok()?
+        .split_once(',')
+        .map(|(a, b)| (a.to_owned(), b.to_owned()))
 }
 
 #[cfg(test)]

--- a/src/unknown/system.rs
+++ b/src/unknown/system.rs
@@ -154,6 +154,22 @@ impl SystemInner {
         None
     }
 
+    pub(crate) fn motherboard_name() -> Option<String> {
+        None
+    }
+
+    pub(crate) fn motherboard_vendor() -> Option<String> {
+        None
+    }
+
+    pub(crate) fn motherboard_version() -> Option<String> {
+        None
+    }
+
+    pub(crate) fn motherboard_serial() -> Option<String> {
+        None
+    }
+
     pub(crate) fn open_files_limit() -> Option<usize> {
         None
     }

--- a/src/windows/ffi.rs
+++ b/src/windows/ffi.rs
@@ -1,0 +1,12 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+#[repr(C, packed)]
+pub(crate) struct SMBIOSBaseboardInformation {
+    pub(crate) _type: u8,
+    pub(crate) length: u8,
+    pub(crate) _handle: u16,
+    pub(crate) manufacturer: u8,
+    pub(crate) product_name: u8,
+    pub(crate) version: u8,
+    pub(crate) serial_number: u8,
+}

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -7,6 +7,7 @@ cfg_if! {
         mod process;
         mod cpu;
         mod system;
+        mod ffi;
 
         pub(crate) use self::cpu::CpuInner;
         pub(crate) use self::process::ProcessInner;
@@ -58,6 +59,8 @@ mod component;
 mod cpu;
 #[cfg(any())]
 mod disk;
+#[cfg(any())]
+mod ffi;
 #[cfg(any())]
 mod groups;
 #[cfg(any())]

--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -689,7 +689,7 @@ fn get_smbios_table() -> Option<Vec<u8>> {
 }
 
 // Parses the SMBIOS table to get mainboard information (type 2).
-// Returns a part of struct with its associat>ed strings.
+// Returns a part of struct with its associated strings.
 // The parsing format is described here: https://wiki.osdev.org/System_Management_BIOS
 fn parse_mainboard_info(table: &[u8]) -> Option<(SMBIOSBaseboardInformation, Vec<&str>)> {
     // Skip SMBIOS types 0 and 1 to get Mainboard Information (type 2)

--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -24,8 +24,8 @@ use windows::Win32::System::Registry::{
 };
 use windows::Win32::System::SystemInformation::{self, GetSystemInfo};
 use windows::Win32::System::SystemInformation::{
-    ComputerNamePhysicalDnsHostname, GetComputerNameExW, GetTickCount64, GlobalMemoryStatusEx,
-    MEMORYSTATUSEX, SYSTEM_INFO,
+    ComputerNamePhysicalDnsHostname, GetComputerNameExW, GetSystemFirmwareTable, GetTickCount64,
+    GlobalMemoryStatusEx, FIRMWARE_TABLE_PROVIDER, MEMORYSTATUSEX, SYSTEM_INFO,
 };
 use windows::Win32::System::Threading::GetExitCodeProcess;
 
@@ -459,6 +459,42 @@ impl SystemInner {
         get_physical_core_count()
     }
 
+    pub(crate) fn motherboard_name() -> Option<String> {
+        let table = get_smbios_table()?;
+        let (info, strings) = parse_mainboard_info(&table)?;
+        strings
+            .get(info.product_name as usize - 1)
+            .copied()
+            .map(str::to_string)
+    }
+
+    pub(crate) fn motherboard_vendor() -> Option<String> {
+        let table = get_smbios_table()?;
+        let (info, strings) = parse_mainboard_info(&table)?;
+        strings
+            .get(info.manufacturer as usize - 1)
+            .copied()
+            .map(str::to_string)
+    }
+
+    pub(crate) fn motherboard_version() -> Option<String> {
+        let table = get_smbios_table()?;
+        let (info, strings) = parse_mainboard_info(&table)?;
+        strings
+            .get(info.version as usize - 1)
+            .copied()
+            .map(str::to_string)
+    }
+
+    pub(crate) fn motherboard_serial() -> Option<String> {
+        let table = get_smbios_table()?;
+        let (info, strings) = parse_mainboard_info(&table)?;
+        strings
+            .get(info.serial_number as usize - 1)
+            .copied()
+            .map(str::to_string)
+    }
+
     pub(crate) fn open_files_limit() -> Option<usize> {
         // Apparently when using C run-time libraries, it's limited by _NHANDLE_.
         // It's a define:
@@ -630,4 +666,75 @@ pub(crate) fn get_reg_value_u32(hkey: HKEY, path: &str, field_name: &str) -> Opt
             .map(|_| buf)
             .ok()
     }
+}
+
+#[repr(C, packed)]
+struct SMBIOSBaseboardInformation {
+    _type: u8,
+    length: u8,
+    _handle: u16,
+    manufacturer: u8,
+    product_name: u8,
+    version: u8,
+    serial_number: u8,
+}
+
+// Get the SMBIOS table using the WinAPI.
+fn get_smbios_table() -> Option<Vec<u8>> {
+    const PROVIDER: FIRMWARE_TABLE_PROVIDER = FIRMWARE_TABLE_PROVIDER(u32::from_be_bytes(*b"RSMB"));
+
+    let size = unsafe { GetSystemFirmwareTable(PROVIDER, 0, None) };
+    if size == 0 {
+        return None;
+    }
+
+    let mut buffer = vec![0u8; size as usize];
+
+    let res = unsafe { GetSystemFirmwareTable(PROVIDER, 0, Some(&mut buffer)) };
+    if res == 0 {
+        return None;
+    }
+
+    Some(buffer)
+}
+
+// Parses the SMBIOS table to get mainboard information (type 2).
+// Returns a part of struct with its associat>ed strings.
+// The parsing format is described here: https://wiki.osdev.org/System_Management_BIOS
+fn parse_mainboard_info(table: &[u8]) -> Option<(SMBIOSBaseboardInformation, Vec<&str>)> {
+    // Skip SMBIOS types 0 and 1 to get Mainboard Information (type 2)
+    // All indexes provided by the structure start at 1.
+    // At index i:
+    //      table[i] is the current SMBIOS type.
+    //      table[i + 1] is the length of the current SMBIOS table header
+    //      Strings section starts immediately after the SMBIOS header,
+    //      and is a list of null-terminated strings, terminated with two \0.
+    let mut i = 0;
+    while i + 1 < table.len() {
+        if table[i] == 2 {
+            break;
+        }
+        i += table[i + 1] as usize;
+        // Skip strings table (terminated itself by \0)
+        while i < table.len() {
+            if table[i] == 0 && table[i + 1] == 0 {
+                i += 2;
+                break;
+            }
+            i += 1;
+        }
+    }
+
+    let info: SMBIOSBaseboardInformation =
+        unsafe { std::ptr::read_unaligned(table[i..].as_ptr() as *const _) };
+
+    // As said in the SMBIOS 3 standard: https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.6.0.pdf,
+    // the strings are necessarily in UTF-8.
+    let values = table[(i + info.length as usize)..]
+        .split(|&b| b == 0)
+        .map(|s| unsafe { std::str::from_utf8_unchecked(s) })
+        .take_while(|s| !s.is_empty())
+        .collect();
+
+    Some((info, values))
 }

--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -4,6 +4,7 @@ use crate::{
     Cpu, CpuRefreshKind, LoadAvg, MemoryRefreshKind, Pid, ProcessRefreshKind, ProcessesToUpdate,
 };
 
+use super::ffi::SMBIOSBaseboardInformation;
 use crate::sys::cpu::*;
 use crate::{Process, ProcessInner};
 
@@ -666,17 +667,6 @@ pub(crate) fn get_reg_value_u32(hkey: HKEY, path: &str, field_name: &str) -> Opt
             .map(|_| buf)
             .ok()
     }
-}
-
-#[repr(C, packed)]
-struct SMBIOSBaseboardInformation {
-    _type: u8,
-    length: u8,
-    _handle: u16,
-    manufacturer: u8,
-    product_name: u8,
-    version: u8,
-    serial_number: u8,
 }
 
 // Get the SMBIOS table using the WinAPI.


### PR DESCRIPTION
This PR adds support for retrieving information from the motherboard using 4 methods: `motherboard_name`, `motherboard_vendor`, `motherboard_version` and `motherboard_serial`.

Some of the logic used to retrieve the information is inspired by [fastfetch](https://github.com/fastfetch-cli/fastfetch).

Thanks to [Squitch](https://github.com/Squitch1) for improvements ideas and for making the code work for MacOS!

Implementation details:

- On Linux, the `/sys/devices/virtual/dmi/id/{board_name, board_vendor, board_version, board_serial}` files, or for ARM systems, the `/proc/device-tree/{board, compatible}` files are used.

- On FreeBSD, the information is retrieved from the kernel environment variables `smbios.planar.product`, `smbios.planar.maker`, `smbios.planar.version` and `smbios.planar.serial`.

- On MacOS, the information is retrieved using the `board-id`, `manufacturer`, `version` and `IOPlatformSerialNumber` keys from the `IOPlatformExpertDevice` service.

- Finally, for Windows, the information is read from the SMBIOS table, which is retrieved using the WinAPI.

Remaining problems:

In the case of Windows, if we want to read the 4 information we have to make 4 calls to the WinAPI and parse the table 4 times. It might be interesting to store the cached information in `SystemInner` or to add a complementary method returning the four information in a structure? Or perhaps you have a better idea?
