### PR TITLE
return all partitions and disks in linux, regardless of mount status - take 2

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -84,18 +84,32 @@ impl std::fmt::Debug for crate::Process {
 #[cfg(feature = "disk")]
 impl std::fmt::Debug for crate::Disk {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            fmt,
-            "Disk({:?})[FS: {:?}][Type: {:?}][removable: {}][I/O: {:?}] mounted on {:?}: {}/{} B",
-            self.name(),
-            self.file_system(),
-            self.kind(),
-            if self.is_removable() { "yes" } else { "no" },
-            self.usage(),
-            self.mount_point(),
-            self.available_space(),
-            self.total_space(),
-        )
+        if self.mount_point().exists() {
+            write!(
+                fmt,
+                "Disk({:?})[FS: {:?}][Type: {:?}][removable: {}][I/O: {:?}] mounted on {:?}: {}/{} B",
+                self.name(),
+                self.file_system(),
+                self.kind(),
+                if self.is_removable() { "yes" } else { "no" },
+                self.usage(),
+                self.mount_point(),
+                self.available_space(),
+                self.total_space(),
+            )
+        } else {
+            write!(
+                fmt,
+                "Disk({:?})[FS: {:?}][Type: {:?}][removable: {}][I/O: {:?}] not mounted: {}/{} B",
+                self.name(),
+                self.file_system(),
+                self.kind(),
+                if self.is_removable() { "yes" } else { "no" },
+                self.usage(),
+                self.available_space(),
+                self.total_space(),
+            )
+        }
     }
 }
 

--- a/src/unix/linux/disk.rs
+++ b/src/unix/linux/disk.rs
@@ -437,12 +437,17 @@ fn get_all_list(
 
     let procfs_disk_stats = disk_stats(&refresh_kind);
 
-    for fs_spec in content_partitions.lines().skip(2).map(|line| {
-        let line = line.trim_start();
-        let fields = line.split_whitespace();
-        let vec = fields.into_iter().collect::<Vec<&str>>();
-        vec.get(3).unwrap().to_owned()
-    }) {
+    for fs_spec in content_partitions
+        .lines()
+        .skip(2)
+        .map(|line| {
+            let line = line.trim_start();
+            let fields = line.split_whitespace();
+            let vec = fields.into_iter().collect::<Vec<&str>>();
+            vec.get(3).unwrap().to_owned()
+        })
+        .filter(|fs_spec| !(fs_spec.starts_with("sr")))
+    {
         let mount_point = Path::new("");
         let disk_name = format!("/dev/{}", fs_spec);
 

--- a/src/unix/linux/disk.rs
+++ b/src/unix/linux/disk.rs
@@ -338,7 +338,7 @@ fn find_type_for_device_name(device_name: &OsStr) -> DiskKind {
 fn get_all_list(container: &mut Vec<Disk>, content: &str, refresh_kind: DiskRefreshKind) {
     // The goal of this array is to list all removable devices (the ones whose name starts with
     // "usb-").
-    println!("get_all_list: {content}");
+    //println!("get_all_list: {content}");
     let removable_entries = match fs::read_dir("/dev/disk/by-id/") {
         Ok(r) => r
             .filter_map(|res| Some(res.ok()?.path()))

--- a/src/unix/linux/disk.rs
+++ b/src/unix/linux/disk.rs
@@ -338,6 +338,7 @@ fn find_type_for_device_name(device_name: &OsStr) -> DiskKind {
 fn get_all_list(container: &mut Vec<Disk>, content: &str, refresh_kind: DiskRefreshKind) {
     // The goal of this array is to list all removable devices (the ones whose name starts with
     // "usb-").
+    println!("get_all_list: {content}");
     let removable_entries = match fs::read_dir("/dev/disk/by-id/") {
         Ok(r) => r
             .filter_map(|res| Some(res.ok()?.path()))

--- a/src/unix/linux/disk.rs
+++ b/src/unix/linux/disk.rs
@@ -155,6 +155,7 @@ impl crate::DisksInner {
         get_all_list(
             &mut self.disks,
             &get_all_utf8_data("/proc/mounts", 16_385).unwrap_or_default(),
+            &get_all_utf8_data("/proc/partitions", 16_385).unwrap_or_default(),
             refresh_kind,
         );
 
@@ -335,7 +336,12 @@ fn find_type_for_device_name(device_name: &OsStr) -> DiskKind {
     }
 }
 
-fn get_all_list(container: &mut Vec<Disk>, content: &str, refresh_kind: DiskRefreshKind) {
+fn get_all_list(
+    container: &mut Vec<Disk>,
+    content_mounts: &str,
+    content_partitions: &str,
+    refresh_kind: DiskRefreshKind,
+) {
     // The goal of this array is to list all removable devices (the ones whose name starts with
     // "usb-").
     //println!("get_all_list: {content}");
@@ -358,7 +364,7 @@ fn get_all_list(container: &mut Vec<Disk>, content: &str, refresh_kind: DiskRefr
 
     let procfs_disk_stats = disk_stats(&refresh_kind);
 
-    for (fs_spec, fs_file, fs_vfstype) in content
+    for (fs_spec, fs_file, fs_vfstype) in content_mounts
         .lines()
         .map(|line| {
             println!("get_all_list: {line}");
@@ -419,7 +425,6 @@ fn get_all_list(container: &mut Vec<Disk>, content: &str, refresh_kind: DiskRefr
             disk.inner.updated = true;
             continue;
         }
-        println!("-> {fs_spec}");
         container.push(new_disk(
             fs_spec.as_ref(),
             mount_point,
@@ -429,7 +434,10 @@ fn get_all_list(container: &mut Vec<Disk>, content: &str, refresh_kind: DiskRefr
             refresh_kind,
         ));
     }
-}
+
+    for (major, minor, blocks, name) in content_partitions.lines().map(|line| {
+      println!("{line}");
+    }) {}
 
 /// Disk IO stat information from `/proc/diskstats` file.
 ///

--- a/src/unix/linux/disk.rs
+++ b/src/unix/linux/disk.rs
@@ -441,7 +441,6 @@ fn get_all_list(
         let line = line.trim_start();
         let fields = line.split_whitespace();
         let vec = fields.into_iter().collect::<Vec<&str>>();
-        println!("{vec:?}");
         vec.get(3).unwrap().to_owned()
     }) {
         let mount_point = Path::new("");
@@ -458,7 +457,7 @@ fn get_all_list(
         container.push(new_disk(
             disk_name.as_ref(),
             mount_point,
-            "".as_ref(),
+            "<unknown>".as_ref(),
             &removable_entries,
             &procfs_disk_stats,
             refresh_kind,

--- a/src/unix/linux/disk.rs
+++ b/src/unix/linux/disk.rs
@@ -344,7 +344,6 @@ fn get_all_list(
 ) {
     // The goal of this array is to list all removable devices (the ones whose name starts with
     // "usb-").
-    //println!("get_all_list: {content}");
     let removable_entries = match fs::read_dir("/dev/disk/by-id/") {
         Ok(r) => r
             .filter_map(|res| Some(res.ok()?.path()))
@@ -367,7 +366,6 @@ fn get_all_list(
     for (fs_spec, fs_file, fs_vfstype) in content_mounts
         .lines()
         .map(|line| {
-            //println!("get_all_list: {line}");
             let line = line.trim_start();
             // mounts format
             // http://man7.org/linux/man-pages/man5/fstab.5.html

--- a/src/unix/linux/disk.rs
+++ b/src/unix/linux/disk.rs
@@ -367,7 +367,7 @@ fn get_all_list(
     for (fs_spec, fs_file, fs_vfstype) in content_mounts
         .lines()
         .map(|line| {
-            println!("get_all_list: {line}");
+            //println!("get_all_list: {line}");
             let line = line.trim_start();
             // mounts format
             // http://man7.org/linux/man-pages/man5/fstab.5.html

--- a/src/unix/linux/disk.rs
+++ b/src/unix/linux/disk.rs
@@ -433,8 +433,6 @@ fn get_all_list(
         ));
     }
 
-    let procfs_disk_stats = disk_stats(&refresh_kind);
-
     for fs_spec in content_partitions
         .lines()
         .skip(2)

--- a/src/unix/linux/disk.rs
+++ b/src/unix/linux/disk.rs
@@ -446,9 +446,10 @@ fn get_all_list(
         let mount_point = Path::new("");
         let disk_name = format!("/dev/{}", fs_spec);
 
-        if let Some(disk) = container.iter_mut().find(|d| {
-            d.inner.mount_point == mount_point && d.inner.device_name == disk_name.as_str()
-        }) {
+        if let Some(disk) = container
+            .iter_mut()
+            .find(|d| d.inner.device_name == disk_name.as_str())
+        {
             disk.inner
                 .efficient_refresh(refresh_kind, &procfs_disk_stats, false);
             disk.inner.updated = true;

--- a/src/unix/linux/disk.rs
+++ b/src/unix/linux/disk.rs
@@ -361,6 +361,7 @@ fn get_all_list(container: &mut Vec<Disk>, content: &str, refresh_kind: DiskRefr
     for (fs_spec, fs_file, fs_vfstype) in content
         .lines()
         .map(|line| {
+            println!("get_all_list: {line}");
             let line = line.trim_start();
             // mounts format
             // http://man7.org/linux/man-pages/man5/fstab.5.html

--- a/src/unix/linux/disk.rs
+++ b/src/unix/linux/disk.rs
@@ -434,10 +434,8 @@ fn get_all_list(
             refresh_kind,
         ));
     }
-
-    for (major, minor, blocks, name) in content_partitions.lines().map(|line| {
-      println!("{line}");
-    }) {}
+    println!("{content_partitions}");
+}
 
 /// Disk IO stat information from `/proc/diskstats` file.
 ///

--- a/src/unix/linux/disk.rs
+++ b/src/unix/linux/disk.rs
@@ -437,7 +437,7 @@ fn get_all_list(
 
     let procfs_disk_stats = disk_stats(&refresh_kind);
 
-    for fs_spec in content_partitions.lines().map(|line| {
+    for fs_spec in content_partitions.lines().skip(2).map(|line| {
         let line = line.trim_start();
         let fields = line.split_whitespace();
         let vec = fields.into_iter().collect::<Vec<&str>>();

--- a/src/unix/linux/disk.rs
+++ b/src/unix/linux/disk.rs
@@ -361,7 +361,7 @@ fn get_all_list(container: &mut Vec<Disk>, content: &str, refresh_kind: DiskRefr
     for (fs_spec, fs_file, fs_vfstype) in content
         .lines()
         .map(|line| {
-            println!("get_all_list: {line}");
+            //println!("get_all_list: {line}");
             let line = line.trim_start();
             // mounts format
             // http://man7.org/linux/man-pages/man5/fstab.5.html
@@ -419,6 +419,7 @@ fn get_all_list(container: &mut Vec<Disk>, content: &str, refresh_kind: DiskRefr
             disk.inner.updated = true;
             continue;
         }
+        println!("-> {fs_spec}");
         container.push(new_disk(
             fs_spec.as_ref(),
             mount_point,

--- a/src/unix/linux/disk.rs
+++ b/src/unix/linux/disk.rs
@@ -361,7 +361,7 @@ fn get_all_list(container: &mut Vec<Disk>, content: &str, refresh_kind: DiskRefr
     for (fs_spec, fs_file, fs_vfstype) in content
         .lines()
         .map(|line| {
-            //println!("get_all_list: {line}");
+            println!("get_all_list: {line}");
             let line = line.trim_start();
             // mounts format
             // http://man7.org/linux/man-pages/man5/fstab.5.html

--- a/src/unix/linux/disk.rs
+++ b/src/unix/linux/disk.rs
@@ -441,6 +441,7 @@ fn get_all_list(
         let line = line.trim_start();
         let fields = line.split_whitespace();
         let vec = fields.into_iter().collect::<Vec<&str>>();
+        println!("{vec:?}");
         vec.get(3).unwrap().to_owned()
     }) {
         let mount_point = Path::new("");

--- a/src/unix/linux/utils.rs
+++ b/src/unix/linux/utils.rs
@@ -20,14 +20,14 @@ pub(crate) fn get_all_utf8_data_from_file(file: &mut File, size: usize) -> io::R
     let mut buf = String::with_capacity(size);
     file.rewind()?;
     file.read_to_string(&mut buf)?;
-    println!("get_all_utf8_data_from_file: {buf}");
+    //println!("get_all_utf8_data_from_file: {buf}");
     Ok(buf)
 }
 
 #[cfg(any(feature = "disk", feature = "system"))]
 pub(crate) fn get_all_utf8_data<P: AsRef<Path>>(file_path: P, size: usize) -> io::Result<String> {
     let mut file = File::open(file_path.as_ref())?;
-    println!("get_all_utf8_data: {file:?}");
+    //println!("get_all_utf8_data: {file:?}");
     get_all_utf8_data_from_file(&mut file, size)
 }
 

--- a/src/unix/linux/utils.rs
+++ b/src/unix/linux/utils.rs
@@ -20,14 +20,12 @@ pub(crate) fn get_all_utf8_data_from_file(file: &mut File, size: usize) -> io::R
     let mut buf = String::with_capacity(size);
     file.rewind()?;
     file.read_to_string(&mut buf)?;
-    //println!("get_all_utf8_data_from_file: {buf}");
     Ok(buf)
 }
 
 #[cfg(any(feature = "disk", feature = "system"))]
 pub(crate) fn get_all_utf8_data<P: AsRef<Path>>(file_path: P, size: usize) -> io::Result<String> {
     let mut file = File::open(file_path.as_ref())?;
-    //println!("get_all_utf8_data: {file:?}");
     get_all_utf8_data_from_file(&mut file, size)
 }
 

--- a/src/unix/linux/utils.rs
+++ b/src/unix/linux/utils.rs
@@ -20,12 +20,14 @@ pub(crate) fn get_all_utf8_data_from_file(file: &mut File, size: usize) -> io::R
     let mut buf = String::with_capacity(size);
     file.rewind()?;
     file.read_to_string(&mut buf)?;
+    println!("get_all_utf8_data_from_file: {buf}");
     Ok(buf)
 }
 
 #[cfg(any(feature = "disk", feature = "system"))]
 pub(crate) fn get_all_utf8_data<P: AsRef<Path>>(file_path: P, size: usize) -> io::Result<String> {
     let mut file = File::open(file_path.as_ref())?;
+    println!("get_all_utf8_data: {file:?}");
     get_all_utf8_data_from_file(&mut file, size)
 }
 


### PR DESCRIPTION
Well, I would say this is my try to fix this issue mentioned in https://github.com/GuillaumeGomez/sysinfo/issues/1181
(Since I stumbled over it as well).

What I've additionally added was, to read the `/proc/partitions` and have it pass as an additional parameter to `get_all_list()`.

If the fs-type is not known, I'll have it say `<unknown>` instead.

Additionally I've edited the debug message as well, since it's weird if it prints `mounted on ""`, even though it's not mounted. On unmounted disks it'll now say `not mounted`

I've also sorted out, possible `/dev/sr*`, since it's not a "real" disk, more an optical drive.

Looking at PR https://github.com/GuillaumeGomez/sysinfo/pull/1251
I saw that you also have loop devices in `/proc/partitions`.

I couldn't find any references on possible content of `/proc/partitions`, so if you have any devices which aren't currently listed in the filter block, feel free to tell me, so I can adjust it further. :)