### PR TITLE
linux: fix network stats truncation when buffer shrinks after read_str

### DIFF
--- a/src/unix/linux/network.rs
+++ b/src/unix/linux/network.rs
@@ -20,9 +20,7 @@ macro_rules! old_and_new {
     }};
 }
 
-#[allow(clippy::ptr_arg)]
-fn read<P: AsRef<Path>>(parent: P, path: &str, data: &mut Vec<u8>) -> u64 {
-    data.resize(30, 0);
+fn read<P: AsRef<Path>>(parent: P, path: &str, data: &mut [u8]) -> u64 {
     if let Ok(mut f) = File::open(parent.as_ref().join(path))
         && let Ok(size) = f.read(data)
     {
@@ -39,6 +37,10 @@ fn read<P: AsRef<Path>>(parent: P, path: &str, data: &mut Vec<u8>) -> u64 {
     0
 }
 
+// `read_str` clears and refills the Vec, so its length becomes the length of
+// the string just read. For example, reading "up\n" leaves the Vec length at 3.
+// Keep this buffer separate from numeric read buffers, otherwise counters could
+// be truncated to a few bytes.
 #[allow(clippy::ptr_arg)]
 fn read_str<'data, P: AsRef<Path>>(parent: P, path: &str, data: &'data mut Vec<u8>) -> &'data [u8] {
     data.clear();
@@ -73,7 +75,8 @@ fn refresh_networks_list_from_sysfs(
     sysfs_net: &Path,
 ) {
     if let Ok(dir) = std::fs::read_dir(sysfs_net) {
-        let mut data = vec![0; 30];
+        let mut num_buf = [0u8; 32];
+        let mut str_buf = Vec::with_capacity(32);
 
         for stats in interfaces.values_mut() {
             stats.inner.updated = false;
@@ -86,18 +89,18 @@ fn refresh_networks_list_from_sysfs(
                 Ok(entry) => entry,
                 Err(_) => continue,
             };
-            let rx_bytes = read(parent, "rx_bytes", &mut data);
-            let tx_bytes = read(parent, "tx_bytes", &mut data);
-            let rx_packets = read(parent, "rx_packets", &mut data);
-            let tx_packets = read(parent, "tx_packets", &mut data);
-            let rx_errors = read(parent, "rx_errors", &mut data);
-            let tx_errors = read(parent, "tx_errors", &mut data);
-            // let rx_compressed = read(parent, "rx_compressed", &mut data);
-            // let tx_compressed = read(parent, "tx_compressed", &mut data);
-            let mtu = read(entry_path, "mtu", &mut data);
+            let rx_bytes = read(parent, "rx_bytes", &mut num_buf);
+            let tx_bytes = read(parent, "tx_bytes", &mut num_buf);
+            let rx_packets = read(parent, "rx_packets", &mut num_buf);
+            let tx_packets = read(parent, "tx_packets", &mut num_buf);
+            let rx_errors = read(parent, "rx_errors", &mut num_buf);
+            let tx_errors = read(parent, "tx_errors", &mut num_buf);
+            // let rx_compressed = read(parent, "rx_compressed", &mut num_buf);
+            // let tx_compressed = read(parent, "tx_compressed", &mut num_buf);
+            let mtu = read(entry_path, "mtu", &mut num_buf);
 
             let operational_state = InterfaceOperationalState::from_data(
-                read_str(entry_path, "operstate", &mut data).trim_ascii(),
+                read_str(entry_path, "operstate", &mut str_buf).trim_ascii(),
             );
 
             match interfaces.entry(entry) {

--- a/src/unix/linux/network.rs
+++ b/src/unix/linux/network.rs
@@ -22,6 +22,7 @@ macro_rules! old_and_new {
 
 #[allow(clippy::ptr_arg)]
 fn read<P: AsRef<Path>>(parent: P, path: &str, data: &mut Vec<u8>) -> u64 {
+    data.resize(30, 0);
     if let Ok(mut f) = File::open(parent.as_ref().join(path))
         && let Ok(size) = f.read(data)
     {
@@ -337,5 +338,57 @@ mod test {
 
         refresh_networks_list_from_sysfs(&mut interfaces, true, sys_net_dir.path());
         assert_eq!(interfaces.keys().collect::<Vec<_>>(), ["itf2"]);
+    }
+
+    #[test]
+    fn refresh_networks_list_with_multiple_interfaces() {
+        let dir = tempfile::tempdir().expect("failed to create temporary directory");
+
+        for (name, rx) in [
+            ("if_a", "100"),
+            ("if_b", "1234567890123"),
+            ("if_c", "9876543210987"),
+        ] {
+            let stats = dir.path().join(name).join("statistics");
+
+            fs::create_dir_all(&stats).expect("failed to create statistics dir");
+
+            for f in &[
+                "rx_bytes",
+                "tx_bytes",
+                "rx_packets",
+                "tx_packets",
+                "rx_errors",
+                "tx_errors",
+            ] {
+                fs::write(stats.join(f), rx).expect("failed to write stats");
+            }
+
+            fs::write(dir.path().join(name).join("mtu"), "1500")
+                .expect("failed to write mtu");
+
+            fs::write(dir.path().join(name).join("operstate"), "up\n")
+                .expect("failed to write operstate");
+        }
+
+        let mut interfaces = HashMap::new();
+
+        refresh_networks_list_from_sysfs(&mut interfaces, false, dir.path());
+        refresh_networks_list_from_sysfs(&mut interfaces, false, dir.path());
+
+        assert_eq!(interfaces.get("if_a").unwrap().inner.rx_bytes, 100);
+        assert_eq!(
+            interfaces.get("if_b").unwrap().inner.rx_bytes,
+            1_234_567_890_123
+        );
+        assert_eq!(
+            interfaces.get("if_c").unwrap().inner.rx_bytes,
+            9_876_543_210_987
+        );
+
+        for name in ["if_a", "if_b", "if_c"] {
+            let interface = interfaces.get(name).unwrap();
+            assert_eq!(interface.inner.mtu, 1500, "{name}: mtu");
+        }
     }
 }

--- a/src/unix/linux/network.rs
+++ b/src/unix/linux/network.rs
@@ -364,8 +364,7 @@ mod test {
                 fs::write(stats.join(f), rx).expect("failed to write stats");
             }
 
-            fs::write(dir.path().join(name).join("mtu"), "1500")
-                .expect("failed to write mtu");
+            fs::write(dir.path().join(name).join("mtu"), "1500").expect("failed to write mtu");
 
             fs::write(dir.path().join(name).join("operstate"), "up\n")
                 .expect("failed to write operstate");

--- a/src/unix/linux/network.rs
+++ b/src/unix/linux/network.rs
@@ -75,7 +75,8 @@ fn refresh_networks_list_from_sysfs(
     sysfs_net: &Path,
 ) {
     if let Ok(dir) = std::fs::read_dir(sysfs_net) {
-        let mut num_buf = [0u8; 32];
+        // ilog10 gives number of digits minus one; the extra +1 is for the newline character.
+        let mut num_buf = [0u8; u64::MAX.ilog(10) as usize + 2];
         let mut str_buf = Vec::with_capacity(32);
 
         for stats in interfaces.values_mut() {
@@ -351,6 +352,7 @@ mod test {
             ("if_a", "100"),
             ("if_b", "1234567890123"),
             ("if_c", "9876543210987"),
+            ("if_d", "18446744073709551615"),
         ] {
             let stats = dir.path().join(name).join("statistics");
 
@@ -387,8 +389,9 @@ mod test {
             interfaces.get("if_c").unwrap().inner.rx_bytes,
             9_876_543_210_987
         );
+        assert_eq!(interfaces.get("if_d").unwrap().inner.rx_bytes, u64::MAX);
 
-        for name in ["if_a", "if_b", "if_c"] {
+        for name in ["if_a", "if_b", "if_c", "if_d"] {
             let interface = interfaces.get(name).unwrap();
             assert_eq!(interface.inner.mtu, 1500, "{name}: mtu");
         }


### PR DESCRIPTION
`read_str` uses `read_to_end` which shrinks the shared Vec length to the size of the file content. Since `operstate` is read last per interface, subsequent interfaces read stats into a truncated buffer, silently cutting large numeric values.

Fix: resize the buffer back to 30 at the start of `read`.

Fixes #1658