### PR TITLE
Update outdated doc about `multithead` feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ loop {
 }
 ```
 
-By default, `sysinfo` uses multiple threads. However, this can increase the memory usage on some
-platforms (macOS for example). The behavior can be disabled by setting `default-features = false`
-in `Cargo.toml` (which disables the `multithread` cargo feature).
+With the `multithread` feature (which is not enabled by default), `sysinfo`
+uses multiple threads.
+However, this can increase the memory usage on some platforms (macOS for example).
 
 ### Good practice / Performance tips
 


### PR DESCRIPTION
Closes https://github.com/GuillaumeGomez/sysinfo/issues/1699

Do you want me to add a (hidden) code block that asserts the feature is out by default? I am not sure whether or how this is doable, but I can explore it if you want me to.