### PR TITLE
Rename Cpu::cpu_usage into Cpu::usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ let mut sys = System::new();
 loop {
     sys.refresh_cpu_usage(); // Refreshing CPU usage.
     for cpu in sys.cpus() {
-        print!("{}% ", cpu.cpu_usage());
+        print!("{}% ", cpu.usage());
     }
     // Sleeping to let time for the system to run for long
     // enough to have useful information.

--- a/src/c_interface.rs
+++ b/src/c_interface.rs
@@ -337,7 +337,7 @@ pub extern "C" fn sysinfo_cpus_usage(
                     libc::malloc(::std::mem::size_of::<c_float>() * cpus.len()) as *mut c_float;
             }
             for (pos, cpu) in cpus.iter().skip(1).enumerate() {
-                (*(*procs).offset(pos as isize)) = cpu.cpu_usage();
+                (*(*procs).offset(pos as isize)) = cpu.usage();
             }
             *length = cpus.len() as c_uint - 1;
         }

--- a/src/common/system.rs
+++ b/src/common/system.rs
@@ -177,7 +177,7 @@ impl System {
     /// to get accurate value as it uses previous results to compute the next value.
     ///
     /// Calling this method is the same as calling
-    /// `system.refresh_cpu_specifics(CpuRefreshKind::nothing().with_cpu_usage())`.
+    /// `system.refresh_cpu_specifics(CpuRefreshKind::nothing().with_usage())`.
     ///
     /// ```no_run
     /// use sysinfo::System;
@@ -191,7 +191,7 @@ impl System {
     ///
     /// [`MINIMUM_CPU_UPDATE_INTERVAL`]: crate::MINIMUM_CPU_UPDATE_INTERVAL
     pub fn refresh_cpu_usage(&mut self) {
-        self.refresh_cpu_specifics(CpuRefreshKind::nothing().with_cpu_usage())
+        self.refresh_cpu_specifics(CpuRefreshKind::nothing().with_usage())
     }
 
     /// Refreshes CPUs frequency information.
@@ -518,7 +518,7 @@ impl System {
     /// // Refresh CPUs again to get actual value.
     /// s.refresh_cpu_usage();
     /// for cpu in s.cpus() {
-    ///     println!("{}%", cpu.cpu_usage());
+    ///     println!("{}%", cpu.usage());
     /// }
     /// ```
     pub fn cpus(&self) -> &[Cpu] {
@@ -2569,7 +2569,7 @@ It will retrieve the following information:
 /// [`Cpu`]: crate::Cpu
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct CpuRefreshKind {
-    cpu_usage: bool,
+    usage: bool,
     frequency: bool,
 }
 
@@ -2582,7 +2582,7 @@ impl CpuRefreshKind {
     /// let r = CpuRefreshKind::nothing();
     ///
     /// assert_eq!(r.frequency(), false);
-    /// assert_eq!(r.cpu_usage(), false);
+    /// assert_eq!(r.usage(), false);
     /// ```
     pub fn nothing() -> Self {
         Self::default()
@@ -2596,16 +2596,16 @@ impl CpuRefreshKind {
     /// let r = CpuRefreshKind::everything();
     ///
     /// assert_eq!(r.frequency(), true);
-    /// assert_eq!(r.cpu_usage(), true);
+    /// assert_eq!(r.usage(), true);
     /// ```
     pub fn everything() -> Self {
         Self {
-            cpu_usage: true,
+            usage: true,
             frequency: true,
         }
     }
 
-    impl_get_set!(CpuRefreshKind, cpu_usage, with_cpu_usage, without_cpu_usage);
+    impl_get_set!(CpuRefreshKind, usage, with_usage, without_usage);
     impl_get_set!(CpuRefreshKind, frequency, with_frequency, without_frequency);
 }
 
@@ -2811,7 +2811,7 @@ pub fn get_current_pid() -> Result<Pid, &'static str> {
 /// s.refresh_cpu_all();
 ///
 /// for cpu in s.cpus() {
-///     println!("{}%", cpu.cpu_usage());
+///     println!("{}%", cpu.usage());
 /// }
 /// ```
 pub struct Cpu {
@@ -2837,10 +2837,10 @@ impl Cpu {
     /// s.refresh_cpu_all();
     ///
     /// for cpu in s.cpus() {
-    ///     println!("{}%", cpu.cpu_usage());
+    ///     println!("{}%", cpu.usage());
     /// }
     /// ```
-    pub fn cpu_usage(&self) -> f32 {
+    pub fn usage(&self) -> f32 {
         self.inner.cpu_usage()
     }
 
@@ -3058,7 +3058,7 @@ mod test {
             s.refresh_cpu_usage();
             // Wait a bit to update CPU usage values
             std::thread::sleep(MINIMUM_CPU_UPDATE_INTERVAL);
-            if s.cpus().iter().any(|c| c.cpu_usage() > 0.0) {
+            if s.cpus().iter().any(|c| c.usage() > 0.0) {
                 // All good!
                 return;
             }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -5,7 +5,7 @@ impl std::fmt::Debug for crate::Cpu {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Cpu")
             .field("name", &self.name())
-            .field("CPU usage", &self.cpu_usage())
+            .field("CPU usage", &self.usage())
             .field("frequency", &self.frequency())
             .field("vendor ID", &self.vendor_id())
             .field("brand", &self.brand())

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -114,7 +114,7 @@ impl Serialize for crate::Cpu {
         // `5` corresponds to the number of fields.
         let mut state = serializer.serialize_struct("Cpu", 5)?;
 
-        state.serialize_field("cpu_usage", &self.cpu_usage())?;
+        state.serialize_field("usage", &self.usage())?;
         state.serialize_field("name", &self.name())?;
         state.serialize_field("vendor_id", &self.vendor_id())?;
         state.serialize_field("brand", &self.brand())?;

--- a/src/unix/apple/cpu.rs
+++ b/src/unix/apple/cpu.rs
@@ -48,7 +48,7 @@ impl CpusWrapper {
             }
             self.got_cpu_frequency = true;
         }
-        if refresh_kind.cpu_usage() && need_cpu_usage_update {
+        if refresh_kind.usage() && need_cpu_usage_update {
             self.last_update = Some(Instant::now());
             update_cpu_usage(port, &mut self.global_cpu, |proc_data, cpu_info| {
                 let mut percentage = 0f32;
@@ -353,10 +353,10 @@ pub(crate) fn init_cpus(
                     brand.clone(),
                 ),
             };
-            if refresh_kind.cpu_usage() {
+            if refresh_kind.usage() {
                 let cpu_usage = compute_usage_of_cpu(&cpu, cpu_info, offset);
                 cpu.inner.set_cpu_usage(cpu_usage);
-                percentage += cpu.cpu_usage();
+                percentage += cpu.usage();
             }
             cpus.push(cpu);
 
@@ -478,7 +478,7 @@ mod test {
         let stdout = String::from_utf8(child.stdout).expect("Not valid UTF8");
 
         let sys = System::new_with_specifics(
-            crate::RefreshKind::nothing().with_cpu(CpuRefreshKind::nothing().with_cpu_usage()),
+            crate::RefreshKind::nothing().with_cpu(CpuRefreshKind::nothing().with_usage()),
         );
         let cpus = sys.cpus();
         assert!(!cpus.is_empty(), "no CPU found");

--- a/src/unix/bsd/freebsd/cpu.rs
+++ b/src/unix/bsd/freebsd/cpu.rs
@@ -68,7 +68,7 @@ impl CpusWrapper {
             }
             self.got_cpu_frequency = true;
         }
-        if refresh_kind.cpu_usage() {
+        if refresh_kind.usage() {
             self.get_cpu_usage();
         }
     }

--- a/src/unix/bsd/netbsd/cpu.rs
+++ b/src/unix/bsd/netbsd/cpu.rs
@@ -64,7 +64,7 @@ impl CpusWrapper {
             }
             self.got_cpu_frequency = true;
         }
-        if refresh_kind.cpu_usage() {
+        if refresh_kind.usage() {
             self.get_cpu_usage();
         }
     }

--- a/src/unix/linux/cpu.rs
+++ b/src/unix/linux/cpu.rs
@@ -71,7 +71,7 @@ impl CpusWrapper {
             let mut i: usize = 0;
             let mut it = buf.split(b'\n');
 
-            if first || refresh_kind.cpu_usage() {
+            if first || refresh_kind.usage() {
                 if let Some(Ok(line)) = it.next() {
                     if line.len() < 4 || &line[..4] != b"cpu " {
                         return;

--- a/src/unix/linux/system.rs
+++ b/src/unix/linux/system.rs
@@ -192,7 +192,7 @@ impl SystemInner {
             return;
         }
         self.cpus
-            .refresh_if_needed(true, CpuRefreshKind::nothing().with_cpu_usage());
+            .refresh_if_needed(true, CpuRefreshKind::nothing().with_usage());
 
         if self.cpus.is_empty() {
             sysinfo_debug!("cannot compute processes CPU usage: no CPU found...");

--- a/src/windows/system.rs
+++ b/src/windows/system.rs
@@ -118,7 +118,7 @@ impl SystemInner {
 
         // The PDH query is used to compute cpu_usage, and opening it the
         // first time is slow. Skip it when usage isn't requested.
-        if !refresh_kind.cpu_usage() {
+        if !refresh_kind.usage() {
             return;
         }
 

--- a/tests/cpu.rs
+++ b/tests/cpu.rs
@@ -48,5 +48,5 @@ fn test_too_rapid_cpu_refresh() {
     s.refresh_cpu_all();
     s.refresh_cpu_all();
 
-    assert!(s.cpus().iter().any(|c| !c.cpu_usage().is_nan()));
+    assert!(s.cpus().iter().any(|c| !c.usage().is_nan()));
 }


### PR DESCRIPTION
Fixes #1673.

Renames `Cpu::cpu_usage` to `Cpu::usage`, and updates the matching
`CpuRefreshKind` methods to `usage` / `with_usage` / `without_usage`.

Also updates the serde field name to match.