### PR TITLE
Unix: Fix retrieval of `Network::mac_addr`

### DIFF
--- a/src/unix/network_helper.rs
+++ b/src/unix/network_helper.rs
@@ -105,11 +105,11 @@ impl<'a> Iterator for InterfaceAddressIterator<'a> {
     type Item = &'a InterfaceAddressHelper;
 
     fn next(&mut self) -> Option<Self::Item> {
+        // Advance the pointer until a MAC address is found
+        if self.ifap.is_null() {
+            return None;
+        }
         unsafe {
-            // advance the pointer until a MAC address is found
-            if self.ifap.is_null() {
-                return None;
-            }
             // Safety: `ifap` is already checked as non-null in the above `if` condition.
             let ifap = self.ifap;
             self.ifap = (*ifap).ifa_next;
@@ -205,17 +205,18 @@ pub(crate) unsafe fn refresh_network_interfaces(
         if let Some(interface_name) = entry.name()
             // We only do work if the existing interfaces contain this one.
             && let Some(interface) = interfaces.get_mut(&interface_name)
-            && let Some(ip) = entry.ip()
         {
-            let prefix = entry.prefix();
-            ifaces
-                .entry(interface_name)
-                .and_modify(|values| {
-                    values.insert(IpNetwork { addr: ip, prefix });
-                })
-                .or_insert(HashSet::from([IpNetwork { addr: ip, prefix }]));
             if let Some(mac_addr) = entry.mac_addr() {
                 interface.inner.mac_addr = mac_addr;
+            }
+            if let Some(ip) = entry.ip() {
+                let prefix = entry.prefix();
+                ifaces
+                    .entry(interface_name)
+                    .and_modify(|values| {
+                        values.insert(IpNetwork { addr: ip, prefix });
+                    })
+                    .or_insert(HashSet::from([IpNetwork { addr: ip, prefix }]));
             }
         }
     }

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -2,15 +2,30 @@
 
 // This test is used to ensure that the networks are not loaded by default.
 
-#[cfg(feature = "network")]
+#![cfg(feature = "network")]
+
+use sysinfo::Networks;
+
 #[test]
 fn test_networks() {
-    use sysinfo::Networks;
-
-    if sysinfo::IS_SUPPORTED_SYSTEM {
-        let mut n = Networks::new();
-        assert_eq!(n.iter().count(), 0);
-        n.refresh(false);
-        assert!(n.iter().count() > 0);
+    if !sysinfo::IS_SUPPORTED_SYSTEM {
+        return;
     }
+    let mut networks = Networks::new();
+    assert_eq!(networks.list().len(), 0);
+    networks.refresh(false);
+    assert_ne!(networks.list().len(), 0);
+}
+
+#[test]
+fn test_mac_addr() {
+    if !sysinfo::IS_SUPPORTED_SYSTEM {
+        return;
+    }
+    let mut networks = Networks::new();
+    networks.refresh(false);
+    assert_ne!(networks.list().len(), 0);
+    networks
+        .iter()
+        .any(|(_, n)| !n.mac_address().is_unspecified());
 }


### PR DESCRIPTION
Fixes #1670.

Problem is that one `ifap` doesn't provide all information for one network interface, but rather through multiple `ifap`.