### PR TITLE
Added negative value handling in open_files()

### DIFF
--- a/src/unix/apple/macos/process.rs
+++ b/src/unix/apple/macos/process.rs
@@ -272,6 +272,11 @@ impl ProcessInner {
             )
         };
 
+        if buffer_filled_bytes < 0 {
+            sysinfo_debug!("proc_pidinfo failed");
+            return None;
+        }
+
         Some(buffer_filled_bytes as usize / std::mem::size_of::<libc::proc_fdinfo>())
     }
 }


### PR DESCRIPTION
Fixes possible failure introduced in #1682 .

I overlooked the possibility of `proc_pidinfo()` returning negative values indicating failure on the second call. This is a fix for the issue. 