### PR TITLE
Stub `get_users` on iOS via `app_store::users`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,11 @@ objc2-io-kit = { version = "0.3.2", optional = true, default-features = false, f
     "std",
     "libc",
 ] }
+
+# OpenDirectory framework is macOS-only; binding it on iOS triggers a linker
+# error (`framework 'OpenDirectory' not found`) because the framework does not
+# ship on iOS.
+[target.'cfg(target_os = "macos")'.dependencies]
 objc2-open-directory = { version = "0.3.2", optional = true, default-features = false, features = [
     "objc2-core-foundation",
     "std",

--- a/src/unix/apple/app_store/mod.rs
+++ b/src/unix/apple/app_store/mod.rs
@@ -4,3 +4,5 @@
 pub mod component;
 #[cfg(feature = "system")]
 pub mod process;
+#[cfg(all(feature = "user", target_os = "ios"))]
+pub mod users;

--- a/src/unix/apple/app_store/users.rs
+++ b/src/unix/apple/app_store/users.rs
@@ -1,0 +1,25 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::{Gid, Group, Uid, User};
+
+pub(crate) struct UserInner;
+
+impl UserInner {
+    pub(crate) fn id(&self) -> &Uid {
+        &Uid(0)
+    }
+
+    pub(crate) fn group_id(&self) -> Gid {
+        Gid(0)
+    }
+
+    pub(crate) fn name(&self) -> &str {
+        ""
+    }
+
+    pub(crate) fn groups(&self) -> Vec<Group> {
+        Vec::new()
+    }
+}
+
+pub(crate) fn get_users(_: &mut Vec<User>) {}

--- a/src/unix/apple/mod.rs
+++ b/src/unix/apple/mod.rs
@@ -61,10 +61,19 @@ cfg_select! {
 }
 cfg_select! {
     feature = "user" => {
+        // `users.rs` binds OpenDirectory, which is macOS-only. On iOS the
+        // framework does not exist, so we reuse the `app_store` stub the
+        // same way `component` and `process` do.
+        #[cfg(target_os = "macos")]
         pub mod users;
+        #[cfg(target_os = "ios")]
+        pub use crate::sys::app_store::users;
 
         pub(crate) use crate::unix::groups::get_groups;
+        #[cfg(target_os = "macos")]
         pub(crate) use crate::unix::users::UserInner;
+        #[cfg(target_os = "ios")]
+        pub(crate) use self::users::UserInner;
         pub(crate) use self::users::get_users;
     }
     _ => {}

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -55,6 +55,9 @@ pub(crate) mod network_helper;
 
 cfg_select! {
     feature = "user" => {
+        // On iOS the apple module provides its own `UserInner`/`get_users`
+        // stubs, so `unix::users` is unused there.
+        #[cfg(not(target_os = "ios"))]
         pub(crate) mod users;
         pub(crate) mod groups;
     }


### PR DESCRIPTION
`objc2-open-directory` is pulled in on all Apple targets by the `user` feature, but `OpenDirectory.framework` only ships on macOS, so downstream binaries fail to link for iOS with `ld: framework 'OpenDirectory' not found`. Move the dependency into a `cfg(target_os = "macos")` section, gate `apple/users.rs` to macOS, and route iOS through a new `app_store::users` stub mirroring how `component` and `process` are handled for locked-down Apple targets. Gate `unix::users` out on iOS so the now-unused helpers there don't trip `-Dwarnings`.