### PR TITLE
NetBSD: fix disk I/O and process I/O statistics 

### DIFF
--- a/src/unix/bsd/netbsd/disk.rs
+++ b/src/unix/bsd/netbsd/disk.rs
@@ -223,7 +223,15 @@ impl GetValues for DiskInner {
 }
 
 fn same_name(dev_id: &[c_char], drive_name: &[c_char]) -> bool {
+    // NetBSD iostats returns device names without partition letters (e.g., "ld0")
+    // but mount points use full device names with partitions (e.g., "ld0a").
+    // We need to match by checking if dev_id starts with drive_name.
+
     for (c1, c2) in dev_id.iter().zip(drive_name.iter()) {
+        // Stop comparison at null terminator in drive_name
+        if *c2 == 0 {
+            return true;
+        }
         if c1 != c2 {
             return false;
         }
@@ -292,7 +300,7 @@ pub unsafe fn get_all_list(
 ) {
     let mut mnt_buf: *mut libc::statvfs = null_mut();
 
-    let count = unsafe { libc::getmntinfo(&mut mnt_buf, libc::MNT_WAIT) };
+    let count = unsafe { ffi::getmntinfo(&mut mnt_buf, libc::MNT_WAIT) };
     if count < 1 {
         return;
     }
@@ -347,10 +355,14 @@ pub unsafe fn get_all_list(
         if mount_point == "/boot/efi" {
             continue;
         }
-        let name = if mount_point == "/" {
-            OsString::from("root")
-        } else {
-            OsString::from(mount_point)
+
+        // Extract device name from f_mntfromname (e.g., "/dev/ld0a")
+        let name = match c_buf_to_utf8_str(&fs_info.f_mntfromname) {
+            Some(device_name) => OsString::from(device_name),
+            None => {
+                sysinfo_debug!("Cannot get disk device name, ignoring it.");
+                continue;
+            }
         };
 
         if let Some(disk) = container.iter_mut().find(|d| {

--- a/src/unix/bsd/netbsd/ffi.rs
+++ b/src/unix/bsd/netbsd/ffi.rs
@@ -2,7 +2,7 @@
 
 #![allow(non_camel_case_types, dead_code)]
 
-use libc::{c_char, c_int, c_ulong, c_void, kinfo_proc2, size_t};
+use libc::{c_char, c_int, c_long, c_ulong, c_void, kinfo_proc2, size_t};
 
 pub(crate) const SIDL: u64 = 1;
 pub(crate) const SACTIVE: u64 = 2;
@@ -228,4 +228,16 @@ unsafe extern "C" {
 #[link(name = "c")]
 unsafe extern "C" {
     pub(crate) fn err(status: c_int, fmt: *const c_char);
+
+    // The `#[link_name = "__getmntinfo13"]` on `getmntinfo` was accidentally
+    // dropped in libc 0.2.174 and restored by rust-lang/libc#5251.
+    // Can be removed once libc makes a new release.
+    #[link_name = "__getmntinfo13"]
+    pub(crate) fn getmntinfo(mntbufp: *mut *mut libc::statvfs, flags: c_int) -> c_int;
+
+    // Reads the user-preferred display block size (BLOCKSIZE env var, or the
+    // system default DEV_BSIZE = 512). Used to convert `struct rusage`
+    // block-op counts into bytes; matches the historical BSD convention
+    // (`time(1)`, `ps -o inblk`).
+    pub(crate) fn getbsize(headerlenp: *mut c_int, blocksizep: *mut c_long) -> *const c_char;
 }

--- a/src/unix/bsd/netbsd/process.rs
+++ b/src/unix/bsd/netbsd/process.rs
@@ -44,10 +44,10 @@ impl ProcessInner {
 
     pub(crate) fn disk_usage(&self) -> DiskUsage {
         DiskUsage {
-            written_bytes: 0,       // self.written_bytes.saturating_sub(self.old_written_bytes),
-            total_written_bytes: 0, // self.written_bytes,
-            read_bytes: 0,          // self.read_bytes.saturating_sub(self.old_read_bytes),
-            total_read_bytes: 0,    // self.read_bytes,
+            written_bytes: self.written_bytes.saturating_sub(self.old_written_bytes),
+            total_written_bytes: self.written_bytes,
+            read_bytes: self.read_bytes.saturating_sub(self.old_read_bytes),
+            total_read_bytes: self.read_bytes,
         }
     }
 
@@ -123,9 +123,9 @@ fn update_proc_info(
 
     if refresh_kind.disk_usage() {
         proc_.old_read_bytes = proc_.read_bytes;
-        proc_.read_bytes = kproc.p_uru_inblock as _;
+        proc_.read_bytes = kproc.p_uru_inblock.saturating_mul(system_info.block_size);
         proc_.old_written_bytes = proc_.written_bytes;
-        proc_.written_bytes = kproc.p_uru_oublock as _;
+        proc_.written_bytes = kproc.p_uru_oublock.saturating_mul(system_info.block_size);
     }
 
     if refresh_kind.cpu() {

--- a/src/unix/bsd/netbsd/system.rs
+++ b/src/unix/bsd/netbsd/system.rs
@@ -439,6 +439,8 @@ impl SystemInfo {
             }
 
             let mut block_size: libc::c_long = 0;
+            // `getbsize` isn't thread-safe because it returns a `static char*`. However
+            // we don't read from this `char*` so it's all fine.
             ffi::getbsize(std::ptr::null_mut(), &mut block_size);
             if block_size > 0 {
                 si.block_size = block_size as u64;

--- a/src/unix/bsd/netbsd/system.rs
+++ b/src/unix/bsd/netbsd/system.rs
@@ -392,6 +392,11 @@ pub(crate) struct SystemInfo {
     /// From NetBSD manual: "The kernel fixed-point scale factor". It's used when computing
     /// processes' CPU usage.
     pub(crate) fscale: f32,
+    /// NetBSD does not expose the block size per process, only the total
+    /// blocks in and out. We use the User-preferred display block size
+    /// `getbsize(3)` to convert `struct rusage` block-op counts to bytes
+    /// for per-process disk-usage reporting.
+    pub(crate) block_size: u64,
 }
 
 // This is needed because `kd: *mut libc::kvm_t` isn't thread-safe.
@@ -417,6 +422,7 @@ impl SystemInfo {
                 page_size: 0,
                 kd,
                 fscale: 0.,
+                block_size: 512,
             };
             let mut fscale: c_int = 0;
             if !get_sys_value(&[libc::CTL_KERN, libc::KERN_FSCALE], &mut fscale) || fscale < 0 {
@@ -430,6 +436,12 @@ impl SystemInfo {
                 sysinfo_debug!("failed to get page size, cannot retrieve memory information");
             } else {
                 si.page_size = page_size as _;
+            }
+
+            let mut block_size: libc::c_long = 0;
+            ffi::getbsize(std::ptr::null_mut(), &mut block_size);
+            if block_size > 0 {
+                si.block_size = block_size as u64;
             }
 
             si


### PR DESCRIPTION
Enable proper Disk / Process I/O statistics.

The Issue was discovered when trying to get `bottom` to work in NetBSD
- https://github.com/ClementTsang/bottom/issues/640#issuecomment-3925868116

> Note: AI assistance was used to discover the fixes as well as to test the fixes within a NetBSD environment.

Changes:
- Modify `same_name()` to use prefix matching, allowing partition names like `ld0a` to match device names like `ld0` from sysctl `HW_IOSTATS`.
- Convert block counts to bytes by multiplying by 512
- Return actual I/O values instead of hard-coded zeros
- Preserve delta calculations (current - old) for rates

Examples of stats now working in `bottom`
- <img width="514" height="110" alt="image" src="https://github.com/user-attachments/assets/8273cef8-75fc-42a3-88c7-828c13f4aac2" />
- <img width="598" height="192" alt="image" src="https://github.com/user-attachments/assets/d19a9974-2526-4b03-bcaa-696a3ac607c2" />

Tested on NetBSD 10.1 x86_64.

cc: @0323pin