### PR TITLE
Migrate `Users`, `Groups` and `Networks` to new `Error` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,16 +80,17 @@ for disk in &disks {
 }
 
 // Network interfaces name, total data received and total data transmitted:
-let networks = Networks::new_with_refreshed_list();
-println!("=> networks:");
-for (interface_name, data) in &networks {
-    println!(
-        "{interface_name}: {} B (down) / {} B (up)",
-        data.total_received(),
-        data.total_transmitted(),
-    );
-    // If you want the amount of data received/transmitted since last call
-    // to `Networks::refresh`, use `received`/`transmitted`.
+if let Ok(networks) = Networks::new_with_refreshed_list() {
+    println!("=> networks:");
+    for (interface_name, data) in &networks {
+        println!(
+            "{interface_name}: {} B (down) / {} B (up)",
+            data.total_received(),
+            data.total_transmitted(),
+        );
+        // If you want the amount of data received/transmitted since last call
+        // to `Networks::refresh`, use `received`/`transmitted`.
+    }
 }
 
 // Components temperature:

--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -92,7 +92,9 @@ fn bench_refresh_disks(b: &mut test::Bencher) {
 #[cfg(feature = "network")]
 #[bench]
 fn bench_refresh_networks(b: &mut test::Bencher) {
-    let mut n = sysinfo::Networks::new_with_refreshed_list();
+    let Ok(mut n) = sysinfo::Networks::new_with_refreshed_list() else {
+        return;
+    };
 
     b.iter(move || {
         n.refresh(true);
@@ -136,7 +138,9 @@ fn bench_refresh_components(b: &mut test::Bencher) {
 
 #[bench]
 fn bench_refresh_users_list(b: &mut test::Bencher) {
-    let mut users = sysinfo::Users::new_with_refreshed_list();
+    let Ok(mut users) = sysinfo::Users::new_with_refreshed_list() else {
+        return;
+    };
 
     b.iter(move || {
         users.refresh();

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -75,7 +75,7 @@ fn interpret_input(
     input: &str,
     sys: Result<&mut System, &mut sysinfo::Error>,
     gpus: Result<&mut Gpus, &mut sysinfo::Error>,
-    networks: &mut Networks,
+    networks: Result<&mut Networks, &mut sysinfo::Error>,
     disks: &mut Disks,
     components: &mut Components,
     users: Result<&mut Users, &mut sysinfo::Error>,
@@ -97,11 +97,16 @@ fn interpret_input(
                 println!("Users information cannot be retrieved: {error}");
             }
         },
-        "refresh_networks" => {
-            println!("Refreshing network list...");
-            networks.refresh(true);
-            println!("Done.");
-        }
+        "refresh_networks" => match networks {
+            Ok(networks) => {
+                println!("Refreshing network list...");
+                networks.refresh(true);
+                println!("Done.");
+            }
+            Err(error) => {
+                println!("Networks information cannot be retrieved: {error}");
+            }
+        },
         "refresh_components" => {
             println!("Refreshing component list...");
             components.refresh(true);
@@ -279,24 +284,29 @@ fn interpret_input(
                 println!("{component:?}");
             }
         }
-        "network" => {
-            for (interface_name, data) in networks.iter() {
-                println!(
-                    "\
-{interface_name}:
-  operational state {}
-  ether {}
-  input data  (new / total): {} / {} B
-  output data (new / total): {} / {} B",
-                    data.operational_state(),
-                    data.mac_address(),
-                    data.received(),
-                    data.total_received(),
-                    data.transmitted(),
-                    data.total_transmitted(),
-                );
+        "network" => match networks {
+            Ok(networks) => {
+                for (interface_name, data) in networks.iter() {
+                    println!(
+                        "\
+    {interface_name}:
+      operational state {}
+      ether {}
+      input data  (new / total): {} / {} B
+      output data (new / total): {} / {} B",
+                        data.operational_state(),
+                        data.mac_address(),
+                        data.received(),
+                        data.total_received(),
+                        data.transmitted(),
+                        data.total_transmitted(),
+                    );
+                }
             }
-        }
+            Err(error) => {
+                println!("Networks information cannot be retrieved: {error}");
+            }
+        },
         "show" => {
             println!("'show' command expects a pid number or a process name");
         }
@@ -504,7 +514,7 @@ fn main() {
             input.as_ref(),
             system.as_mut(),
             gpus.as_mut(),
-            &mut networks,
+            networks.as_mut(),
             &mut disks,
             &mut components,
             users.as_mut(),

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -78,7 +78,7 @@ fn interpret_input(
     networks: &mut Networks,
     disks: &mut Disks,
     components: &mut Components,
-    users: &mut Users,
+    users: Result<&mut Users, &mut sysinfo::Error>,
 ) -> bool {
     match input.trim() {
         "help" => print_help(),
@@ -87,11 +87,16 @@ fn interpret_input(
             disks.refresh(true);
             println!("Done.");
         }
-        "refresh_users" => {
-            println!("Refreshing user list...");
-            users.refresh();
-            println!("Done.");
-        }
+        "refresh_users" => match users {
+            Ok(users) => {
+                println!("Refreshing user list...");
+                users.refresh();
+                println!("Done.");
+            }
+            Err(error) => {
+                println!("Users information cannot be retrieved: {error}");
+            }
+        },
         "refresh_networks" => {
             println!("Refreshing network list...");
             networks.refresh(true);
@@ -346,16 +351,26 @@ fn interpret_input(
                 println!("{disk:?}");
             }
         }
-        "users" => {
-            for user in users {
-                println!("{:?} => {:?}", user.name(), user.groups());
+        "users" => match users {
+            Ok(users) => {
+                for user in users {
+                    println!("{:?} => {:?}", user.name(), user.groups());
+                }
             }
-        }
-        "groups" => {
-            for group in Groups::new_with_refreshed_list().list() {
-                println!("{group:?}");
+            Err(error) => {
+                println!("Users information cannot be retrieved: {error}");
             }
-        }
+        },
+        "groups" => match Groups::new_with_refreshed_list() {
+            Ok(groups) => {
+                for group in groups.list() {
+                    println!("{group:?}");
+                }
+            }
+            Err(error) => {
+                println!("Groups information cannot be retrieved: {error}");
+            }
+        },
         "boot_time" => match System::boot_time() {
             Ok(boot_time) => println!("{boot_time} seconds"),
             Err(error) => eprintln!("Failed to get `boot_time`: {error}"),
@@ -492,7 +507,7 @@ fn main() {
             &mut networks,
             &mut disks,
             &mut components,
-            &mut users,
+            users.as_mut(),
         );
     }
 }

--- a/src/common/network.rs
+++ b/src/common/network.rs
@@ -762,7 +762,7 @@ mod tests {
         let networks = match Networks::new_with_refreshed_list() {
             Ok(n) => n,
             Err(error) => {
-                assert_matches!(error, Error::Unsupported);
+                std::assert_matches!(error, Error::Unsupported);
                 return;
             }
         };

--- a/src/common/network.rs
+++ b/src/common/network.rs
@@ -6,16 +6,17 @@ use std::net::{AddrParseError, IpAddr};
 use std::num::ParseIntError;
 use std::str::FromStr;
 
-use crate::{NetworkDataInner, NetworksInner};
+use crate::{Error, NetworkDataInner, NetworksInner};
 
 /// Interacting with network interfaces.
 ///
 /// ```no_run
 /// use sysinfo::Networks;
 ///
-/// let networks = Networks::new_with_refreshed_list();
-/// for (interface_name, network) in &networks {
-///     println!("[{interface_name}]: {network:?}");
+/// if let Ok(networks) = Networks::new_with_refreshed_list() {
+///     for (interface_name, network) in &networks {
+///         println!("[{interface_name}]: {network:?}");
+///     }
 /// }
 /// ```
 pub struct Networks {
@@ -31,12 +32,6 @@ impl<'a> IntoIterator for &'a Networks {
     }
 }
 
-impl Default for Networks {
-    fn default() -> Self {
-        Networks::new()
-    }
-}
-
 impl Networks {
     /// Creates a new empty [`Networks`][crate::Networks] type.
     ///
@@ -45,16 +40,17 @@ impl Networks {
     /// ```no_run
     /// use sysinfo::Networks;
     ///
-    /// let mut networks = Networks::new();
-    /// networks.refresh(true);
-    /// for (interface_name, network) in &networks {
-    ///     println!("[{interface_name}]: {network:?}");
+    /// if let Ok(mut networks) = Networks::new() {
+    ///     networks.refresh(true);
+    ///     for (interface_name, network) in &networks {
+    ///         println!("[{interface_name}]: {network:?}");
+    ///     }
     /// }
     /// ```
-    pub fn new() -> Self {
-        Self {
-            inner: NetworksInner::new(),
-        }
+    pub fn new() -> Result<Self, Error> {
+        Ok(Self {
+            inner: NetworksInner::new()?,
+        })
     }
 
     /// Creates a new [`Networks`][crate::Networks] type with the network interfaces
@@ -63,15 +59,16 @@ impl Networks {
     /// ```no_run
     /// use sysinfo::Networks;
     ///
-    /// let networks = Networks::new_with_refreshed_list();
-    /// for network in &networks {
-    ///     println!("{network:?}");
+    /// if let Ok(networks) = Networks::new_with_refreshed_list() {
+    ///     for network in &networks {
+    ///         println!("{network:?}");
+    ///     }
     /// }
     /// ```
-    pub fn new_with_refreshed_list() -> Self {
-        let mut networks = Self::new();
+    pub fn new_with_refreshed_list() -> Result<Self, Error> {
+        let mut networks = Self::new()?;
         networks.refresh(false);
-        networks
+        Ok(networks)
     }
 
     /// Returns the network interfaces map.
@@ -79,9 +76,10 @@ impl Networks {
     /// ```no_run
     /// use sysinfo::Networks;
     ///
-    /// let networks = Networks::new_with_refreshed_list();
-    /// for network in networks.list() {
-    ///     println!("{network:?}");
+    /// if let Ok(networks) = Networks::new_with_refreshed_list() {
+    ///     for network in networks.list() {
+    ///         println!("{network:?}");
+    ///     }
     /// }
     /// ```
     pub fn list(&self) -> &HashMap<String, NetworkData> {
@@ -93,9 +91,10 @@ impl Networks {
     /// ```no_run
     /// use sysinfo::Networks;
     ///
-    /// let mut networks = Networks::new_with_refreshed_list();
-    /// // Wait some time...? Then refresh the data of each network.
-    /// networks.refresh(true);
+    /// if let Ok(mut networks) = Networks::new_with_refreshed_list() {
+    ///     // Wait some time...? Then refresh the data of each network.
+    ///     networks.refresh(true);
+    /// }
     /// ```
     pub fn refresh(&mut self, remove_not_listed_interfaces: bool) {
         self.inner.refresh(remove_not_listed_interfaces)
@@ -115,9 +114,10 @@ impl std::ops::Deref for Networks {
 /// ```no_run
 /// use sysinfo::Networks;
 ///
-/// let networks = Networks::new_with_refreshed_list();
-/// for (interface_name, network) in &networks {
-///     println!("[{interface_name}] {network:?}");
+/// if let Ok(networks) = Networks::new_with_refreshed_list() {
+///     for (interface_name, network) in &networks {
+///         println!("[{interface_name}] {network:?}");
+///     }
 /// }
 /// ```
 pub struct NetworkData {
@@ -134,14 +134,15 @@ impl NetworkData {
     /// use sysinfo::Networks;
     /// use std::{thread, time};
     ///
-    /// let mut networks = Networks::new_with_refreshed_list();
-    /// // Waiting a bit to get data from network...
-    /// thread::sleep(time::Duration::from_millis(10));
-    /// // Refreshing again to generate diff.
-    /// networks.refresh(true);
+    /// if let Ok(mut networks) = Networks::new_with_refreshed_list() {
+    ///     // Waiting a bit to get data from network...
+    ///     thread::sleep(time::Duration::from_millis(10));
+    ///     // Refreshing again to generate diff.
+    ///     networks.refresh(true);
     ///
-    /// for (interface_name, network) in &networks {
-    ///     println!("in: {} B", network.received());
+    ///     for (interface_name, network) in &networks {
+    ///         println!("in: {} B", network.received());
+    ///     }
     /// }
     /// ```
     pub fn received(&self) -> u64 {
@@ -156,9 +157,10 @@ impl NetworkData {
     /// ```no_run
     /// use sysinfo::Networks;
     ///
-    /// let networks = Networks::new_with_refreshed_list();
-    /// for (interface_name, network) in &networks {
-    ///     println!("in: {} B", network.total_received());
+    /// if let Ok(networks) = Networks::new_with_refreshed_list() {
+    ///     for (interface_name, network) in &networks {
+    ///         println!("in: {} B", network.total_received());
+    ///     }
     /// }
     /// ```
     pub fn total_received(&self) -> u64 {
@@ -174,14 +176,15 @@ impl NetworkData {
     /// use sysinfo::Networks;
     /// use std::{thread, time};
     ///
-    /// let mut networks = Networks::new_with_refreshed_list();
-    /// // Waiting a bit to get data from network...
-    /// thread::sleep(time::Duration::from_millis(10));
-    /// // Refreshing again to generate diff.
-    /// networks.refresh(true);
+    /// if let Ok(mut networks) = Networks::new_with_refreshed_list() {
+    ///     // Waiting a bit to get data from network...
+    ///     thread::sleep(time::Duration::from_millis(10));
+    ///     // Refreshing again to generate diff.
+    ///     networks.refresh(true);
     ///
-    /// for (interface_name, network) in &networks {
-    ///     println!("out: {} B", network.transmitted());
+    ///     for (interface_name, network) in &networks {
+    ///         println!("out: {} B", network.transmitted());
+    ///     }
     /// }
     /// ```
     pub fn transmitted(&self) -> u64 {
@@ -196,9 +199,10 @@ impl NetworkData {
     /// ```no_run
     /// use sysinfo::Networks;
     ///
-    /// let networks = Networks::new_with_refreshed_list();
-    /// for (interface_name, network) in &networks {
-    ///     println!("out: {} B", network.total_transmitted());
+    /// if let Ok(networks) = Networks::new_with_refreshed_list() {
+    ///     for (interface_name, network) in &networks {
+    ///         println!("out: {} B", network.total_transmitted());
+    ///     }
     /// }
     /// ```
     pub fn total_transmitted(&self) -> u64 {
@@ -214,14 +218,15 @@ impl NetworkData {
     /// use sysinfo::Networks;
     /// use std::{thread, time};
     ///
-    /// let mut networks = Networks::new_with_refreshed_list();
-    /// // Waiting a bit to get data from network...
-    /// thread::sleep(time::Duration::from_millis(10));
-    /// // Refreshing again to generate diff.
-    /// networks.refresh(true);
+    /// if let Ok(mut networks) = Networks::new_with_refreshed_list() {
+    ///     // Waiting a bit to get data from network...
+    ///     thread::sleep(time::Duration::from_millis(10));
+    ///     // Refreshing again to generate diff.
+    ///     networks.refresh(true);
     ///
-    /// for (interface_name, network) in &networks {
-    ///     println!("in: {}", network.packets_received());
+    ///     for (interface_name, network) in &networks {
+    ///         println!("in: {}", network.packets_received());
+    ///     }
     /// }
     /// ```
     pub fn packets_received(&self) -> u64 {
@@ -236,9 +241,10 @@ impl NetworkData {
     /// ```no_run
     /// use sysinfo::Networks;
     ///
-    /// let networks = Networks::new_with_refreshed_list();
-    /// for (interface_name, network) in &networks {
-    ///     println!("in: {}", network.total_packets_received());
+    /// if let Ok(networks) = Networks::new_with_refreshed_list() {
+    ///     for (interface_name, network) in &networks {
+    ///         println!("in: {}", network.total_packets_received());
+    ///     }
     /// }
     /// ```
     pub fn total_packets_received(&self) -> u64 {
@@ -254,14 +260,15 @@ impl NetworkData {
     /// use sysinfo::Networks;
     /// use std::{thread, time};
     ///
-    /// let mut networks = Networks::new_with_refreshed_list();
-    /// // Waiting a bit to get data from network...
-    /// thread::sleep(time::Duration::from_millis(10));
-    /// // Refreshing again to generate diff.
-    /// networks.refresh(true);
+    /// if let Ok(mut networks) = Networks::new_with_refreshed_list() {
+    ///     // Waiting a bit to get data from network...
+    ///     thread::sleep(time::Duration::from_millis(10));
+    ///     // Refreshing again to generate diff.
+    ///     networks.refresh(true);
     ///
-    /// for (interface_name, network) in &networks {
-    ///     println!("out: {}", network.packets_transmitted());
+    ///     for (interface_name, network) in &networks {
+    ///         println!("out: {}", network.packets_transmitted());
+    ///     }
     /// }
     /// ```
     pub fn packets_transmitted(&self) -> u64 {
@@ -276,9 +283,10 @@ impl NetworkData {
     /// ```no_run
     /// use sysinfo::Networks;
     ///
-    /// let networks = Networks::new_with_refreshed_list();
-    /// for (interface_name, network) in &networks {
-    ///     println!("out: {}", network.total_packets_transmitted());
+    /// if let Ok(networks) = Networks::new_with_refreshed_list() {
+    ///     for (interface_name, network) in &networks {
+    ///         println!("out: {}", network.total_packets_transmitted());
+    ///     }
     /// }
     /// ```
     pub fn total_packets_transmitted(&self) -> u64 {
@@ -294,14 +302,15 @@ impl NetworkData {
     /// use sysinfo::Networks;
     /// use std::{thread, time};
     ///
-    /// let mut networks = Networks::new_with_refreshed_list();
-    /// // Waiting a bit to get data from network...
-    /// thread::sleep(time::Duration::from_millis(10));
-    /// // Refreshing again to generate diff.
-    /// networks.refresh(true);
+    /// if let Ok(mut networks) = Networks::new_with_refreshed_list() {
+    ///     // Waiting a bit to get data from network...
+    ///     thread::sleep(time::Duration::from_millis(10));
+    ///     // Refreshing again to generate diff.
+    ///     networks.refresh(true);
     ///
-    /// for (interface_name, network) in &networks {
-    ///     println!("in: {}", network.errors_on_received());
+    ///     for (interface_name, network) in &networks {
+    ///         println!("in: {}", network.errors_on_received());
+    ///     }
     /// }
     /// ```
     pub fn errors_on_received(&self) -> u64 {
@@ -316,9 +325,10 @@ impl NetworkData {
     /// ```no_run
     /// use sysinfo::Networks;
     ///
-    /// let networks = Networks::new_with_refreshed_list();
-    /// for (interface_name, network) in &networks {
-    ///     println!("in: {}", network.total_errors_on_received());
+    /// if let Ok(networks) = Networks::new_with_refreshed_list() {
+    ///     for (interface_name, network) in &networks {
+    ///         println!("in: {}", network.total_errors_on_received());
+    ///     }
     /// }
     /// ```
     pub fn total_errors_on_received(&self) -> u64 {
@@ -334,14 +344,15 @@ impl NetworkData {
     /// use sysinfo::Networks;
     /// use std::{thread, time};
     ///
-    /// let mut networks = Networks::new_with_refreshed_list();
-    /// // Waiting a bit to get data from network...
-    /// thread::sleep(time::Duration::from_millis(10));
-    /// // Refreshing again to generate diff.
-    /// networks.refresh(true);
+    /// if let Ok(mut networks) = Networks::new_with_refreshed_list() {
+    ///     // Waiting a bit to get data from network...
+    ///     thread::sleep(time::Duration::from_millis(10));
+    ///     // Refreshing again to generate diff.
+    ///     networks.refresh(true);
     ///
-    /// for (interface_name, network) in &networks {
-    ///     println!("out: {}", network.errors_on_transmitted());
+    ///     for (interface_name, network) in &networks {
+    ///         println!("out: {}", network.errors_on_transmitted());
+    ///     }
     /// }
     /// ```
     pub fn errors_on_transmitted(&self) -> u64 {
@@ -356,9 +367,10 @@ impl NetworkData {
     /// ```no_run
     /// use sysinfo::Networks;
     ///
-    /// let networks = Networks::new_with_refreshed_list();
-    /// for (interface_name, network) in &networks {
-    ///     println!("out: {}", network.total_errors_on_transmitted());
+    /// if let Ok(networks) = Networks::new_with_refreshed_list() {
+    ///     for (interface_name, network) in &networks {
+    ///         println!("out: {}", network.total_errors_on_transmitted());
+    ///     }
     /// }
     /// ```
     pub fn total_errors_on_transmitted(&self) -> u64 {
@@ -370,9 +382,10 @@ impl NetworkData {
     /// ```no_run
     /// use sysinfo::Networks;
     ///
-    /// let mut networks = Networks::new_with_refreshed_list();
-    /// for (interface_name, network) in &networks {
-    ///     println!("MAC address: {}", network.mac_address());
+    /// if let Ok(mut networks) = Networks::new_with_refreshed_list() {
+    ///     for (interface_name, network) in &networks {
+    ///         println!("MAC address: {}", network.mac_address());
+    ///     }
     /// }
     /// ```
     pub fn mac_address(&self) -> MacAddr {
@@ -384,9 +397,10 @@ impl NetworkData {
     /// ```no_run
     /// use sysinfo::Networks;
     ///
-    /// let mut networks = Networks::new_with_refreshed_list();
-    /// for (interface_name, network) in &networks {
-    ///     println!("Ip Networks: {:?}", network.ip_networks());
+    /// if let Ok(mut networks) = Networks::new_with_refreshed_list() {
+    ///     for (interface_name, network) in &networks {
+    ///         println!("Ip Networks: {:?}", network.ip_networks());
+    ///     }
     /// }
     /// ```
     pub fn ip_networks(&self) -> &[IpNetwork] {
@@ -398,9 +412,10 @@ impl NetworkData {
     /// ```no_run
     /// use sysinfo::Networks;
     ///
-    /// let mut networks = Networks::new_with_refreshed_list();
-    /// for (interface_name, network) in &networks {
-    ///     println!("mtu: {}", network.mtu());
+    /// if let Ok(mut networks) = Networks::new_with_refreshed_list() {
+    ///     for (interface_name, network) in &networks {
+    ///         println!("mtu: {}", network.mtu());
+    ///     }
     /// }
     /// ```
     pub fn mtu(&self) -> u64 {
@@ -415,9 +430,10 @@ impl NetworkData {
     /// ```no_run
     /// use sysinfo::Networks;
     ///
-    /// let mut networks = Networks::new_with_refreshed_list();
-    /// for (interface_name, network) in &networks {
-    ///     println!("operational state: {}", network.operational_state());
+    /// if let Ok(mut networks) = Networks::new_with_refreshed_list() {
+    ///     for (interface_name, network) in &networks {
+    ///         println!("operational state: {}", network.operational_state());
+    ///     }
     /// }
     /// ```
     pub fn operational_state(&self) -> InterfaceOperationalState {
@@ -743,10 +759,13 @@ mod tests {
 
     #[test]
     fn check_ip_networks() {
-        if !IS_SUPPORTED_SYSTEM {
-            return;
-        }
-        let networks = Networks::new_with_refreshed_list();
+        let networks = match Networks::new_with_refreshed_list() {
+            Ok(n) => n,
+            Err(error) => {
+                assert_matches!(error, Error::Unsupported);
+                return;
+            }
+        };
         if networks.iter().any(|(_, n)| !n.ip_networks().is_empty()) {
             return;
         }

--- a/src/common/network.rs
+++ b/src/common/network.rs
@@ -759,13 +759,7 @@ mod tests {
 
     #[test]
     fn check_ip_networks() {
-        let networks = match Networks::new_with_refreshed_list() {
-            Ok(n) => n,
-            Err(error) => {
-                std::assert_matches!(error, Error::Unsupported);
-                return;
-            }
-        };
+        let networks = check_unsupported!(Networks::new_with_refreshed_list());
         if networks.iter().any(|(_, n)| !n.ip_networks().is_empty()) {
             return;
         }

--- a/src/common/user.rs
+++ b/src/common/user.rs
@@ -2,7 +2,7 @@
 
 use std::cmp::Ordering;
 
-use crate::{Gid, Uid, UserInner};
+use crate::{Error, Gid, Uid, UserInner};
 
 /// Type containing user information.
 ///
@@ -11,9 +11,10 @@ use crate::{Gid, Uid, UserInner};
 /// ```no_run
 /// use sysinfo::Users;
 ///
-/// let users = Users::new_with_refreshed_list();
-/// for user in users.list() {
-///     println!("{:?}", user);
+/// if let Ok(users) = Users::new_with_refreshed_list() {
+///     for user in users.list() {
+///         println!("{:?}", user);
+///     }
 /// }
 /// ```
 pub struct User {
@@ -48,9 +49,10 @@ impl User {
     /// ```no_run
     /// use sysinfo::Users;
     ///
-    /// let users = Users::new_with_refreshed_list();
-    /// for user in users.list() {
-    ///     println!("{:?}", *user.id());
+    /// if let Ok(users) = Users::new_with_refreshed_list() {
+    ///     for user in users.list() {
+    ///         println!("{:?}", *user.id());
+    ///     }
     /// }
     /// ```
     pub fn id(&self) -> &Uid {
@@ -69,9 +71,10 @@ impl User {
     /// ```no_run
     /// use sysinfo::Users;
     ///
-    /// let users = Users::new_with_refreshed_list();
-    /// for user in users.list() {
-    ///     println!("{}", *user.group_id());
+    /// if let Ok(users) = Users::new_with_refreshed_list() {
+    ///     for user in users.list() {
+    ///         println!("{}", *user.group_id());
+    ///     }
     /// }
     /// ```
     pub fn group_id(&self) -> Gid {
@@ -83,9 +86,10 @@ impl User {
     /// ```no_run
     /// use sysinfo::Users;
     ///
-    /// let users = Users::new_with_refreshed_list();
-    /// for user in users.list() {
-    ///     println!("{}", user.name());
+    /// if let Ok(users) = Users::new_with_refreshed_list() {
+    ///     for user in users.list() {
+    ///         println!("{}", user.name());
+    ///     }
     /// }
     /// ```
     pub fn name(&self) -> &str {
@@ -99,9 +103,10 @@ impl User {
     /// ```no_run
     /// use sysinfo::Users;
     ///
-    /// let users = Users::new_with_refreshed_list();
-    /// for user in users.list() {
-    ///     println!("{} is in {:?}", user.name(), user.groups());
+    /// if let Ok(users) = Users::new_with_refreshed_list() {
+    ///     for user in users.list() {
+    ///         println!("{} is in {:?}", user.name(), user.groups());
+    ///     }
     /// }
     /// ```
     pub fn groups(&self) -> Vec<Group> {
@@ -122,17 +127,17 @@ pub(crate) struct GroupInner {
 /// ```no_run
 /// use sysinfo::Users;
 ///
-/// let mut users = Users::new_with_refreshed_list();
-///
-/// for user in users.list() {
-///     println!(
-///         "user: (ID: {:?}, group ID: {:?}, name: {:?})",
-///         user.id(),
-///         user.group_id(),
-///         user.name(),
-///     );
-///     for group in user.groups() {
-///         println!("group: (ID: {:?}, name: {:?})", group.id(), group.name());
+/// if let Ok(users) = Users::new_with_refreshed_list() {
+///     for user in users.list() {
+///         println!(
+///             "user: (ID: {:?}, group ID: {:?}, name: {:?})",
+///             user.id(),
+///             user.group_id(),
+///             user.name(),
+///         );
+///         for group in user.groups() {
+///             println!("group: (ID: {:?}, name: {:?})", group.id(), group.name());
+///         }
 ///     }
 /// }
 /// ```
@@ -149,11 +154,11 @@ impl Group {
     /// ```no_run
     /// use sysinfo::Users;
     ///
-    /// let mut users = Users::new_with_refreshed_list();
-    ///
-    /// for user in users.list() {
-    ///     for group in user.groups() {
-    ///         println!("{:?}", group.id());
+    /// if let Ok(users) = Users::new_with_refreshed_list() {
+    ///     for user in users.list() {
+    ///         for group in user.groups() {
+    ///             println!("{:?}", group.id());
+    ///         }
     ///     }
     /// }
     /// ```
@@ -166,11 +171,11 @@ impl Group {
     /// ```no_run
     /// use sysinfo::Users;
     ///
-    /// let mut users = Users::new_with_refreshed_list();
-    ///
-    /// for user in users.list() {
-    ///     for group in user.groups() {
-    ///         println!("{}", group.name());
+    /// if let Ok(users) = Users::new_with_refreshed_list() {
+    ///     for user in users.list() {
+    ///         for group in user.groups() {
+    ///             println!("{}", group.name());
+    ///         }
     ///     }
     /// }
     /// ```
@@ -184,19 +189,14 @@ impl Group {
 /// ```no_run
 /// use sysinfo::Users;
 ///
-/// let mut users = Users::new();
-/// for user in users.list() {
-///     println!("{} is in {} groups", user.name(), user.groups().len());
+/// if let Ok(users) = Users::new_with_refreshed_list() {
+///     for user in users.list() {
+///         println!("{} is in {} groups", user.name(), user.groups().len());
+///     }
 /// }
 /// ```
 pub struct Users {
     users: Vec<User>,
-}
-
-impl Default for Users {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl From<Users> for Vec<User> {
@@ -251,14 +251,17 @@ impl Users {
     /// ```no_run
     /// use sysinfo::Users;
     ///
-    /// let mut users = Users::new();
-    /// users.refresh();
-    /// for user in users.list() {
-    ///     println!("{user:?}");
+    /// if let Ok(mut users) = Users::new() {
+    ///     users.refresh();
+    ///     for user in users.list() {
+    ///         println!("{user:?}");
+    ///     }
     /// }
     /// ```
-    pub fn new() -> Self {
-        Self { users: Vec::new() }
+    pub fn new() -> Result<Self, Error> {
+        Ok(Self {
+            users: crate::sys::new_users()?,
+        })
     }
 
     /// Creates a new [`Users`][crate::Users] type with the user list loaded.
@@ -266,15 +269,16 @@ impl Users {
     /// ```no_run
     /// use sysinfo::Users;
     ///
-    /// let mut users = Users::new_with_refreshed_list();
-    /// for user in users.list() {
-    ///     println!("{user:?}");
+    /// if let Ok(users) = Users::new_with_refreshed_list() {
+    ///     for user in users.list() {
+    ///         println!("{user:?}");
+    ///     }
     /// }
     /// ```
-    pub fn new_with_refreshed_list() -> Self {
-        let mut users = Self::new();
+    pub fn new_with_refreshed_list() -> Result<Self, Error> {
+        let mut users = Self::new()?;
         users.refresh();
-        users
+        Ok(users)
     }
 
     /// Returns the users list.
@@ -282,9 +286,10 @@ impl Users {
     /// ```no_run
     /// use sysinfo::Users;
     ///
-    /// let users = Users::new_with_refreshed_list();
-    /// for user in users.list() {
-    ///     println!("{user:?}");
+    /// if let Ok(users) = Users::new_with_refreshed_list() {
+    ///     for user in users.list() {
+    ///         println!("{user:?}");
+    ///     }
     /// }
     /// ```
     pub fn list(&self) -> &[User] {
@@ -296,10 +301,11 @@ impl Users {
     /// ```no_run
     /// use sysinfo::Users;
     ///
-    /// let mut users = Users::new_with_refreshed_list();
-    /// users.list_mut().sort_by(|user1, user2| {
-    ///     user1.name().partial_cmp(user2.name()).unwrap()
-    /// });
+    /// if let Ok(mut users) = Users::new_with_refreshed_list() {
+    ///     users.list_mut().sort_by(|user1, user2| {
+    ///         user1.name().partial_cmp(user2.name()).unwrap()
+    ///     });
+    /// }
     /// ```
     pub fn list_mut(&mut self) -> &mut [User] {
         &mut self.users
@@ -310,8 +316,9 @@ impl Users {
     /// ```no_run
     /// use sysinfo::Users;
     ///
-    /// let mut users = Users::new();
-    /// users.refresh();
+    /// if let Ok(mut users) = Users::new() {
+    ///     users.refresh();
+    /// }
     /// ```
     pub fn refresh(&mut self) {
         crate::sys::get_users(&mut self.users);
@@ -326,8 +333,9 @@ impl Users {
     ///
     /// ```ignore
     /// # use sysinfo::Users;
-    /// let users = Users::new_with_refreshed_list();
-    /// users.list().find(|user| user.id() == user_id);
+    /// if let Ok(users) = Users::new_with_refreshed_list() {
+    ///     users.list().find(|user| user.id() == user_id);
+    /// }
     /// ```
     ///
     /// Full example:
@@ -336,14 +344,12 @@ impl Users {
     #[cfg_attr(not(feature = "system"), doc = "```ignore")]
     /// use sysinfo::{Pid, System, Users};
     ///
-    /// if let Ok(mut s) = System::new_all() {
-    ///     let users = Users::new_with_refreshed_list();
-    ///
-    ///     if let Some(process) = s.process(Pid::from(1337)) {
-    ///         if let Some(user_id) = process.user_id() {
-    ///             println!("User for process 1337: {:?}", users.get_user_by_id(user_id));
-    ///         }
-    ///     }
+    /// if let Ok(mut s) = System::new_all()
+    ///     && let Ok(users) = Users::new_with_refreshed_list()
+    ///     && let Some(process) = s.process(Pid::from(1337)) {
+    ///     && let Some(user_id) = process.user_id()
+    /// {
+    ///     println!("User for process 1337: {:?}", users.get_user_by_id(user_id));
     /// }
     /// ```
     pub fn get_user_by_id(&self, user_id: &Uid) -> Option<&User> {
@@ -356,19 +362,14 @@ impl Users {
 /// ```no_run
 /// use sysinfo::Groups;
 ///
-/// let mut groups = Groups::new();
-/// for group in groups.list() {
-///     println!("{}", group.name());
+/// if let Ok(groups) = Groups::new_with_refreshed_list() {
+///     for group in groups.list() {
+///         println!("{}", group.name());
+///     }
 /// }
 /// ```
 pub struct Groups {
     groups: Vec<Group>,
-}
-
-impl Default for Groups {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl From<Groups> for Vec<Group> {
@@ -423,14 +424,17 @@ impl Groups {
     /// ```no_run
     /// use sysinfo::Groups;
     ///
-    /// let mut groups = Groups::new();
-    /// groups.refresh();
-    /// for group in groups.list() {
-    ///     println!("{group:?}");
+    /// if let Ok(mut groups) = Groups::new() {
+    ///     groups.refresh();
+    ///     for group in groups.list() {
+    ///         println!("{group:?}");
+    ///     }
     /// }
     /// ```
-    pub fn new() -> Self {
-        Self { groups: Vec::new() }
+    pub fn new() -> Result<Self, Error> {
+        Ok(Self {
+            groups: crate::sys::new_groups()?,
+        })
     }
 
     /// Creates a new [`Groups`][crate::Groups] type with the group list loaded.
@@ -438,15 +442,16 @@ impl Groups {
     /// ```no_run
     /// use sysinfo::Groups;
     ///
-    /// let mut groups = Groups::new_with_refreshed_list();
-    /// for group in groups.list() {
-    ///     println!("{group:?}");
+    /// if let Ok(groups) = Groups::new_with_refreshed_list() {
+    ///     for group in groups.list() {
+    ///         println!("{group:?}");
+    ///     }
     /// }
     /// ```
-    pub fn new_with_refreshed_list() -> Self {
-        let mut groups = Self::new();
+    pub fn new_with_refreshed_list() -> Result<Self, Error> {
+        let mut groups = Self::new()?;
         groups.refresh();
-        groups
+        Ok(groups)
     }
 
     /// Returns the groups list.
@@ -454,9 +459,10 @@ impl Groups {
     /// ```no_run
     /// use sysinfo::Groups;
     ///
-    /// let groups = Groups::new_with_refreshed_list();
-    /// for group in groups.list() {
-    ///     println!("{group:?}");
+    /// if let Ok(groups) = Groups::new_with_refreshed_list() {
+    ///     for group in groups.list() {
+    ///         println!("{group:?}");
+    ///     }
     /// }
     /// ```
     pub fn list(&self) -> &[Group] {
@@ -468,10 +474,11 @@ impl Groups {
     /// ```no_run
     /// use sysinfo::Groups;
     ///
-    /// let mut groups = Groups::new_with_refreshed_list();
-    /// groups.list_mut().sort_by(|user1, user2| {
-    ///     user1.name().partial_cmp(user2.name()).unwrap()
-    /// });
+    /// if let Ok(mut groups) = Groups::new_with_refreshed_list() {
+    ///     groups.list_mut().sort_by(|user1, user2| {
+    ///         user1.name().partial_cmp(user2.name()).unwrap()
+    ///     });
+    /// }
     /// ```
     pub fn list_mut(&mut self) -> &mut [Group] {
         &mut self.groups
@@ -482,8 +489,9 @@ impl Groups {
     /// ```no_run
     /// use sysinfo::Groups;
     ///
-    /// let mut groups = Groups::new();
-    /// groups.refresh();
+    /// if let Ok(mut groups) = Groups::new() {
+    ///     groups.refresh();
+    /// }
     /// ```
     pub fn refresh(&mut self) {
         crate::sys::get_groups(&mut self.groups);
@@ -496,7 +504,13 @@ mod tests {
 
     #[test]
     fn check_list() {
-        let mut users = Users::new();
+        let mut users = match Users::new() {
+            Ok(users) => users,
+            Err(err) => {
+                assert_matches!(err, Error::Unsupported);
+                return;
+            }
+        };
         assert!(users.list().is_empty());
         users.refresh();
         assert!(users.list().len() >= MIN_USERS);
@@ -527,9 +541,9 @@ mod tests {
 
     #[test]
     fn check_groups() {
-        if !crate::IS_SUPPORTED_SYSTEM {
-            return;
+        match Groups::new_with_refreshed_list() {
+            Ok(groups) => assert!(!groups.is_empty()),
+            Err(err) => assert_matches!(err, Error::Unsupported),
         }
-        assert!(!Groups::new_with_refreshed_list().is_empty());
     }
 }

--- a/src/common/user.rs
+++ b/src/common/user.rs
@@ -346,7 +346,7 @@ impl Users {
     ///
     /// if let Ok(mut s) = System::new_all()
     ///     && let Ok(users) = Users::new_with_refreshed_list()
-    ///     && let Some(process) = s.process(Pid::from(1337)) {
+    ///     && let Some(process) = s.process(Pid::from(1337))
     ///     && let Some(user_id) = process.user_id()
     /// {
     ///     println!("User for process 1337: {:?}", users.get_user_by_id(user_id));
@@ -504,13 +504,7 @@ mod tests {
 
     #[test]
     fn check_list() {
-        let mut users = match Users::new() {
-            Ok(users) => users,
-            Err(err) => {
-                std::assert_matches!(err, Error::Unsupported);
-                return;
-            }
-        };
+        let mut users = check_unsupported!(Users::new());
         assert!(users.list().is_empty());
         users.refresh();
         assert!(users.list().len() >= MIN_USERS);
@@ -541,9 +535,7 @@ mod tests {
 
     #[test]
     fn check_groups() {
-        match Groups::new_with_refreshed_list() {
-            Ok(groups) => assert!(!groups.is_empty()),
-            Err(err) => std::assert_matches!(err, Error::Unsupported),
-        }
+        let groups = check_unsupported!(Groups::new_with_refreshed_list());
+        assert!(!groups.is_empty());
     }
 }

--- a/src/common/user.rs
+++ b/src/common/user.rs
@@ -507,7 +507,7 @@ mod tests {
         let mut users = match Users::new() {
             Ok(users) => users,
             Err(err) => {
-                assert_matches!(err, Error::Unsupported);
+                std::assert_matches!(err, Error::Unsupported);
                 return;
             }
         };
@@ -543,7 +543,7 @@ mod tests {
     fn check_groups() {
         match Groups::new_with_refreshed_list() {
             Ok(groups) => assert!(!groups.is_empty()),
-            Err(err) => assert_matches!(err, Error::Unsupported),
+            Err(err) => std::assert_matches!(err, Error::Unsupported),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,7 +298,7 @@ mod test {
     #[cfg(feature = "user")]
     #[test]
     fn check_uid_gid() {
-        let mut users = Users::new();
+        let mut users = check_unsupported!(Users::new());
         assert!(users.list().is_empty());
         users.refresh();
         let user_list = users.list();
@@ -344,20 +344,20 @@ mod test {
     fn check_all_process_uids_resolvable() {
         // On linux, some user IDs don't have an associated user (no idea why though).
         // If `getent` doesn't find them, we can assume it's a dark secret from the linux land.
-        if cfg!(not(target_os = "linux"))
-            && let Ok(s) = System::new_with_specifics(
-                RefreshKind::nothing()
-                    .with_processes(ProcessRefreshKind::nothing().with_user(UpdateKind::Always)),
-            )
-        {
-            let users = Users::new_with_refreshed_list();
+        if cfg!(target_os = "linux") {
+            return;
+        }
+        let s = check_unsupported!(System::new_with_specifics(
+            RefreshKind::nothing()
+                .with_processes(ProcessRefreshKind::nothing().with_user(UpdateKind::Always)),
+        ));
+        let users = check_unsupported!(Users::new_with_refreshed_list());
 
-            // For every process where we can get a user ID, we should also be able
-            // to find that user ID in the global user list
-            for process in s.processes().values() {
-                if let Some(uid) = process.user_id() {
-                    assert!(users.get_user_by_id(uid).is_some(), "No UID {uid:?} found");
-                }
+        // For every process where we can get a user ID, we should also be able
+        // to find that user ID in the global user list
+        for process in s.processes().values() {
+            if let Some(uid) = process.user_id() {
+                assert!(users.get_user_by_id(uid).is_some(), "No UID {uid:?} found");
             }
         }
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -93,3 +93,19 @@ macro_rules! retry_eintr {
         }
     }};
 }
+
+#[cfg(test)]
+#[allow(unused_macros)]
+macro_rules! check_unsupported {
+    ($e:expr) => {
+        match $e {
+            Ok(a) => a,
+            Err(error) => {
+                if !matches!(error, crate::Error::Unsupported) {
+                    panic!("Expected `Error::Unsupported`, found {error:?}");
+                }
+                return;
+            }
+        }
+    };
+}

--- a/src/unix/apple/app_store/users.rs
+++ b/src/unix/apple/app_store/users.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::{Gid, Group, Uid, User};
+use crate::{Error, Gid, Group, Uid, User};
 
 pub(crate) struct UserInner;
 
@@ -23,3 +23,6 @@ impl UserInner {
 }
 
 pub(crate) fn get_users(_: &mut Vec<User>) {}
+pub(crate) fn new_users() -> Result<Vec<User>, Error> {
+    Err(Error::Unsupported)
+}

--- a/src/unix/apple/cpu.rs
+++ b/src/unix/apple/cpu.rs
@@ -244,13 +244,10 @@ fn get_idle(cpu_info: *mut i32, offset: isize) -> i32 {
 
 pub(crate) fn compute_usage_of_cpu(proc_: &Cpu, cpu_info: *mut i32, offset: isize) -> f32 {
     let old_cpu_info = proc_.inner.data().cpu_info.0;
-    let in_use;
-    let idle;
 
     // In case we are initializing cpus, there is no "old value" yet.
-    if std::ptr::eq(old_cpu_info, cpu_info) {
-        in_use = get_in_use(cpu_info, offset);
-        idle = get_idle(cpu_info, offset);
+    let (in_use, idle) = if std::ptr::eq(old_cpu_info, cpu_info) {
+        (get_in_use(cpu_info, offset), get_idle(cpu_info, offset))
     } else {
         let new_in_use = get_in_use(cpu_info, offset);
         let old_in_use = get_in_use(old_cpu_info, offset);
@@ -258,9 +255,11 @@ pub(crate) fn compute_usage_of_cpu(proc_: &Cpu, cpu_info: *mut i32, offset: isiz
         let new_idle = get_idle(cpu_info, offset);
         let old_idle = get_idle(old_cpu_info, offset);
 
-        in_use = new_in_use.saturating_sub(old_in_use);
-        idle = new_idle.saturating_sub(old_idle) as _;
-    }
+        (
+            new_in_use.saturating_sub(old_in_use),
+            new_idle.saturating_sub(old_idle) as _,
+        )
+    };
     let total = in_use.saturating_add(idle as _);
     let usage = (in_use as f32 / total as f32) * 100.;
     if usage.is_nan() {

--- a/src/unix/apple/mod.rs
+++ b/src/unix/apple/mod.rs
@@ -77,12 +77,12 @@ cfg_select! {
         #[cfg(target_os = "ios")]
         pub use crate::sys::app_store::users;
 
-        pub(crate) use crate::unix::groups::get_groups;
+        pub(crate) use crate::unix::groups::{get_groups, new_groups};
         #[cfg(target_os = "macos")]
         pub(crate) use crate::unix::users::UserInner;
         #[cfg(target_os = "ios")]
         pub(crate) use self::users::UserInner;
-        pub(crate) use self::users::get_users;
+        pub(crate) use self::users::{get_users, new_users};
     }
     _ => {}
 }

--- a/src/unix/apple/network.rs
+++ b/src/unix/apple/network.rs
@@ -95,6 +95,7 @@ impl NetworksInner {
 
     #[allow(clippy::cast_ptr_alignment)]
     #[allow(clippy::uninit_vec)]
+    #[allow(clippy::needless_late_init)]
     fn update_networks(&mut self) {
         let mib = &mut [CTL_NET, PF_ROUTE, 0, 0, NET_RT_IFLIST2, 0];
         let mib2 = &mut [

--- a/src/unix/apple/network.rs
+++ b/src/unix/apple/network.rs
@@ -10,7 +10,7 @@ use std::mem::{MaybeUninit, size_of};
 use std::ptr::null_mut;
 
 use crate::network::refresh_networks_addresses;
-use crate::{InterfaceOperationalState, IpNetwork, MacAddr, NetworkData};
+use crate::{Error, InterfaceOperationalState, IpNetwork, MacAddr, NetworkData};
 
 // FIXME: To be removed once https://github.com/rust-lang/libc/pull/4022 is merged and released.
 #[repr(C)]
@@ -69,10 +69,10 @@ pub(crate) struct NetworksInner {
 }
 
 impl NetworksInner {
-    pub(crate) fn new() -> Self {
-        Self {
+    pub(crate) fn new() -> Result<Self, Error> {
+        Ok(Self {
             interfaces: HashMap::new(),
-        }
+        })
     }
 
     pub(crate) fn list(&self) -> &HashMap<String, NetworkData> {

--- a/src/unix/apple/users.rs
+++ b/src/unix/apple/users.rs
@@ -1,7 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use crate::unix::users::UserInner;
-use crate::{Gid, Uid, User};
+use crate::{Error, Gid, Uid, User};
 
 use libc::c_void;
 use objc2_core_foundation::{
@@ -115,4 +115,8 @@ fn add_user(result: *const c_void) -> Option<User> {
             inner: UserInner::new(Uid(uid), Gid(gid), name),
         })
     }
+}
+
+pub(crate) fn new_users() -> Result<Vec<User>, Error> {
+    Ok(Vec::new())
 }

--- a/src/unix/bsd/freebsd/mod.rs
+++ b/src/unix/bsd/freebsd/mod.rs
@@ -54,8 +54,8 @@ cfg_select! {
 }
 cfg_select! {
     feature = "user" => {
-        pub(crate) use crate::unix::groups::get_groups;
-        pub(crate) use crate::unix::users::{get_users, UserInner};
+        pub(crate) use crate::unix::groups::{get_groups, new_groups};
+        pub(crate) use crate::unix::users::{get_users, new_users, UserInner};
     }
     _ => {}
 }

--- a/src/unix/bsd/freebsd/network.rs
+++ b/src/unix/bsd/freebsd/network.rs
@@ -6,7 +6,7 @@ use std::mem::MaybeUninit;
 use super::utils;
 use crate::network::refresh_networks_addresses;
 use crate::unix::bsd::NetworkDataInner;
-use crate::{InterfaceOperationalState, MacAddr, NetworkData};
+use crate::{Error, InterfaceOperationalState, MacAddr, NetworkData};
 
 macro_rules! old_and_new {
     ($ty_:expr, $name:ident, $old:ident, $data:expr) => {{
@@ -20,10 +20,10 @@ pub(crate) struct NetworksInner {
 }
 
 impl NetworksInner {
-    pub(crate) fn new() -> Self {
-        Self {
+    pub(crate) fn new() -> Result<Self, Error> {
+        Ok(Self {
             interfaces: HashMap::new(),
-        }
+        })
     }
 
     pub(crate) fn list(&self) -> &HashMap<String, NetworkData> {

--- a/src/unix/bsd/netbsd/mod.rs
+++ b/src/unix/bsd/netbsd/mod.rs
@@ -54,8 +54,8 @@ cfg_select! {
 }
 cfg_select! {
     feature = "user" => {
-        pub(crate) use crate::unix::groups::get_groups;
-        pub(crate) use crate::unix::users::{get_users, UserInner};
+        pub(crate) use crate::unix::groups::{get_groups, new_groups};
+        pub(crate) use crate::unix::users::{get_users, new_users, UserInner};
     }
     _ => {}
 }

--- a/src/unix/bsd/netbsd/network.rs
+++ b/src/unix/bsd/netbsd/network.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, hash_map};
 
 use crate::network::refresh_networks_addresses;
 use crate::unix::bsd::NetworkDataInner;
-use crate::{InterfaceOperationalState, MacAddr, NetworkData};
+use crate::{Error, InterfaceOperationalState, MacAddr, NetworkData};
 
 macro_rules! old_and_new {
     ($ty_:expr, $name:ident, $old:ident, $data:expr) => {{
@@ -18,10 +18,10 @@ pub(crate) struct NetworksInner {
 }
 
 impl NetworksInner {
-    pub(crate) fn new() -> Self {
-        Self {
+    pub(crate) fn new() -> Result<Self, Error> {
+        Ok(Self {
             interfaces: HashMap::new(),
-        }
+        })
     }
 
     pub(crate) fn list(&self) -> &HashMap<String, NetworkData> {

--- a/src/unix/groups.rs
+++ b/src/unix/groups.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::{Gid, Group, GroupInner};
+use crate::{Error, Gid, Group, GroupInner};
 
 impl GroupInner {
     pub(crate) fn new(id: crate::Gid, name: String) -> Self {
@@ -49,4 +49,8 @@ pub(crate) fn get_groups(groups: &mut Vec<Group>) {
             inner: GroupInner::new(gid, name),
         });
     }
+}
+
+pub(crate) fn new_groups() -> Result<Vec<Group>, Error> {
+    Ok(Vec::new())
 }

--- a/src/unix/linux/mod.rs
+++ b/src/unix/linux/mod.rs
@@ -55,8 +55,8 @@ cfg_select! {
 }
 cfg_select! {
     feature = "user" => {
-        pub(crate) use crate::unix::groups::get_groups;
-        pub(crate) use crate::unix::users::{get_users, UserInner};
+        pub(crate) use crate::unix::groups::{get_groups, new_groups};
+        pub(crate) use crate::unix::users::{UserInner, get_users, new_users};
     }
     _ => {}
 }

--- a/src/unix/linux/network.rs
+++ b/src/unix/linux/network.rs
@@ -6,7 +6,7 @@ use std::io::Read;
 use std::path::Path;
 
 use crate::network::refresh_networks_addresses;
-use crate::{InterfaceOperationalState, IpNetwork, MacAddr, NetworkData};
+use crate::{Error, InterfaceOperationalState, IpNetwork, MacAddr, NetworkData};
 
 macro_rules! old_and_new {
     ($ty_:expr, $name:ident, $old:ident) => {{
@@ -170,10 +170,10 @@ pub(crate) struct NetworksInner {
 }
 
 impl NetworksInner {
-    pub(crate) fn new() -> Self {
-        Self {
+    pub(crate) fn new() -> Result<Self, Error> {
+        Ok(Self {
             interfaces: HashMap::new(),
-        }
+        })
     }
 
     pub(crate) fn list(&self) -> &HashMap<String, NetworkData> {

--- a/src/unix/users.rs
+++ b/src/unix/users.rs
@@ -167,3 +167,8 @@ pub(crate) fn get_users(users: &mut Vec<crate::User>) {
         });
     }
 }
+
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+pub(crate) fn new_users() -> Result<Vec<crate::User>, crate::Error> {
+    Ok(Vec::new())
+}

--- a/src/unknown/groups.rs
+++ b/src/unknown/groups.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::{Gid, Group, GroupInner};
+use crate::{Error, Gid, Group, GroupInner};
 
 impl GroupInner {
     pub(crate) fn id(&self) -> &Gid {
@@ -13,3 +13,7 @@ impl GroupInner {
 }
 
 pub(crate) fn get_groups(_: &mut Vec<Group>) {}
+
+pub(crate) fn new_groups() -> Result<Vec<Group>, Error> {
+    Err(Error::Unsupported)
+}

--- a/src/unknown/mod.rs
+++ b/src/unknown/mod.rs
@@ -54,8 +54,8 @@ cfg_select! {
         pub mod groups;
         pub mod users;
 
-        pub(crate) use self::groups::get_groups;
-        pub(crate) use self::users::{get_users, UserInner};
+        pub(crate) use self::groups::{get_groups, new_groups};
+        pub(crate) use self::users::{UserInner, get_users, new_users};
     }
     _ => {}
 }

--- a/src/unknown/network.rs
+++ b/src/unknown/network.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::{InterfaceOperationalState, IpNetwork, MacAddr, NetworkData};
+use crate::{Error, InterfaceOperationalState, IpNetwork, MacAddr, NetworkData};
 
 use std::collections::HashMap;
 
@@ -9,10 +9,8 @@ pub(crate) struct NetworksInner {
 }
 
 impl NetworksInner {
-    pub(crate) fn new() -> Self {
-        Self {
-            interfaces: HashMap::new(),
-        }
+    pub(crate) fn new() -> Result<Self, Error> {
+        Err(Error::Unsupported)
     }
 
     pub(crate) fn list(&self) -> &HashMap<String, NetworkData> {

--- a/src/unknown/users.rs
+++ b/src/unknown/users.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::{Gid, Group, Uid, User};
+use crate::{Error, Gid, Group, Uid, User};
 
 pub(crate) struct UserInner;
 
@@ -23,3 +23,6 @@ impl UserInner {
 }
 
 pub(crate) fn get_users(_: &mut Vec<User>) {}
+pub(crate) fn new_users() -> Result<Vec<User>, Error> {
+    Err(Error::Unsupported)
+}

--- a/src/windows/groups.rs
+++ b/src/windows/groups.rs
@@ -1,7 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use crate::sys::utils::to_utf8_str;
-use crate::{Gid, Group, GroupInner};
+use crate::{Error, Gid, Group, GroupInner};
 
 use std::ptr::null_mut;
 use windows::Win32::Foundation::{ERROR_MORE_DATA, ERROR_SUCCESS};
@@ -79,4 +79,8 @@ pub(crate) fn get_groups(groups: &mut Vec<Group>) {
             }
         }
     }
+}
+
+pub(crate) fn new_groups() -> Result<Vec<Group>, Error> {
+    Ok(Vec::new())
 }

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -58,8 +58,8 @@ cfg_select! {
         mod groups;
         mod users;
 
-        pub(crate) use self::groups::get_groups;
-        pub(crate) use self::users::get_users;
+        pub(crate) use self::groups::{get_groups, new_groups};
+        pub(crate) use self::users::{get_users, new_users};
         pub(crate) use self::users::UserInner;
     }
     _ => {}

--- a/src/windows/network.rs
+++ b/src/windows/network.rs
@@ -1,7 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use crate::network::refresh_networks_addresses;
-use crate::{InterfaceOperationalState, IpNetwork, MacAddr, NetworkData};
+use crate::{Error, InterfaceOperationalState, IpNetwork, MacAddr, NetworkData};
 
 use std::collections::{HashMap, hash_map};
 
@@ -24,10 +24,10 @@ pub(crate) struct NetworksInner {
 }
 
 impl NetworksInner {
-    pub(crate) fn new() -> Self {
-        Self {
+    pub(crate) fn new() -> Result<Self, Error> {
+        Ok(Self {
             interfaces: HashMap::new(),
-        }
+        })
     }
 
     pub(crate) fn list(&self) -> &HashMap<String, NetworkData> {

--- a/src/windows/users.rs
+++ b/src/windows/users.rs
@@ -1,7 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use crate::sys::utils::to_utf8_str;
-use crate::{Gid, Group, GroupInner, Uid, User, windows::sid::Sid};
+use crate::{Error, Gid, Group, GroupInner, Uid, User, windows::sid::Sid};
 
 use std::ptr::null_mut;
 use windows::Win32::Foundation::{ERROR_MORE_DATA, LUID};
@@ -276,4 +276,8 @@ pub(crate) fn get_users(users: &mut Vec<User>) {
             }
         }
     }
+}
+
+pub(crate) fn new_users() -> Result<Vec<User>, Error> {
+    Ok(Vec::new())
 }

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -8,10 +8,13 @@ use sysinfo::Networks;
 
 #[test]
 fn test_networks() {
-    if !sysinfo::IS_SUPPORTED_SYSTEM {
-        return;
-    }
-    let mut networks = Networks::new();
+    let mut networks = match Networks::new() {
+        Ok(n) => n,
+        Err(error) => {
+            assert_matches!(error, Error::Unsupported);
+            return;
+        }
+    };
     assert_eq!(networks.list().len(), 0);
     networks.refresh(false);
     assert_ne!(networks.list().len(), 0);
@@ -19,10 +22,13 @@ fn test_networks() {
 
 #[test]
 fn test_mac_addr() {
-    if !sysinfo::IS_SUPPORTED_SYSTEM {
-        return;
-    }
-    let mut networks = Networks::new();
+    let mut networks = match Networks::new() {
+        Ok(n) => n,
+        Err(error) => {
+            assert_matches!(error, Error::Unsupported);
+            return;
+        }
+    };
     networks.refresh(false);
     assert_ne!(networks.list().len(), 0);
     networks

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -11,7 +11,7 @@ fn test_networks() {
     let mut networks = match Networks::new() {
         Ok(n) => n,
         Err(error) => {
-            assert_matches!(error, Error::Unsupported);
+            std::assert_matches!(error, Error::Unsupported);
             return;
         }
     };
@@ -25,7 +25,7 @@ fn test_mac_addr() {
     let mut networks = match Networks::new() {
         Ok(n) => n,
         Err(error) => {
-            assert_matches!(error, Error::Unsupported);
+            std::assert_matches!(error, Error::Unsupported);
             return;
         }
     };

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -4,14 +4,16 @@
 
 #![cfg(feature = "network")]
 
-use sysinfo::Networks;
+use sysinfo::{Error, Networks};
 
 #[test]
 fn test_networks() {
     let mut networks = match Networks::new() {
         Ok(n) => n,
         Err(error) => {
-            std::assert_matches!(error, Error::Unsupported);
+            if !matches!(error, Error::Unsupported) {
+                panic!("Expected `Error::Unsupported`, found {error:?}");
+            }
             return;
         }
     };
@@ -25,7 +27,9 @@ fn test_mac_addr() {
     let mut networks = match Networks::new() {
         Ok(n) => n,
         Err(error) => {
-            std::assert_matches!(error, Error::Unsupported);
+            if !matches!(error, Error::Unsupported) {
+                panic!("Expected `Error::Unsupported`, found {error:?}");
+            }
             return;
         }
     };

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -1,23 +1,27 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+#![cfg(feature = "user")]
+
 // This test is used to ensure that the users are not loaded by default.
 //
-// users.groupps()  multiple times doesn't return the same output https://github.com/GuillaumeGomez/sysinfo/issues/1233
+// Calling users.groups() multiple times doesn't return the same output https://github.com/GuillaumeGomez/sysinfo/issues/1233
 //
 // Example:
 // ---- test_users 1 stdout ----
 // user: Administrator group:[Group { inner: GroupInner { id: Gid(0), name: "Administrators" } }]
 // ---- test_users 2 stdout ----
 // user: Administrator group:[]
-#[cfg(feature = "user")]
 #[test]
 fn test_users() {
     use sysinfo::Users;
 
-    if !sysinfo::IS_SUPPORTED_SYSTEM {
-        return;
-    }
-    let mut users = Users::new();
+    let mut users = match Users::new() {
+        Ok(u) => u,
+        Err(error) => {
+            assert_matches!(error, Error::Unsupported);
+            return;
+        }
+    };
     assert_eq!(users.iter().count(), 0);
     users.refresh();
     assert!(users.iter().count() > 0);
@@ -28,15 +32,17 @@ fn test_users() {
 }
 
 // This test ensures that there are actually groups listed, in particular for Windows.
-#[cfg(feature = "user")]
 #[test]
 fn test_groups() {
     use sysinfo::Groups;
 
-    if !sysinfo::IS_SUPPORTED_SYSTEM {
-        return;
-    }
-    let mut groups = Groups::new();
+    let mut groups = match Groups::new() {
+        Ok(g) => g,
+        Err(error) => {
+            assert_matches!(error, Error::Unsupported);
+            return;
+        }
+    };
     groups.refresh();
     assert!(groups.list().len() > 1);
 }

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -18,7 +18,7 @@ fn test_users() {
     let mut users = match Users::new() {
         Ok(u) => u,
         Err(error) => {
-            assert_matches!(error, Error::Unsupported);
+            std::assert_matches!(error, Error::Unsupported);
             return;
         }
     };
@@ -39,7 +39,7 @@ fn test_groups() {
     let mut groups = match Groups::new() {
         Ok(g) => g,
         Err(error) => {
-            assert_matches!(error, Error::Unsupported);
+            std::assert_matches!(error, Error::Unsupported);
             return;
         }
     };

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -2,6 +2,8 @@
 
 #![cfg(feature = "user")]
 
+use sysinfo::{Error, Groups, Users};
+
 // This test is used to ensure that the users are not loaded by default.
 //
 // Calling users.groups() multiple times doesn't return the same output https://github.com/GuillaumeGomez/sysinfo/issues/1233
@@ -13,12 +15,12 @@
 // user: Administrator group:[]
 #[test]
 fn test_users() {
-    use sysinfo::Users;
-
     let mut users = match Users::new() {
         Ok(u) => u,
         Err(error) => {
-            std::assert_matches!(error, Error::Unsupported);
+            if !matches!(error, crate::Error::Unsupported) {
+                panic!("Expected `Error::Unsupported`, found {error:?}");
+            }
             return;
         }
     };
@@ -34,12 +36,12 @@ fn test_users() {
 // This test ensures that there are actually groups listed, in particular for Windows.
 #[test]
 fn test_groups() {
-    use sysinfo::Groups;
-
     let mut groups = match Groups::new() {
         Ok(g) => g,
         Err(error) => {
-            std::assert_matches!(error, Error::Unsupported);
+            if !matches!(error, crate::Error::Unsupported) {
+                panic!("Expected `Error::Unsupported`, found {error:?}");
+            }
             return;
         }
     };


### PR DESCRIPTION
Part of https://github.com/GuillaumeGomez/sysinfo/issues/1267.
Part of https://github.com/GuillaumeGomez/sysinfo/issues/1656.