### PR TITLE
fix: inaccurate open_files() implementation (#1681)

### DIFF
--- a/src/unix/apple/macos/process.rs
+++ b/src/unix/apple/macos/process.rs
@@ -257,7 +257,7 @@ impl ProcessInner {
 
         if buffer_size_bytes < 0 {
             sysinfo_debug!("proc_pidinfo failed");
-            return None
+            return None;
         }
 
         let mut buffer = vec![0u8; buffer_size_bytes as usize];
@@ -268,7 +268,7 @@ impl ProcessInner {
                 libc::PROC_PIDLISTFDS,
                 0,
                 buffer.as_mut_ptr() as *mut std::ffi::c_void,
-                buffer_size_bytes
+                buffer_size_bytes,
             )
         };
 

--- a/src/unix/apple/macos/process.rs
+++ b/src/unix/apple/macos/process.rs
@@ -257,10 +257,22 @@ impl ProcessInner {
 
         if buffer_size_bytes < 0 {
             sysinfo_debug!("proc_pidinfo failed");
-            None
-        } else {
-            Some(buffer_size_bytes as usize / std::mem::size_of::<libc::proc_fdinfo>())
+            return None
         }
+
+        let mut buffer = vec![0u8; buffer_size_bytes as usize];
+
+        let buffer_filled_bytes = unsafe {
+            libc::proc_pidinfo(
+                self.pid.0,
+                libc::PROC_PIDLISTFDS,
+                0,
+                buffer.as_mut_ptr() as *mut std::ffi::c_void,
+                buffer_size_bytes
+            )
+        };
+
+        Some(buffer_filled_bytes as usize / std::mem::size_of::<libc::proc_fdinfo>())
     }
 }
 


### PR DESCRIPTION
Fix for #1681 where `open_files()` always return a fixed value.

This implementation uses a two pass approach on `proc_pidinfo`.
However, I am concerned whether taking the size from the first call as the buffer size for the second call may lead to race conditions. If the process opens significantly more files during the interval between the first and the second call, the needed buffer size may increase. 