### PR TITLE
Add C binding for accessing cgroup limits

### DIFF
--- a/src/sysinfo.h
+++ b/src/sysinfo.h
@@ -45,6 +45,9 @@ size_t      sysinfo_total_swap(CSystem system);
 size_t      sysinfo_free_swap(CSystem system);
 size_t      sysinfo_used_swap(CSystem system);
 
+bool        sysinfo_cgroup_limits(CSystem system, size_t *total_memory,
+                                 size_t *free_memory, size_t *free_swap, size_t *rss);
+
 void        sysinfo_cpus_usage(CSystem system, unsigned int *length, float **cpus);
 
 size_t      sysinfo_processes(CSystem system, bool (*fn_pointer)(PID, CProcess, void*),


### PR DESCRIPTION
Add a C binding for accessing `cgroup_limits`.

Since C doesn't have optional types, the function instead writes the limits to passed-in-pointers, and returns a boolean of whether the information was available. This is probably the most C-like way of doing things.

Currently I have it taking in separate pointers for each data field in `cgroup_limits`, to avoid making a struct definition shared between C and Rust (which seemed more complex and kind of error-prone), but either way should work