### PR TITLE
On Windows handle invalid UTF-8 from SMBIOS

### DIFF
--- a/src/windows/utils.rs
+++ b/src/windows/utils.rs
@@ -136,10 +136,10 @@ cfg_if! {
             let info: T = unsafe { std::ptr::read_unaligned(table[i..].as_ptr() as *const _) };
 
             // As said in the SMBIOS 3 standard: https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.6.0.pdf,
-            // the strings are necessarily in UTF-8.
+            // the strings are necessarily in UTF-8. But sometimes virtual machines may return non-compliant data.
             let values = table[(i + info.length() as usize)..]
                 .split(|&b| b == 0)
-                .map(|s| unsafe { std::str::from_utf8_unchecked(s) })
+                .filter_map(|s| std::str::from_utf8(s).ok())
                 .take_while(|s| !s.is_empty())
                 .collect();
 


### PR DESCRIPTION
I got one user reporting this crashes on a VM instance from a NAS server:

```
[preferences\src\main.rs:32:5] sysinfo::Motherboard::new() = Some(
    Motherboard
thread 'main' panicked at C:\Users\User\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\sysinfo-0.36.1\src\windows\utils.rs:138:31:
range start index 618 out of range for slice of length 424
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Don't trust that SMBIOS strings are well-formed. This also avoids one unsafe block.
