### PR TITLE
Improve performance of network interfaces refresh by removing one call of `getifaddrs`

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -3,26 +3,34 @@
 use std::collections::HashMap;
 
 use crate::NetworkData;
-use crate::network_helper::{get_interface_address, get_interface_ip_networks};
 
 /// Interface addresses are OS-independent
 pub(crate) fn refresh_networks_addresses(interfaces: &mut HashMap<String, NetworkData>) {
-    let interface_networks = unsafe { get_interface_ip_networks() };
-    for (interface_name, ip_networks) in interface_networks {
-        if let Some(interface) = interfaces.get_mut(&interface_name) {
-            interface.inner.ip_networks = ip_networks.into_iter().collect::<Vec<_>>();
-        }
-    }
-    match unsafe { get_interface_address() } {
-        Ok(ifa_iterator) => {
-            for (name, ifa) in ifa_iterator {
-                if let Some(interface) = interfaces.get_mut(&name) {
-                    interface.inner.mac_addr = ifa;
-                }
+    #[cfg(windows)]
+    {
+        let interface_networks = unsafe { crate::network_helper::get_interface_ip_networks() };
+        for (interface_name, ip_networks) in interface_networks {
+            if let Some(interface) = interfaces.get_mut(&interface_name) {
+                interface.inner.ip_networks = ip_networks.into_iter().collect::<Vec<_>>();
             }
         }
-        Err(_e) => {
-            sysinfo_debug!("refresh_networks_addresses failed: {:?}", _e);
+        match unsafe { crate::network_helper::get_interface_address() } {
+            Ok(ifa_iterator) => {
+                for (name, ifa) in ifa_iterator {
+                    if let Some(interface) = interfaces.get_mut(&name) {
+                        interface.inner.mac_addr = ifa;
+                    }
+                }
+            }
+            Err(_e) => {
+                sysinfo_debug!("refresh_networks_addresses failed: {:?}", _e);
+            }
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        unsafe {
+            crate::network_helper::refresh_network_interfaces(interfaces);
         }
     }
 }

--- a/src/unix/bsd/netbsd/network.rs
+++ b/src/unix/bsd/netbsd/network.rs
@@ -42,6 +42,8 @@ impl NetworksInner {
                 true
             });
         }
+        // FIXME: Try to find a way to call `getifaddrs` only once. Currently it's called in
+        // `Self::refresh_interfaces` and in `refresh_networks_addresses`.
         refresh_networks_addresses(&mut self.interfaces);
     }
 

--- a/src/unix/network_helper.rs
+++ b/src/unix/network_helper.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::ffi::CStr;
-use std::mem::MaybeUninit;
+use std::marker::PhantomData;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::os::raw::c_char;
@@ -14,48 +14,111 @@ use std::{io, mem};
 use crate::{IpNetwork, MacAddr};
 
 /// This iterator yields an interface name and address.
-pub(crate) struct InterfaceAddressIterator {
-    /// Pointer to the current `ifaddrs` struct.
-    ifap: *mut libc::ifaddrs,
+pub(crate) struct InterfaceAddress {
     /// Pointer to the first element in linked list.
     buf: *mut libc::ifaddrs,
 }
 
-impl Iterator for InterfaceAddressIterator {
-    type Item = (String, MacAddr);
-
-    fn next(&mut self) -> Option<Self::Item> {
+impl Drop for InterfaceAddress {
+    fn drop(&mut self) {
+        // Safety: this struct cannot be built with a NULL `buf` field.
         unsafe {
-            while !self.ifap.is_null() {
-                // advance the pointer until a MAC address is found
-                // Safety: `ifap` is already checked as non-null in the loop condition.
-                let ifap = &*self.ifap;
-                self.ifap = ifap.ifa_next;
-
-                if let Some(addr) = parse_interface_address(ifap) {
-                    let ifa_name = ifap.ifa_name;
-                    if ifa_name.is_null() {
-                        continue;
-                    }
-                    // libc::IFNAMSIZ + 6
-                    // This size refers to ./apple/network.rs:75
-                    let mut name = vec![0u8; libc::IFNAMSIZ + 6];
-                    libc::strcpy(name.as_mut_ptr() as _, ifap.ifa_name);
-                    name.set_len(libc::strlen(ifap.ifa_name));
-                    let name = String::from_utf8_unchecked(name);
-
-                    return Some((name, addr));
-                }
-            }
-            None
+            libc::freeifaddrs(self.buf);
         }
     }
 }
 
-impl Drop for InterfaceAddressIterator {
-    fn drop(&mut self) {
+impl InterfaceAddress {
+    pub(crate) fn new() -> Option<Self> {
+        let mut ifap = null_mut();
+        if unsafe { retry_eintr!(libc::getifaddrs(&mut ifap)) } == 0 && !ifap.is_null() {
+            Some(Self { buf: ifap })
+        } else {
+            sysinfo_debug!("`getifaddrs` failed");
+            None
+        }
+    }
+
+    pub(crate) fn iter(&self) -> InterfaceAddressIterator<'_> {
+        InterfaceAddressIterator {
+            ifap: self.buf,
+            helper: InterfaceAddressHelper { ifap: self.buf },
+            _phantom: PhantomData,
+        }
+    }
+}
+
+pub(crate) struct InterfaceAddressIterator<'a> {
+    ifap: *mut libc::ifaddrs,
+    helper: InterfaceAddressHelper,
+    _phantom: PhantomData<&'a ()>,
+}
+
+pub(crate) struct InterfaceAddressHelper {
+    ifap: *mut libc::ifaddrs,
+}
+
+impl InterfaceAddressHelper {
+    pub(crate) fn name(&self) -> Option<String> {
+        // Safety: We assume that addr is valid for the lifetime of this body, and is not mutated.
+        let addr_ref: &libc::ifaddrs = unsafe { &*self.ifap };
+
+        let c_str = addr_ref.ifa_name as *const c_char;
+
+        // Safety: ifa_name is a null terminated interface name
+        let bytes = unsafe { CStr::from_ptr(c_str).to_bytes() };
+
+        // Safety: Interfaces on unix must be valid UTF-8
+        let name = unsafe { from_utf8_unchecked(bytes).to_owned() };
+        // Interfaces names may be formatted as <interface name>:<sub-interface index>
+        if name.contains(':') {
+            name.split(':').next().map(|v| v.to_string())
+        } else {
+            Some(name)
+        }
+    }
+
+    pub(crate) fn ip(&self) -> Option<IpAddr> {
+        // Safety: We assume that addr is valid for the lifetime of this body, and is not mutated.
+        let addr_ref: &libc::ifaddrs = unsafe { &*self.ifap };
+
+        sockaddr_to_network_addr(addr_ref.ifa_addr as *const libc::sockaddr)
+    }
+
+    pub(crate) fn prefix(&self) -> u8 {
+        // Safety: We assume that addr is valid for the lifetime of this body, and is not mutated.
+        let addr_ref: &libc::ifaddrs = unsafe { &*self.ifap };
+        let netmask = sockaddr_to_network_addr(addr_ref.ifa_netmask as *const libc::sockaddr);
+        netmask
+            .and_then(|netmask| ip_mask_to_prefix(netmask).ok())
+            .unwrap_or(0)
+    }
+
+    pub(crate) fn mac_addr(&self) -> Option<MacAddr> {
+        // Safety: We assume that addr is valid for the lifetime of this body, and is not mutated.
+        let addr_ref: &libc::ifaddrs = unsafe { &*self.ifap };
+        unsafe { parse_interface_address(addr_ref) }
+    }
+}
+
+impl<'a> Iterator for InterfaceAddressIterator<'a> {
+    type Item = &'a InterfaceAddressHelper;
+
+    fn next(&mut self) -> Option<Self::Item> {
         unsafe {
-            libc::freeifaddrs(self.buf);
+            // advance the pointer until a MAC address is found
+            if self.ifap.is_null() {
+                return None;
+            }
+            // Safety: `ifap` is already checked as non-null in the above `if` condition.
+            let ifap = self.ifap;
+            self.ifap = (*ifap).ifa_next;
+
+            self.helper.ifap = ifap;
+            // Safety: The returned reference will always match `Self`'s so should not be an issue.
+            Some(std::mem::transmute::<&InterfaceAddressHelper, Self::Item>(
+                &self.helper,
+            ))
         }
     }
 }
@@ -130,73 +193,38 @@ unsafe fn parse_interface_address(ifap: &libc::ifaddrs) -> Option<MacAddr> {
     }
 }
 
-/// Return an iterator on (interface_name, address) pairs
-pub(crate) unsafe fn get_interface_address() -> Result<InterfaceAddressIterator, String> {
-    let mut ifap = null_mut();
-    if unsafe { retry_eintr!(libc::getifaddrs(&mut ifap)) } == 0 && !ifap.is_null() {
-        Ok(InterfaceAddressIterator { ifap, buf: ifap })
-    } else {
-        Err("failed to call getifaddrs()".to_string())
-    }
-}
-
-pub(crate) unsafe fn get_interface_ip_networks() -> HashMap<String, HashSet<IpNetwork>> {
+pub(crate) unsafe fn refresh_network_interfaces(
+    interfaces: &mut HashMap<String, crate::NetworkData>,
+) {
+    let Some(interface_iter) = InterfaceAddress::new() else {
+        return;
+    };
     let mut ifaces: HashMap<String, HashSet<IpNetwork>> = HashMap::new();
-    let mut addrs: MaybeUninit<*mut libc::ifaddrs> = MaybeUninit::uninit();
 
-    // Safety: addrs.as_mut_ptr() is valid, it points to addrs.
-    if unsafe { libc::getifaddrs(addrs.as_mut_ptr()) } != 0 {
-        sysinfo_debug!("Failed to operate libc::getifaddrs as ifaddrs Uninitialized");
-        return ifaces;
-    }
-
-    // Safety: If there was an error, we would have already returned.
-    // Therefore, getifaddrs has initialized `addrs`.
-    let addrs = unsafe { addrs.assume_init() };
-
-    let mut addr = addrs;
-    while !addr.is_null() {
-        // Safety: We assume that addr is valid for the lifetime of this loop
-        // body, and is not mutated.
-        let addr_ref: &libc::ifaddrs = unsafe { &*addr };
-
-        let c_str = addr_ref.ifa_name as *const c_char;
-
-        // Safety: ifa_name is a null terminated interface name
-        let bytes = unsafe { CStr::from_ptr(c_str).to_bytes() };
-
-        // Safety: Interfaces on unix must be valid UTF-8
-        let mut name = unsafe { from_utf8_unchecked(bytes).to_owned() };
-        // Interfaces names may be formatted as <interface name>:<sub-interface index>
-        if name.contains(':') {
-            if let Some(interface_name) = name.split(':').next() {
-                name = interface_name.to_string()
-            } else {
-                // The sub-interface is malformed, skipping to the next addr
-                addr = addr_ref.ifa_next;
-                continue;
-            }
-        }
-
-        let ip = sockaddr_to_network_addr(addr_ref.ifa_addr as *const libc::sockaddr);
-        let netmask = sockaddr_to_network_addr(addr_ref.ifa_netmask as *const libc::sockaddr);
-        let prefix = netmask
-            .and_then(|netmask| ip_mask_to_prefix(netmask).ok())
-            .unwrap_or(0);
-        if let Some(ip) = ip {
+    for entry in interface_iter.iter() {
+        if let Some(interface_name) = entry.name()
+            // We only do work if the existing interfaces contain this one.
+            && let Some(interface) = interfaces.get_mut(&interface_name)
+            && let Some(ip) = entry.ip()
+        {
+            let prefix = entry.prefix();
             ifaces
-                .entry(name)
+                .entry(interface_name)
                 .and_modify(|values| {
                     values.insert(IpNetwork { addr: ip, prefix });
                 })
                 .or_insert(HashSet::from([IpNetwork { addr: ip, prefix }]));
+            if let Some(mac_addr) = entry.mac_addr() {
+                interface.inner.mac_addr = mac_addr;
+            }
         }
-        addr = addr_ref.ifa_next;
     }
 
-    // Safety: addrs has been previously allocated through getifaddrs
-    unsafe { libc::freeifaddrs(addrs) };
-    ifaces
+    for (interface_name, ip_networks) in ifaces {
+        if let Some(interface) = interfaces.get_mut(&interface_name) {
+            interface.inner.ip_networks = ip_networks.into_iter().collect::<Vec<_>>();
+        }
+    }
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -1124,6 +1124,9 @@ fn test_tasks() {
             ProcessRefreshKind::nothing(),
         );
 
+        // Try to remove flakyness a bit.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
         let mut system_new = System::new_with_specifics(RefreshKind::nothing());
         system_new.refresh_processes_specifics(
             ProcessesToUpdate::All,


### PR DESCRIPTION
Fixes https://github.com/GuillaumeGomez/sysinfo/issues/1598.

Tested on linux:

Before this PR:

```
running 1 test
test bench_refresh_networks        ... bench:     394,685.12 ns/iter (+/- 3,319.36)
```

With this PR:

```
running 1 test
test bench_refresh_networks        ... bench:     357,574.94 ns/iter (+/- 3,057.69)
```

Not as much of an improvement as I was hoping but still nice to have. Also, it improves the situation on NetBSD where instead of having 3 calls to `getifaddrs`, we now have 2. But could be improved further, although not really a priority.