### PR TITLE
fix(macos): improve accuracy of used memory calculation for macos

### DIFF
--- a/src/unix/apple/system.rs
+++ b/src/unix/apple/system.rs
@@ -197,7 +197,11 @@ impl SystemInner {
                         .saturating_add(u64::from(stat.inactive_count))
                         .saturating_add(u64::from(stat.free_count))
                         .saturating_mul(self.page_size_b);
-                    self.mem_used = self.mem_total.saturating_sub(self.mem_available);
+                    self.mem_used = u64::from(stat.internal_page_count)
+                        .saturating_sub(u64::from(stat.purgeable_count))
+                        .saturating_add(u64::from(stat.wire_count))
+                        .saturating_add(u64::from(stat.compressor_page_count))
+                        .saturating_mul(self.page_size_b);
                     self.mem_free = u64::from(stat.free_count)
                         .saturating_sub(u64::from(stat.speculative_count))
                         .saturating_mul(self.page_size_b);


### PR DESCRIPTION
Related to #1620. I improved `used` memory, did it even better, now it even more accurately. Comparing with native MacOS app `Activity Monitor` ≈4% deviation. 