### PR TITLE
src,unix: expose cpu total_time directly

### DIFF
--- a/src/common/system.rs
+++ b/src/common/system.rs
@@ -2334,7 +2334,7 @@ pub enum ProcessesToUpdate<'a> {
 /// information from `/proc/<pid>/` as well as all the information from `/proc/<pid>/task/<tid>/`
 /// folders. This makes the refresh mechanism a lot slower depending on the number of tasks
 /// each process has.
-///  
+///
 /// If you don't care about tasks information, use `ProcessRefreshKind::everything().without_tasks()`
 /// as much as possible.
 ///
@@ -2775,6 +2775,22 @@ impl Cpu {
     /// ```
     pub fn cpu_usage(&self) -> f32 {
         self.inner.cpu_usage()
+    }
+
+    /// Returns this CPU's total_time.
+    ///
+    /// ```no_run
+    /// use sysinfo::{System, RefreshKind, CpuRefreshKind};
+    ///
+    /// let s = System::new_with_specifics(
+    ///     RefreshKind::nothing().with_cpu(CpuRefreshKind::everything()),
+    /// );
+    /// for cpu in s.cpus() {
+    ///     println!("{}", cpu.cpu_total_time());
+    /// }
+    /// ```
+    pub fn cpu_total_time(&self) -> u64 {
+        self.inner.cpu_total_time()
     }
 
     /// Returns this CPU's name.

--- a/src/unix/apple/cpu.rs
+++ b/src/unix/apple/cpu.rs
@@ -115,6 +115,7 @@ pub(crate) struct CpuUsage {
     data: Arc<CpuData>,
     // Cannot be frequency for each CPU apparently so we store it in the CPU usage...
     frequency: u64,
+    total_time: u64,
 }
 
 impl CpuUsage {
@@ -123,6 +124,7 @@ impl CpuUsage {
             percent: 0.,
             data: Arc::new(CpuData::new(std::ptr::null_mut(), 0)),
             frequency: 0,
+            total_time: 0,
         }
     }
 
@@ -130,8 +132,16 @@ impl CpuUsage {
         self.percent
     }
 
+    pub(crate) fn total_time(&self) -> u64 {
+        self.total_time
+    }
+
     pub(crate) fn set_cpu_usage(&mut self, value: f32) {
         self.percent = value;
+    }
+
+    pub(crate) fn set_cpu_total_time(&mut self, value: u64) {
+        self.total_time = value;
     }
 }
 
@@ -156,6 +166,7 @@ impl CpuInner {
                 percent: 0.,
                 data: cpu_data,
                 frequency,
+                total_time: 0,
             },
             vendor_id,
             brand,
@@ -164,6 +175,10 @@ impl CpuInner {
 
     pub(crate) fn set_cpu_usage(&mut self, cpu_usage: f32) {
         self.usage.set_cpu_usage(cpu_usage);
+    }
+
+    pub(crate) fn set_cpu_total_time(&mut self, total_time: u64) {
+        self.usage.set_cpu_total_time(total_time)
     }
 
     pub(crate) fn update(&mut self, cpu_usage: f32, cpu_data: Arc<CpuData>) {
@@ -181,6 +196,10 @@ impl CpuInner {
 
     pub(crate) fn cpu_usage(&self) -> f32 {
         self.usage.percent()
+    }
+
+    pub(crate) fn cpu_total_time(&self) -> u64 {
+        self.usage.total_time()
     }
 
     pub(crate) fn name(&self) -> &str {
@@ -355,6 +374,7 @@ pub(crate) fn init_cpus(
                 let cpu_usage = compute_usage_of_cpu(&cpu, cpu_info, offset);
                 cpu.inner.set_cpu_usage(cpu_usage);
                 percentage += cpu.cpu_usage();
+                cpu.inner.set_cpu_total_time(cpu.cpu_total_time());
             }
             cpus.push(cpu);
 

--- a/src/unix/freebsd/cpu.rs
+++ b/src/unix/freebsd/cpu.rs
@@ -116,6 +116,7 @@ impl CpusWrapper {
 
 pub(crate) struct CpuInner {
     pub(crate) cpu_usage: f32,
+    pub(crate) cpu_total_time: u64,
     name: String,
     pub(crate) vendor_id: String,
     pub(crate) frequency: u64,
@@ -125,6 +126,7 @@ impl CpuInner {
     pub(crate) fn new(name: String, vendor_id: String, frequency: u64) -> Self {
         Self {
             cpu_usage: 0.,
+            cpu_total_time: 0,
             name,
             vendor_id,
             frequency,
@@ -133,6 +135,10 @@ impl CpuInner {
 
     pub(crate) fn cpu_usage(&self) -> f32 {
         self.cpu_usage
+    }
+
+    pub(crate) fn cpu_total_time(&self) -> u64 {
+        self.cpu_total_time
     }
 
     pub(crate) fn name(&self) -> &str {

--- a/src/unix/linux/cpu.rs
+++ b/src/unix/linux/cpu.rs
@@ -424,6 +424,10 @@ impl CpuInner {
         self.usage.percent
     }
 
+    pub(crate) fn cpu_total_time(&self) -> u64 {
+        self.usage.total_time
+    }
+
     pub(crate) fn name(&self) -> &str {
         &self.name
     }

--- a/src/unknown/cpu.rs
+++ b/src/unknown/cpu.rs
@@ -7,6 +7,10 @@ impl CpuInner {
         0.0
     }
 
+    pub(crate) fn cpu_total_time(&self) -> u64 {
+        0
+    }
+
     pub(crate) fn name(&self) -> &str {
         ""
     }

--- a/src/windows/cpu.rs
+++ b/src/windows/cpu.rs
@@ -268,6 +268,7 @@ impl CpusWrapper {
             global: CpuUsage {
                 percent: 0f32,
                 key_used: None,
+                total_time: 0,
             },
             cpus: Vec::new(),
         }
@@ -309,6 +310,7 @@ impl CpusWrapper {
 pub(crate) struct CpuUsage {
     percent: f32,
     pub(crate) key_used: Option<KeyHandler>,
+    total_time: u64,
 }
 
 impl CpuUsage {
@@ -328,6 +330,10 @@ pub(crate) struct CpuInner {
 impl CpuInner {
     pub(crate) fn cpu_usage(&self) -> f32 {
         self.usage.percent
+    }
+
+    pub(crate) fn cpu_total_time(&self) -> u64 {
+        self.usage.total_time
     }
 
     pub(crate) fn name(&self) -> &str {
@@ -357,6 +363,7 @@ impl CpuInner {
             usage: CpuUsage {
                 percent: 0f32,
                 key_used: None,
+                total_time: 0,
             },
             vendor_id,
             brand,


### PR DESCRIPTION
This is collected, but not directly accessible - this just punches it thru so it is.