### PR TITLE
(Linux) Replace unsafe from_utf8_unchecked in to_str! macro with safe from_utf8 fallback

### DIFF
--- a/src/unix/linux/cpu.rs
+++ b/src/unix/linux/cpu.rs
@@ -12,7 +12,7 @@ use crate::{Cpu, CpuRefreshKind};
 
 macro_rules! to_str {
     ($e:expr) => {
-        unsafe { std::str::from_utf8_unchecked($e) }
+        std::str::from_utf8($e).unwrap_or_default()
     };
 }
 


### PR DESCRIPTION
The `to_str!` macro currently uses `unsafe { std::str::from_utf8_unchecked(bytes) }`, which is undefined behavior if `/proc/stat` ever contains non‑UTF8 data (however unlikely). This change:

- Updates `to_str!` to call `std::str::from_utf8(bytes).unwrap_or("")`
- ~Adds a doc comment explaining the fallback~
- Keeps the macro signature and return type (&str) unchanged

All existing calls to `to_str!` still work exactly the same but now panic‑free and UB‑free on malformed input.