### PR TITLE
fix: CGroupLimits should detect memory limits in sub-cgroups

### DIFF
--- a/tests/cgroup_integration.rs
+++ b/tests/cgroup_integration.rs
@@ -1,0 +1,27 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+#![cfg(feature = "system")]
+use sysinfo::System;
+
+#[test]
+#[ignore]
+fn test_cgroup_limits_with_memory_constraint() {
+    // This test should be run via:
+    // systemd-run --user --scope -p MemoryMax=512M cargo test --test cgroup_integration -- --ignored --nocapture
+    let mut sys = System::new();
+    sys.refresh_memory();
+
+    if let Some(limits) = sys.cgroup_limits() {
+        // Check if we're in a constrained cgroup (512MB)
+        let expected = 512 * 1024 * 1024;
+
+        println!("CGroup limits detected: {:?}", limits);
+        assert!(
+            limits.total_memory <= expected,
+            "Expected 512MB limit, got {} bytes",
+            limits.total_memory
+        );
+    } else {
+        panic!("cgroup_limits() returned None - cgroup detection failed");
+    }
+}


### PR DESCRIPTION
closes: https://github.com/GuillaumeGomez/sysinfo/issues/1610

### Integration test ran manually

- Run `test_cgroup_limits_with_memory_constraint` with `512M` bound - passes as the test expects memory to be reported as `512M`

```
❯ systemd-run --user --scope -p MemoryMax=512M cargo test --test cgroup_integration -- --ignored --nocapture
Running as unit: run-p1081902-i5275437.scope; invocation ID: fa8f6fa08f334494bf03d2ef7ca23214
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.01s
     Running tests/cgroup_integration.rs (target/debug/deps/cgroup_integration-e2b02b9d93054168)

running 1 test
CGroup limits detected: CGroupLimits { total_memory: 536870912, free_memory: 525611008, free_swap: 4294963200, rss: 9125888 }
test test_cgroup_limits_with_memory_constraint ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

```

- Run `test_cgroup_limits_with_memory_constraint` with `1024M` bound - fails the test

```
❯ systemd-run --user --scope -p MemoryMax=1024M cargo test --test cgroup_integration -- --ignored --nocapture
Running as unit: run-p1081827-i5275362.scope; invocation ID: 79b08c4bbb3c44a888a7e3505ee9939a
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.01s
     Running tests/cgroup_integration.rs (target/debug/deps/cgroup_integration-e2b02b9d93054168)

running 1 test

thread 'test_cgroup_limits_with_memory_constraint' (1081844) panicked at tests/cgroup_integration.rs:17:9:
Expected 512MB limit, got 1073741824 bytes
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test test_cgroup_limits_with_memory_constraint ... FAILED

failures:

failures:
    test_cgroup_limits_with_memory_constraint

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

error: test failed, to rerun pass `--test cgroup_integration`

```
