### PR TITLE
Remove usage of proc_pidinfo on iOS

### DIFF
--- a/src/unix/apple/app_store/process.rs
+++ b/src/unix/apple/app_store/process.rs
@@ -114,4 +114,8 @@ impl ProcessInner {
     pub(crate) fn exists(&self) -> bool {
         false
     }
+
+    pub(crate) fn open_files(&self) -> Option<usize> {
+        None
+    }
 }

--- a/src/unix/apple/macos/process.rs
+++ b/src/unix/apple/macos/process.rs
@@ -243,6 +243,25 @@ impl ProcessInner {
     pub(crate) fn exists(&self) -> bool {
         self.exists
     }
+
+    pub(crate) fn open_files(&self) -> Option<usize> {
+        let buffer_size_bytes = unsafe {
+            libc::proc_pidinfo(
+                self.pid.0,
+                libc::PROC_PIDLISTFDS,
+                0,
+                std::ptr::null_mut(),
+                0,
+            )
+        };
+
+        if buffer_size_bytes < 0 {
+            sysinfo_debug!("proc_pidinfo failed");
+            None
+        } else {
+            Some(buffer_size_bytes as usize / std::mem::size_of::<libc::proc_fdinfo>())
+        }
+    }
 }
 
 #[allow(deprecated)] // Because of libc::mach_absolute_time.

--- a/src/unix/apple/process.rs
+++ b/src/unix/apple/process.rs
@@ -77,25 +77,6 @@ impl From<i32> for ThreadStatus {
 }
 
 impl ProcessInner {
-    pub(crate) fn open_files(&self) -> Option<usize> {
-        let buffer_size_bytes = unsafe {
-            libc::proc_pidinfo(
-                self.pid().0,
-                libc::PROC_PIDLISTFDS,
-                0,
-                std::ptr::null_mut(),
-                0,
-            )
-        };
-
-        if buffer_size_bytes < 0 {
-            sysinfo_debug!("proc_pidinfo failed");
-            None
-        } else {
-            Some(buffer_size_bytes as usize / std::mem::size_of::<libc::proc_fdinfo>())
-        }
-    }
-
     // FIXME: Should query the value, because it can be changed with setrlimit and other means.
     // For now, cannot find where to get this information sadly...
     pub(crate) fn open_files_limit(&self) -> Option<usize> {


### PR DESCRIPTION
This is not present in the headers in the iOS SDK, so using it [is disallowed by Apple's App Store review guidelines](https://developer.apple.com/app-store/review/guidelines/#software-requirements:~:text=Apps%20may%20only%20use%20public%20APIs).

(And yes, they do tend to read that sentence to the letter, even if they may sometimes grant apps exceptions to it).

I have also filed FB23247918 to ask them for clarification, because the symbols _are_ marked `__OSX_AVAILABLE_STARTING(__MAC_10_5, __IPHONE_2_0)` in the macOS SDK's header, though I don't think we should block on this, there are other places in `sysinfo` where we use `proc_pidinfo` that could benefit from being usable on iOS but that can be re-introduced later once we know more.

---

This should make `sysinfo` compile on iOS with https://github.com/rust-lang/libc/pull/5158.

I did also take a look, it seems that https://github.com/GuillaumeGomez/sysinfo/pull/424 removed usage of `proc_pidinfo` in the past, so doing this for `PROC_PIDLISTFDS` as well is consistent with that.