### PR TITLE
Use dep: syntax to remove accidental Cargo features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ name = "sysinfo"
 [features]
 default = ["component", "disk", "network", "system", "user"]
 component = [
+    "dep:windows",
     "windows/Win32_Foundation",
     "windows/Win32_Security",
     "windows/Win32_System_Com",
@@ -24,22 +25,25 @@ component = [
     "windows/Win32_System_Rpc",
     "windows/Win32_System_Variant",
     "windows/Win32_System_Wmi",
+    "dep:objc2-core-foundation",
     "objc2-core-foundation/CFArray",
     "objc2-core-foundation/CFBase",
     "objc2-core-foundation/CFDictionary",
     "objc2-core-foundation/CFNumber",
     "objc2-core-foundation/CFString",
-    "objc2-io-kit",
+    "dep:objc2-io-kit",
     "objc2-io-kit/hidsystem",
 ]
 disk = [
+    "dep:windows",
     "windows/Win32_Foundation",
     "windows/Win32_Storage_FileSystem",
-    "windows/Win32_Security", # For `windows::Win32::Storage::FileSystem::CreateFileW`.
+    "windows/Win32_Security",                  # For `windows::Win32::Storage::FileSystem::CreateFileW`.
     "windows/Win32_System_IO",
     "windows/Win32_System_Ioctl",
     "windows/Win32_System_SystemServices",
     "windows/Win32_System_WindowsProgramming",
+    "dep:objc2-core-foundation",
     "objc2-core-foundation/CFArray",
     "objc2-core-foundation/CFBase",
     "objc2-core-foundation/CFDictionary",
@@ -47,9 +51,10 @@ disk = [
     "objc2-core-foundation/CFNumber",
     "objc2-core-foundation/CFString",
     "objc2-core-foundation/CFURL",
-    "objc2-io-kit",
+    "dep:objc2-io-kit",
 ]
 system = [
+    "dep:windows",
     "windows/Win32_Foundation",
     "windows/Win32_System_Diagnostics_ToolHelp",
     "windows/Wdk_System_SystemInformation",
@@ -70,19 +75,22 @@ system = [
     "windows/Win32_UI_Shell",
     "dep:ntapi",
     "dep:memchr",
+    "dep:objc2-core-foundation",
     "objc2-core-foundation/CFBase",
     "objc2-core-foundation/CFData",
     "objc2-core-foundation/CFDictionary",
     "objc2-core-foundation/CFString",
-    "objc2-io-kit",
+    "dep:objc2-io-kit",
 ]
 network = [
+    "dep:windows",
     "windows/Win32_Foundation",
     "windows/Win32_NetworkManagement_IpHelper",
     "windows/Win32_NetworkManagement_Ndis",
     "windows/Win32_Networking_WinSock",
 ]
 user = [
+    "dep:windows",
     "windows/Win32_Foundation",
     "windows/Win32_NetworkManagement_NetManagement",
     "windows/Win32_Security",
@@ -96,6 +104,7 @@ multithread = ["dep:rayon"]
 linux-netdevs = []
 linux-tmpfs = []
 debug = ["libc/extra_traits"]
+serde = ["dep:serde"]
 # This feature is used on CI to emulate unknown/unsupported target.
 unknown-ci = []
 
@@ -137,7 +146,7 @@ objc2-io-kit = { version = "0.3.2", optional = true, default-features = false, f
 ] }
 
 [dev-dependencies]
-serde_json = "1.0" # Used in documentation tests.
+serde_json = "1.0"   # Used in documentation tests.
 bstr = "1.9.0"
 tempfile = "3.9"
 itertools = "0.14.0"


### PR DESCRIPTION
I did `cargo add sysinfo` today, and saw:
```
      Adding sysinfo v0.38.4 to dependencies
             Features:
             + component
             + disk
             + network
             + objc2-io-kit
             + system
             + user
             - apple-app-store
             - apple-sandbox
             - c-interface
             - debug
             - linux-netdevs
             - linux-tmpfs
             - multithread
             - objc2-core-foundation
             - serde
             - unknown-ci
             - windows
```

The `objc2-*` and `windows` features are probably not intended, so I've removed them in this PR by using the `dep:` syntax for these dependencies.

This is technically a breaking change, dunno if it warrants a minor release or if you can get away with a patch release.