### PR TITLE
Unified component temperature api with GPU support

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -42,6 +42,7 @@ pid                : displays this example's PID
 brand              : displays CPU brand
 cpus               : displays CPUs state
 frequency          : displays CPU frequency
+cpu_temperature    : displays CPU temperature
 vendor_id          : displays CPU vendor id
 
 = GPU commands =
@@ -174,6 +175,10 @@ fn interpret_input(
                         Some(usage) => println!("  usage: {usage}%"),
                         None => println!("  usage: N/A"),
                     }
+                    match gpu.temperature() {
+                        Some(temp) => println!("  temperature: {temp}C"),
+                        None => println!("  temperature: N/A"),
+                    }
                     if let (Some(used), Some(total)) = (gpu.used_memory(), gpu.total_memory()) {
                         println!("  memory: {}/{} KB", used / 1_000, total / 1_000);
                     } else {
@@ -220,6 +225,23 @@ fn interpret_input(
             Ok(sys) => {
                 for cpu in sys.cpus() {
                     println!("[{}] {} MHz", cpu.name(), cpu.frequency());
+                }
+            }
+            Err(error) => {
+                println!("System information cannot be retrieved: {error}");
+            }
+        },
+        "cpu_temperature" => match sys {
+            Ok(sys) => {
+                for cpu in sys.cpus() {
+                    print!("[{}] {}C", cpu.name(), cpu.temperature());
+                    if let Some(max) = cpu.max() {
+                        print!(" (max: {max}C)");
+                    }
+                    if let Some(critical) = cpu.critical() {
+                        print!(" (critical: {critical}C)");
+                    }
+                    println!();
                 }
             }
             Err(error) => {
@@ -375,6 +397,16 @@ fn interpret_input(
             Ok(disks) => {
                 for disk in disks {
                     println!("{disk:?}");
+                    if let Some(temp) = disk.temperature() {
+                        print!("  temperature: {temp}C");
+                        if let Some(max) = disk.max() {
+                            print!(" (max: {max}C)");
+                        }
+                        if let Some(critical) = disk.critical() {
+                            print!(" (critical: {critical}C)");
+                        }
+                        println!();
+                    }
                 }
             }
             Err(error) => {
@@ -484,7 +516,17 @@ fn interpret_input(
             );
         }
         "motherboard" => match Motherboard::new() {
-            Ok(m) => println!("{m:#?}"),
+            Ok(m) => {
+                println!("{m:#?}");
+                let temps = m.temperatures();
+                if !temps.is_empty() {
+                    print!("  temperatures:");
+                    for t in &temps {
+                        print!(" {}C", t);
+                    }
+                    println!();
+                }
+            }
             Err(error) => println!("Cannot retrieve motherboard information: {error:?}"),
         },
         "product" => {

--- a/src/common/disk.rs
+++ b/src/common/disk.rs
@@ -189,6 +189,30 @@ impl Disk {
     pub fn usage(&self) -> DiskUsage {
         self.inner.usage()
     }
+
+    /// Returns the disk's temperature in degrees Celsius.
+    ///
+    /// Currently only implemented on Linux (NVMe drives).
+    /// Returns `None` if the temperature information is not available.
+    pub fn temperature(&self) -> Option<f32> {
+        self.inner.temperature()
+    }
+
+    /// Returns the highest temperature (in degrees Celsius) recorded for this disk.
+    ///
+    /// Currently only implemented on Linux (NVMe drives).
+    /// Returns `None` if this information isn't available.
+    pub fn max(&self) -> Option<f32> {
+        self.inner.max()
+    }
+
+    /// Returns the critical temperature threshold (in degrees Celsius) for this disk.
+    ///
+    /// Currently only implemented on Linux (NVMe drives).
+    /// Returns `None` if this information isn't available.
+    pub fn critical(&self) -> Option<f32> {
+        self.inner.critical()
+    }
 }
 
 /// Disks interface.
@@ -411,6 +435,7 @@ impl fmt::Display for DiskKind {
 /// * `kind` is about refreshing the [`Disk::kind`] information.
 /// * `storage` is about refreshing the [`Disk::available_space`] and [`Disk::total_space`] information.
 /// * `io_usage` is about refreshing the [`Disk::usage`] information.
+/// * `temperature` is about refreshing the [`Disk::temperature`] information.
 ///
 /// ```no_run
 /// use sysinfo::{Disks, DiskRefreshKind};
@@ -426,6 +451,7 @@ pub struct DiskRefreshKind {
     kind: bool,
     storage: bool,
     io_usage: bool,
+    temperature: bool,
 }
 
 impl DiskRefreshKind {
@@ -439,6 +465,7 @@ impl DiskRefreshKind {
     /// assert_eq!(r.kind(), false);
     /// assert_eq!(r.storage(), false);
     /// assert_eq!(r.io_usage(), false);
+    /// assert_eq!(r.temperature(), false);
     /// ```
     pub fn nothing() -> Self {
         Self::default()
@@ -454,18 +481,26 @@ impl DiskRefreshKind {
     /// assert_eq!(r.kind(), true);
     /// assert_eq!(r.storage(), true);
     /// assert_eq!(r.io_usage(), true);
+    /// assert_eq!(r.temperature(), true);
     /// ```
     pub fn everything() -> Self {
         Self {
             kind: true,
             storage: true,
             io_usage: true,
+            temperature: true,
         }
     }
 
     impl_get_set!(DiskRefreshKind, kind, with_kind, without_kind);
     impl_get_set!(DiskRefreshKind, storage, with_storage, without_storage);
     impl_get_set!(DiskRefreshKind, io_usage, with_io_usage, without_io_usage);
+    impl_get_set!(
+        DiskRefreshKind,
+        temperature,
+        with_temperature,
+        without_temperature
+    );
 }
 
 #[cfg(test)]

--- a/src/common/gpu.rs
+++ b/src/common/gpu.rs
@@ -166,7 +166,7 @@ impl core::str::FromStr for PCI {
             let Some(value) = iter.next() else {
                 return Err(missing_msg);
             };
-            value.parse::<u32>().map_err(|_| invalid_msg)
+            u32::from_str_radix(value, 16).map_err(|_| invalid_msg)
         }
 
         let mut iter = s.split(':');
@@ -281,5 +281,51 @@ impl Gpu {
     /// Returns `None` if the information cannot be retrieved.
     pub fn used_memory(&self) -> Option<u64> {
         self.inner.used_memory()
+    }
+
+    /// Returns the temperature of this GPU in degrees Celsius.
+    ///
+    /// On Linux, this information is only available for NVIDIA and AMD GPUs.
+    ///
+    /// On macOS and Windows, availability depends on GPU driver support.
+    ///
+    /// Returns `None` if the information cannot be retrieved.
+    pub fn temperature(&self) -> Option<f32> {
+        self.inner.temperature()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PCI;
+
+    #[test]
+    fn test_pci_from_str() {
+        // sysfs BDF notation (e.g. `/sys/class/drm/*/device`)
+        let pci: PCI = "0000:c1:00.0".parse().unwrap();
+        assert_eq!(
+            pci,
+            PCI {
+                domain: 0,
+                bus: 0xc1,
+                device: 0,
+                function: 0,
+            }
+        );
+        assert_eq!(pci.to_string(), "0000:c1:00.0");
+
+        // NVML's `busId` format (8-digit hex domain)
+        let pci: PCI = "00000000:65:00.0".parse().unwrap();
+        assert_eq!(
+            pci,
+            PCI {
+                domain: 0,
+                bus: 0x65,
+                device: 0,
+                function: 0,
+            }
+        );
+
+        assert!("0000:01:00".parse::<PCI>().is_err());
     }
 }

--- a/src/common/system.rs
+++ b/src/common/system.rs
@@ -213,6 +213,22 @@ impl System {
         self.refresh_cpu_specifics(CpuRefreshKind::nothing().with_frequency())
     }
 
+    /// Refreshes CPUs temperature.
+    ///
+    /// Calling this method is the same as calling
+    /// `system.refresh_cpu_specifics(CpuRefreshKind::nothing().with_temperature())`.
+    ///
+    /// ```no_run
+    /// use sysinfo::System;
+    ///
+    /// if let Ok(mut s) = System::new_all() {
+    ///     s.refresh_cpu_temperature();
+    /// }
+    /// ```
+    pub fn refresh_cpu_temperature(&mut self) {
+        self.refresh_cpu_specifics(CpuRefreshKind::nothing().with_temperature())
+    }
+
     /// Refreshes the list of CPU.
     ///
     /// Normally, this should almost never be needed as it's pretty rare for a computer
@@ -2449,7 +2465,7 @@ pub enum ProcessesToUpdate<'a> {
 /// information from `/proc/<pid>/` as well as all the information from `/proc/<pid>/task/<tid>/`
 /// folders. This makes the refresh mechanism a lot slower depending on the number of tasks
 /// each process has.
-///  
+///
 /// If you don't care about tasks information, use `ProcessRefreshKind::everything().without_tasks()`
 /// as much as possible.
 ///
@@ -2623,6 +2639,7 @@ It will retrieve the following information:
 pub struct CpuRefreshKind {
     usage: bool,
     frequency: bool,
+    temperature: bool,
 }
 
 impl CpuRefreshKind {
@@ -2635,6 +2652,7 @@ impl CpuRefreshKind {
     ///
     /// assert_eq!(r.frequency(), false);
     /// assert_eq!(r.usage(), false);
+    /// assert_eq!(r.temperature(), false);
     /// ```
     pub fn nothing() -> Self {
         Self::default()
@@ -2649,16 +2667,24 @@ impl CpuRefreshKind {
     ///
     /// assert_eq!(r.frequency(), true);
     /// assert_eq!(r.usage(), true);
+    /// assert_eq!(r.temperature(), true);
     /// ```
     pub fn everything() -> Self {
         Self {
             usage: true,
             frequency: true,
+            temperature: true,
         }
     }
 
     impl_get_set!(CpuRefreshKind, usage, with_usage, without_usage);
     impl_get_set!(CpuRefreshKind, frequency, with_frequency, without_frequency);
+    impl_get_set!(
+        CpuRefreshKind,
+        temperature,
+        with_temperature,
+        without_temperature
+    );
 }
 
 /// Used to determine which memory you want to refresh specifically.
@@ -2962,6 +2988,41 @@ impl Cpu {
     /// ```
     pub fn frequency(&self) -> u64 {
         self.inner.frequency()
+    }
+
+    /// Returns the CPU's temperature in degrees Celsius.
+    ///
+    /// This is currently only implemented on Linux.
+    ///
+    /// ```no_run
+    /// use sysinfo::{System, RefreshKind, CpuRefreshKind};
+    ///
+    /// if let Ok(s) = System::new_with_specifics(
+    ///     RefreshKind::nothing().with_cpu(CpuRefreshKind::everything()),
+    /// ) {
+    ///     for cpu in s.cpus() {
+    ///         println!("{}", cpu.temperature());
+    ///     }
+    /// }
+    /// ```
+    pub fn temperature(&self) -> f32 {
+        self.inner.temperature()
+    }
+
+    /// Returns the highest temperature (in degrees Celsius) recorded for this CPU.
+    ///
+    /// This is currently only implemented on Linux.
+    /// Returns `None` if this information isn't available.
+    pub fn max(&self) -> Option<f32> {
+        self.inner.max()
+    }
+
+    /// Returns the critical temperature threshold (in degrees Celsius) for this CPU.
+    ///
+    /// This is currently only implemented on Linux.
+    /// Returns `None` if this information isn't available.
+    pub fn critical(&self) -> Option<f32> {
+        self.inner.critical()
     }
 }
 

--- a/src/common/system.rs
+++ b/src/common/system.rs
@@ -1086,6 +1086,14 @@ impl Motherboard {
     pub fn asset_tag(&self) -> Option<String> {
         self.inner.asset_tag()
     }
+
+    /// Returns the motherboard's temperature sensors in degrees Celsius.
+    ///
+    /// Currently only implemented on Linux.
+    /// Returns an empty `Vec` if the information is not available.
+    pub fn temperatures(&self) -> Vec<f32> {
+        self.inner.temperatures()
+    }
 }
 
 /// This type allows to retrieve product-related information.

--- a/src/unix/apple/cpu.rs
+++ b/src/unix/apple/cpu.rs
@@ -191,6 +191,18 @@ impl CpuInner {
         self.usage.frequency
     }
 
+    pub(crate) fn temperature(&self) -> f32 {
+        0.0
+    }
+
+    pub(crate) fn max(&self) -> Option<f32> {
+        None
+    }
+
+    pub(crate) fn critical(&self) -> Option<f32> {
+        None
+    }
+
     pub(crate) fn vendor_id(&self) -> &str {
         &self.vendor_id
     }

--- a/src/unix/apple/disk.rs
+++ b/src/unix/apple/disk.rs
@@ -35,6 +35,9 @@ pub(crate) struct DiskInner {
     pub(crate) written_bytes: u64,
     pub(crate) read_bytes: u64,
     updated: bool,
+    temperature: Option<f32>,
+    temperature_max: Option<f32>,
+    temperature_critical: Option<f32>,
     uuid: OsString,
 }
 
@@ -58,6 +61,9 @@ impl Default for DiskInner {
             written_bytes: 0,
             read_bytes: 0,
             updated: false,
+            temperature: None,
+            temperature_max: None,
+            temperature_critical: None,
             uuid: OsString::new(),
         }
     }
@@ -147,6 +153,18 @@ impl DiskInner {
             written_bytes: self.written_bytes.saturating_sub(self.old_written_bytes),
             total_written_bytes: self.written_bytes,
         }
+    }
+
+    pub(crate) fn temperature(&self) -> Option<f32> {
+        self.temperature
+    }
+
+    pub(crate) fn max(&self) -> Option<f32> {
+        self.temperature_max
+    }
+
+    pub(crate) fn critical(&self) -> Option<f32> {
+        self.temperature_critical
     }
 
     fn refresh_kind(&mut self, refresh_kind: DiskRefreshKind) {
@@ -529,6 +547,9 @@ unsafe fn new_disk(
         old_written_bytes: 0,
         updated: true,
         uuid,
+        temperature: None,
+        temperature_max: None,
+        temperature_critical: None,
     };
 
     disk.refresh_kind(refresh_kind);

--- a/src/unix/apple/gpu.rs
+++ b/src/unix/apple/gpu.rs
@@ -49,6 +49,9 @@ impl GpusInner {
             let class_code_key = CFString::from_str("class-code");
             let pcidebug_key = CFString::from_str("pcidebug");
             let perf_key = CFString::from_str("PerformanceStatistics");
+            let usage_percent_key = CFString::from_str("Device Utilization %");
+            let usage_key = CFString::from_str("Device Utilization");
+            let temperature_key = CFString::from_str("Temperature(C)");
 
             while let Some(accelerator) = IOReleaser::new(IOIteratorNext(iterator.inner())) {
                 let mut device = 0;
@@ -99,6 +102,7 @@ impl GpusInner {
                                 model: None,
                                 vendor: None,
                                 usage: None,
+                                temperature: None,
                                 updated: true,
                             },
                         });
@@ -149,13 +153,18 @@ impl GpusInner {
                     0,
                 ) && let Some(usage_dict) = usage.downcast_ref::<CFDictionary>()
                     && let usage_dict = usage_dict.cast_unchecked::<CFString, CFNumber>()
-                    && let Some(usage) = usage_dict
-                        .get(&CFString::from_str("Device Utilization %"))
-                        .or_else(|| usage_dict.get(&CFString::from_str("Device Utilization")))
-                    && let Ok(usage) = usage.downcast::<CFNumber>()
-                    && let Some(usage) = usage.as_i64()
                 {
-                    gpu.usage = Some(usage as f32);
+                    if let Some(usage) = usage_dict
+                        .get(&usage_percent_key)
+                        .or_else(|| usage_dict.get(&usage_key))
+                        .and_then(|usage| usage.as_i64())
+                    {
+                        gpu.usage = Some(usage as f32);
+                    }
+                    gpu.temperature = usage_dict
+                        .get(&temperature_key)
+                        .and_then(|temperature| temperature.as_f32())
+                        .filter(|temperature| temperature.is_finite() && *temperature > 0.0);
                 }
             }
         }
@@ -185,6 +194,7 @@ pub(crate) struct GpuInner {
     vendor: Option<String>,
     model: Option<String>,
     usage: Option<f32>,
+    temperature: Option<f32>,
     pub(crate) updated: bool,
 }
 
@@ -206,5 +216,8 @@ impl GpuInner {
     }
     pub(crate) fn used_memory(&self) -> Option<u64> {
         None
+    }
+    pub(crate) fn temperature(&self) -> Option<f32> {
+        self.temperature
     }
 }

--- a/src/unix/apple/motherboard.rs
+++ b/src/unix/apple/motherboard.rs
@@ -50,4 +50,8 @@ impl MotherboardInner {
     pub(crate) fn asset_tag(&self) -> Option<String> {
         None
     }
+
+    pub(crate) fn temperatures(&self) -> Vec<f32> {
+        Vec::new()
+    }
 }

--- a/src/unix/bsd/freebsd/cpu.rs
+++ b/src/unix/bsd/freebsd/cpu.rs
@@ -142,6 +142,18 @@ impl CpuInner {
         self.frequency
     }
 
+    pub(crate) fn temperature(&self) -> f32 {
+        0.0
+    }
+
+    pub(crate) fn max(&self) -> Option<f32> {
+        None
+    }
+
+    pub(crate) fn critical(&self) -> Option<f32> {
+        None
+    }
+
     pub(crate) fn vendor_id(&self) -> &str {
         &self.vendor_id
     }

--- a/src/unix/bsd/freebsd/disk.rs
+++ b/src/unix/bsd/freebsd/disk.rs
@@ -33,6 +33,9 @@ pub(crate) struct DiskInner {
     written_bytes: u64,
     old_written_bytes: u64,
     updated: bool,
+    temperature: Option<f32>,
+    temperature_max: Option<f32>,
+    temperature_critical: Option<f32>,
 }
 
 #[cfg(test)]
@@ -53,6 +56,9 @@ impl Default for DiskInner {
             written_bytes: 0,
             old_written_bytes: 0,
             updated: false,
+            temperature: None,
+            temperature_max: None,
+            temperature_critical: None,
         }
     }
 }
@@ -102,6 +108,18 @@ impl DiskInner {
             written_bytes: self.written_bytes.saturating_sub(self.old_written_bytes),
             total_written_bytes: self.written_bytes,
         }
+    }
+
+    pub(crate) fn temperature(&self) -> Option<f32> {
+        self.temperature
+    }
+
+    pub(crate) fn max(&self) -> Option<f32> {
+        self.temperature_max
+    }
+
+    pub(crate) fn critical(&self) -> Option<f32> {
+        self.temperature_critical
     }
 }
 
@@ -440,6 +458,9 @@ pub unsafe fn get_all_list(
                 written_bytes: 0,
                 old_written_bytes: 0,
                 updated: true,
+                temperature: None,
+                temperature_max: None,
+                temperature_critical: None,
             };
             // I/O usage is updated for all disks at once at the end.
             refresh_disk(&mut disk, refresh_kind.without_io_usage());

--- a/src/unix/bsd/freebsd/motherboard.rs
+++ b/src/unix/bsd/freebsd/motherboard.rs
@@ -29,4 +29,8 @@ impl MotherboardInner {
     pub(crate) fn serial_number(&self) -> Option<String> {
         get_kenv_var(b"smbios.planar.serial\0")
     }
+
+    pub(crate) fn temperatures(&self) -> Vec<f32> {
+        Vec::new()
+    }
 }

--- a/src/unix/bsd/netbsd/cpu.rs
+++ b/src/unix/bsd/netbsd/cpu.rs
@@ -136,6 +136,18 @@ impl CpuInner {
         self.frequency
     }
 
+    pub(crate) fn temperature(&self) -> f32 {
+        0.0
+    }
+
+    pub(crate) fn max(&self) -> Option<f32> {
+        None
+    }
+
+    pub(crate) fn critical(&self) -> Option<f32> {
+        None
+    }
+
     pub(crate) fn vendor_id(&self) -> &str {
         &self.vendor_id
     }

--- a/src/unix/bsd/netbsd/disk.rs
+++ b/src/unix/bsd/netbsd/disk.rs
@@ -27,6 +27,9 @@ pub(crate) struct DiskInner {
     written_bytes: u64,
     old_written_bytes: u64,
     updated: bool,
+    temperature: Option<f32>,
+    temperature_max: Option<f32>,
+    temperature_critical: Option<f32>,
 }
 
 #[cfg(test)]
@@ -47,6 +50,9 @@ impl Default for DiskInner {
             written_bytes: 0,
             old_written_bytes: 0,
             updated: false,
+            temperature: None,
+            temperature_max: None,
+            temperature_critical: None,
         }
     }
 }
@@ -96,6 +102,18 @@ impl DiskInner {
             written_bytes: self.written_bytes.saturating_sub(self.old_written_bytes),
             total_written_bytes: self.written_bytes,
         }
+    }
+
+    pub(crate) fn temperature(&self) -> Option<f32> {
+        self.temperature
+    }
+
+    pub(crate) fn max(&self) -> Option<f32> {
+        self.temperature_max
+    }
+
+    pub(crate) fn critical(&self) -> Option<f32> {
+        self.temperature_critical
     }
 
     fn update_old(&mut self) {
@@ -401,6 +419,9 @@ pub unsafe fn get_all_list(
                 written_bytes: 0,
                 old_written_bytes: 0,
                 updated: true,
+                temperature: None,
+                temperature_max: None,
+                temperature_critical: None,
             };
             // I/O usage is updated for all disks at once at the end.
             refresh_disk(&mut disk, refresh_kind.without_io_usage());

--- a/src/unix/bsd/netbsd/motherboard.rs
+++ b/src/unix/bsd/netbsd/motherboard.rs
@@ -35,4 +35,8 @@ impl MotherboardInner {
         // FIXME: Wrong mib
         get_sys_value_str_by_name(b"machdep.dmi.board-serial\0")
     }
+
+    pub(crate) fn temperatures(&self) -> Vec<f32> {
+        Vec::new()
+    }
 }

--- a/src/unix/linux/cpu.rs
+++ b/src/unix/linux/cpu.rs
@@ -3,8 +3,9 @@
 #![allow(clippy::too_many_arguments)]
 
 use std::collections::{HashMap, HashSet};
-use std::fs::File;
+use std::fs::{File, read_dir};
 use std::io::{BufRead, BufReader, Read};
+use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use crate::sys::utils::to_u64;
@@ -22,6 +23,8 @@ pub(crate) struct CpusWrapper {
     got_cpu_frequency: bool,
     /// This field is needed to prevent updating when not enough time passed since last update.
     last_update: Option<Instant>,
+    /// Resolved once when `self.cpus` is first populated.
+    cpu_temperature_sensor: Option<CpuTemperatureSensor>,
 }
 
 impl CpusWrapper {
@@ -31,6 +34,7 @@ impl CpusWrapper {
             cpus: Vec::with_capacity(4),
             got_cpu_frequency: false,
             last_update: None,
+            cpu_temperature_sensor: None,
         }
     }
 
@@ -179,6 +183,18 @@ impl CpusWrapper {
                 .for_each(|(pos, proc_)| proc_.inner.frequency = get_cpu_frequency(pos));
 
             self.got_cpu_frequency = true;
+        }
+
+        if first || refresh_kind.temperature() {
+            if first {
+                self.cpu_temperature_sensor =
+                    find_cpu_temperature_sensor(Path::new("/sys/class/hwmon"));
+            }
+            if let Some(sensor) = &self.cpu_temperature_sensor {
+                for cpu in &mut self.cpus {
+                    cpu.inner.update_temperature(sensor);
+                }
+            }
         }
     }
 
@@ -366,6 +382,9 @@ pub(crate) struct CpuInner {
     usage: CpuUsage,
     pub(crate) name: String,
     pub(crate) frequency: u64,
+    pub(crate) temperature: f32,
+    pub(crate) temperature_max: Option<f32>,
+    pub(crate) temperature_critical: Option<f32>,
     pub(crate) vendor_id: String,
     pub(crate) brand: String,
 }
@@ -393,6 +412,9 @@ impl CpuInner {
             ),
             name: name.to_owned(),
             frequency,
+            temperature: 0.0,
+            temperature_max: None,
+            temperature_critical: None,
             vendor_id,
             brand,
         }
@@ -429,12 +451,37 @@ impl CpuInner {
         self.frequency
     }
 
+    /// Returns the CPU temperature in degrees Celsius.
+    pub(crate) fn temperature(&self) -> f32 {
+        self.temperature
+    }
+
+    /// Returns the highest temperature (in degrees Celsius) recorded for this CPU.
+    pub(crate) fn max(&self) -> Option<f32> {
+        self.temperature_max
+    }
+
+    /// Returns the critical temperature threshold (in degrees Celsius) for this CPU, if known.
+    pub(crate) fn critical(&self) -> Option<f32> {
+        self.temperature_critical
+    }
+
     pub(crate) fn vendor_id(&self) -> &str {
         &self.vendor_id
     }
 
     pub(crate) fn brand(&self) -> &str {
         &self.brand
+    }
+
+    fn update_temperature(&mut self, sensor: &CpuTemperatureSensor) {
+        let Some(current) = read_temperature_celsius(&sensor.input) else {
+            return;
+        };
+        self.temperature = current;
+        self.temperature_max = read_temperature_celsius(&sensor.highest)
+            .or_else(|| Some(self.temperature_max.unwrap_or(current).max(current)));
+        self.temperature_critical = sensor.critical;
     }
 }
 
@@ -472,6 +519,93 @@ pub(crate) fn get_cpu_frequency(cpu_core_index: usize) -> u64 {
         .and_then(|val| val.replace("MHz", "").trim().parse::<f64>().ok())
         .map(|speed| speed as u64)
         .unwrap_or_default()
+}
+
+/// Names of the `hwmon` drivers which expose **CPU** temperature sensors, in order of preference
+const CPU_HWMON_DRIVERS: &[&str] = &["coretemp", "k10temp", "zenpower", "cpu_thermal", "acpitz"];
+/// Labels of a sensor reporting a whole-package temperature, in order of preference.
+const CPU_PACKAGE_TEMP_LABELS: &[&str] = &["Package id 0", "Tctl", "Tdie"];
+
+fn read_line(path: &Path) -> Option<String> {
+    let mut buf = String::with_capacity(32);
+    File::open(path).ok()?.read_to_string(&mut buf).ok()?;
+    let len = buf.trim_end().len();
+    buf.truncate(len);
+    Some(buf)
+}
+
+/// Reads a `tempN_input`/`tempN_highest` sysfs file and converts it to Celsius.
+fn read_temperature_celsius(path: &Path) -> Option<f32> {
+    let mut buf = [0u8; 32];
+    let n = File::open(path).ok()?.read(&mut buf).ok()?;
+    std::str::from_utf8(&buf[..n])
+        .ok()?
+        .trim()
+        .parse::<i32>()
+        .ok()
+        .map(|milli_celsius| milli_celsius as f32 / 1000.0)
+}
+
+/// The sysfs files backing the CPU's temperature.
+#[derive(Clone, Debug, PartialEq)]
+struct CpuTemperatureSensor {
+    input: PathBuf,
+    /// May not exist, in which case `update_temperature` falls back to a running maximum.
+    highest: PathBuf,
+    critical: Option<f32>,
+}
+
+fn find_cpu_temperature_sensor(hwmon_root: &Path) -> Option<CpuTemperatureSensor> {
+    let hwmon_dir = read_dir(hwmon_root)
+        .ok()?
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            let name = read_line(&path.join("name"))?;
+            let priority = CPU_HWMON_DRIVERS
+                .iter()
+                .position(|&driver| driver == name)?;
+            Some((priority, path))
+        })
+        .min_by_key(|(priority, _)| *priority)
+        .map(|(_, path)| path)?;
+
+    let mut sensors: Vec<(u32, Option<String>, CpuTemperatureSensor)> = read_dir(&hwmon_dir)
+        .ok()?
+        .flatten()
+        .filter_map(|entry| {
+            let input = entry.path();
+            let id = input
+                .file_name()?
+                .to_str()?
+                .strip_prefix("temp")?
+                .strip_suffix("_input")?
+                .parse::<u32>()
+                .ok()?;
+            let label = read_line(&hwmon_dir.join(format!("temp{id}_label")));
+            let critical = read_temperature_celsius(&hwmon_dir.join(format!("temp{id}_crit")));
+            Some((
+                id,
+                label,
+                CpuTemperatureSensor {
+                    input,
+                    highest: hwmon_dir.join(format!("temp{id}_highest")),
+                    critical,
+                },
+            ))
+        })
+        .collect();
+    sensors.sort_by_key(|(id, ..)| *id);
+
+    CPU_PACKAGE_TEMP_LABELS
+        .iter()
+        .find_map(|&wanted| {
+            sensors
+                .iter()
+                .find(|(_, label, _)| label.as_deref() == Some(wanted))
+        })
+        .or_else(|| sensors.first())
+        .map(|(_, _, sensor)| sensor.clone())
 }
 
 #[allow(unused_assignments)]
@@ -971,7 +1105,7 @@ BogoMIPS        : 38.40
 processor       : 7
 BogoMIPS        : 38.40
 
-Features        : swp half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt 
+Features        : swp half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt
 CPU implementer : 0x41
 CPU architecture: 7
 CPU variant     : 0x0 & 0x3

--- a/src/unix/linux/disk.rs
+++ b/src/unix/linux/disk.rs
@@ -49,6 +49,9 @@ pub(crate) struct DiskInner {
     written_bytes: u64,
     read_bytes: u64,
     updated: bool,
+    temperature: Option<f32>,
+    temperature_max: Option<f32>,
+    temperature_critical: Option<f32>,
 }
 
 #[cfg(test)]
@@ -69,6 +72,9 @@ impl Default for DiskInner {
             written_bytes: 0,
             read_bytes: 0,
             updated: false,
+            temperature: None,
+            temperature_max: None,
+            temperature_critical: None,
         }
     }
 }
@@ -149,6 +155,13 @@ impl DiskInner {
             }
         }
 
+        if refresh_kind.temperature() {
+            let (temp, max, critical) = get_disk_temperature(&self.device_name);
+            self.temperature = temp;
+            self.temperature_max = max;
+            self.temperature_critical = critical;
+        }
+
         true
     }
 
@@ -159,6 +172,18 @@ impl DiskInner {
             written_bytes: self.written_bytes.saturating_sub(self.old_written_bytes),
             total_written_bytes: self.written_bytes,
         }
+    }
+
+    pub(crate) fn temperature(&self) -> Option<f32> {
+        self.temperature
+    }
+
+    pub(crate) fn max(&self) -> Option<f32> {
+        self.temperature_max
+    }
+
+    pub(crate) fn critical(&self) -> Option<f32> {
+        self.temperature_critical
     }
 }
 
@@ -279,6 +304,9 @@ fn new_disk(
             read_bytes: 0,
             written_bytes: 0,
             updated: true,
+            temperature: None,
+            temperature_max: None,
+            temperature_critical: None,
         },
     };
     disk.inner
@@ -531,6 +559,69 @@ fn disk_stats_inner(content: &str) -> HashMap<String, DiskStat> {
         }
     }
     data
+}
+
+/// Reads a `tempN_input` sysfs file and converts it to Celsius.
+fn read_temperature_celsius(path: &Path) -> Option<f32> {
+    let s = std::fs::read_to_string(path).ok()?;
+    let milli = s.trim().parse::<i32>().ok()?;
+    Some(milli as f32 / 1000.0)
+}
+
+/// Strips the partition suffix from a device name (e.g. `nvme0n1p1` → `nvme0n1`, `sda1` → `sda`).
+fn strip_partition_suffix(name: &str) -> &str {
+    // NVMe: nvme0n1p1 → nvme0n1
+    if let Some(pos) = name.rfind('p')
+        && pos > 0
+        && name[pos + 1..].chars().all(|c| c.is_ascii_digit())
+    {
+        return &name[..pos];
+    }
+    // Other: sda1 → sda, vda1 → vda
+    let trimmed = name.trim_end_matches(|c: char| c.is_ascii_digit());
+    if trimmed.is_empty() { name } else { trimmed }
+}
+
+fn get_disk_temperature(device_name: &OsStr) -> (Option<f32>, Option<f32>, Option<f32>) {
+    let name = match device_name.to_str() {
+        Some(n) => n.strip_prefix("/dev/").unwrap_or(n),
+        None => return (None, None, None),
+    };
+
+    let read_all = |base: &str| -> (Option<f32>, Option<f32>, Option<f32>) {
+        let device_dir = Path::new("/sys/block").join(base).join("device");
+        // NVMe drives expose temperature under device/hwmonN/.
+        let dir = std::fs::read_dir(&device_dir)
+            .ok()
+            .and_then(|entries| {
+                entries.flatten().map(|e| e.path()).find(|p| {
+                    p.is_dir()
+                        && p.file_name()
+                            .and_then(|n| n.to_str())
+                            .map(|n| n.starts_with("hwmon"))
+                            .unwrap_or(false)
+                })
+            })
+            .unwrap_or(device_dir);
+        let temp = read_temperature_celsius(&dir.join("temp1_input"));
+        let max = read_temperature_celsius(&dir.join("temp1_max"));
+        let critical = read_temperature_celsius(&dir.join("temp1_crit"));
+        (temp, max, critical)
+    };
+
+    // Try the full name first (for non-partitioned devices).
+    let (temp, max, critical) = read_all(name);
+    if temp.is_some() {
+        return (temp, max, critical);
+    }
+
+    // Try the base device name (strip partition suffix).
+    let base = strip_partition_suffix(name);
+    if base != name {
+        return read_all(base);
+    }
+
+    (None, None, None)
 }
 
 #[cfg(test)]

--- a/src/unix/linux/gpu.rs
+++ b/src/unix/linux/gpu.rs
@@ -36,6 +36,7 @@ pub(crate) struct GpuInner {
     total_memory: Option<u64>,
     used_memory: Option<u64>,
     usage: Option<f32>,
+    temperature: Option<f32>,
     model: Option<String>,
     vendor: String,
     pci: PCI,
@@ -48,6 +49,7 @@ impl GpuInner {
             total_memory: None,
             used_memory: None,
             usage: None,
+            temperature: None,
             model: model.cloned(),
             vendor: vendor.to_owned(),
             pci,
@@ -72,6 +74,9 @@ impl GpuInner {
     }
     pub(crate) fn used_memory(&self) -> Option<u64> {
         self.used_memory
+    }
+    pub(crate) fn temperature(&self) -> Option<f32> {
+        self.temperature
     }
 }
 
@@ -298,6 +303,15 @@ fn get_amd_info(gpu: &mut GpuInner, buffer: &mut String, path: &Path) {
     if read_file(path.join("mem_info_vram_total"), buffer).is_ok() {
         gpu.total_memory = buffer.trim().parse::<u64>().ok();
     }
+    gpu.temperature = read_dir(path.join("hwmon"))
+        .ok()
+        .and_then(|dir| {
+            dir.flatten().find_map(|entry| {
+                read_file(entry.path().join("temp1_input"), buffer).ok()?;
+                buffer.trim().parse::<f32>().ok()
+            })
+        })
+        .map(|milli_c| milli_c / 1_000.0);
     gpu.updated = true;
 }
 
@@ -331,6 +345,7 @@ fn convert_to_str(data: &[libc::c_char]) -> Option<Cow<'_, str>> {
 mod nvidia {
     use super::*;
     use libc::{c_char, c_int, c_uint, c_ulonglong, c_void};
+    use std::ffi::CStr;
     use std::mem::MaybeUninit;
     use std::ptr::null_mut;
 
@@ -372,11 +387,14 @@ mod nvidia {
         unsafe extern "C" fn(NvmlDeviceHandle, *mut NvmlUtilization) -> NvmlReturn;
     type NvmlDeviceGetMemoryInfoFn =
         unsafe extern "C" fn(NvmlDeviceHandle, *mut NvmlMemory) -> NvmlReturn;
+    type NvmlDeviceGetTemperatureFn =
+        unsafe extern "C" fn(NvmlDeviceHandle, c_uint, *mut c_uint) -> NvmlReturn;
     type NvmlDeviceGetPciInfo =
         unsafe extern "C" fn(NvmlDeviceHandle, *mut NvmlPciInfo) -> NvmlReturn;
 
     const NVML_SUCCESS: NvmlReturn = 0;
     const NVML_DEVICE_NAME_V2_BUFFER_SIZE: usize = 96;
+    const NVML_TEMPERATURE_GPU: c_uint = 0;
 
     pub(crate) struct NvmlLib {
         lib_handle: *mut c_void,
@@ -387,25 +405,31 @@ mod nvidia {
         get_name: NvmlDeviceGetNameFn,
         get_utilization: NvmlDeviceGetUtilizationRatesFn,
         get_memory_info: NvmlDeviceGetMemoryInfoFn,
+        get_temperature: NvmlDeviceGetTemperatureFn,
         get_pci_info: NvmlDeviceGetPciInfo,
     }
 
     impl NvmlLib {
         pub(crate) unsafe fn load() -> Option<Self> {
-            let lib_name = c"libnvidia-ml.so.1";
+            const LIB_PATHS: &[&CStr] = &[
+                c"libnvidia-ml.so.1",
+                c"/run/opengl-driver/lib/libnvidia-ml.so.1",
+            ];
             unsafe {
-                let lib_handle = libc::dlopen(lib_name.as_ptr(), libc::RTLD_NOW);
-                if lib_handle.is_null() {
-                    sysinfo_debug!("Failed to find or load {lib_name:?}");
-                    return None;
-                }
-                match Self::load_symbols(lib_handle) {
-                    Some(ret) => Some(ret),
-                    None => {
-                        libc::dlclose(lib_handle);
-                        None
+                for lib_name in LIB_PATHS {
+                    let lib_handle = libc::dlopen(lib_name.as_ptr(), libc::RTLD_NOW);
+                    if lib_handle.is_null() {
+                        sysinfo_debug!("Failed to find or load {lib_name:?}");
+                        continue;
+                    }
+                    match Self::load_symbols(lib_handle) {
+                        Some(ret) => return Some(ret),
+                        None => {
+                            libc::dlclose(lib_handle);
+                        }
                     }
                 }
+                None
             }
         }
 
@@ -435,6 +459,11 @@ mod nvidia {
                         lib_handle,
                         c"nvmlDeviceGetMemoryInfo",
                         NvmlDeviceGetMemoryInfoFn,
+                    )?,
+                    get_temperature: load_sym!(
+                        lib_handle,
+                        c"nvmlDeviceGetTemperature",
+                        NvmlDeviceGetTemperatureFn,
                     )?,
                     get_pci_info: load_sym!(
                         lib_handle,
@@ -546,6 +575,17 @@ mod nvidia {
                         gpu.total_memory = Some(mem_info.total);
                         gpu.used_memory = Some(mem_info.used);
                     }
+
+                    let mut temperature: c_uint = 0;
+                    if (self.inner.get_temperature)(
+                        device_handle,
+                        NVML_TEMPERATURE_GPU,
+                        &mut temperature,
+                    ) == NVML_SUCCESS
+                    {
+                        gpu.temperature = Some(temperature as f32);
+                    }
+
                     gpu.updated = true;
                 }
             }

--- a/src/unix/linux/motherboard.rs
+++ b/src/unix/linux/motherboard.rs
@@ -1,7 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use crate::Error;
-use std::fs::{read, read_to_string};
+use std::fs::{read, read_dir, read_to_string};
+use std::path::Path;
 
 pub(crate) struct MotherboardInner;
 
@@ -45,6 +46,44 @@ impl MotherboardInner {
             .ok()
             .map(|s| s.trim().to_owned())
     }
+
+    pub(crate) fn temperatures(&self) -> Vec<f32> {
+        read_motherboard_temperatures()
+    }
+}
+
+fn read_motherboard_temperatures() -> Vec<f32> {
+    let hwmon_root = Path::new("/sys/class/hwmon");
+    let Ok(entries) = read_dir(hwmon_root) else {
+        return Vec::new();
+    };
+
+    let mut temps = Vec::new();
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = read_to_string(path.join("name")).ok();
+        if name.as_deref().map(|n| n.trim()) != Some("acpitz") {
+            continue;
+        }
+
+        let Ok(sensors) = read_dir(&path) else {
+            continue;
+        };
+        for sensor in sensors.flatten() {
+            let fname = sensor.file_name();
+            let fname_str = fname.to_string_lossy();
+            if fname_str.starts_with("temp")
+                && fname_str.ends_with("_input")
+                && let Ok(raw) = read_to_string(sensor.path())
+                && let Ok(milli) = raw.trim().parse::<i32>()
+            {
+                temps.push(milli as f32 / 1000.0);
+            }
+        }
+    }
+
+    temps
 }
 
 // Parses the first entry of the file `/proc/device-tree/compatible`, to extract the vendor and

--- a/src/unknown/cpu.rs
+++ b/src/unknown/cpu.rs
@@ -15,6 +15,18 @@ impl CpuInner {
         0
     }
 
+    pub(crate) fn temperature(&self) -> f32 {
+        0.0
+    }
+
+    pub(crate) fn max(&self) -> Option<f32> {
+        None
+    }
+
+    pub(crate) fn critical(&self) -> Option<f32> {
+        None
+    }
+
     pub(crate) fn vendor_id(&self) -> &str {
         ""
     }

--- a/src/unknown/disk.rs
+++ b/src/unknown/disk.rs
@@ -59,6 +59,18 @@ impl DiskInner {
     pub(crate) fn usage(&self) -> DiskUsage {
         DiskUsage::default()
     }
+
+    pub(crate) fn temperature(&self) -> Option<f32> {
+        None
+    }
+
+    pub(crate) fn max(&self) -> Option<f32> {
+        None
+    }
+
+    pub(crate) fn critical(&self) -> Option<f32> {
+        None
+    }
 }
 
 pub(crate) struct DisksInner;

--- a/src/unknown/gpu.rs
+++ b/src/unknown/gpu.rs
@@ -39,4 +39,7 @@ impl GpuInner {
     pub(crate) fn used_memory(&self) -> Option<u64> {
         unreachable!()
     }
+    pub(crate) fn temperature(&self) -> Option<f32> {
+        unreachable!()
+    }
 }

--- a/src/unknown/motherboard.rs
+++ b/src/unknown/motherboard.rs
@@ -28,4 +28,8 @@ impl MotherboardInner {
     pub(crate) fn asset_tag(&self) -> Option<String> {
         unreachable!()
     }
+
+    pub(crate) fn temperatures(&self) -> Vec<f32> {
+        Vec::new()
+    }
 }

--- a/src/windows/cpu.rs
+++ b/src/windows/cpu.rs
@@ -347,6 +347,18 @@ impl CpuInner {
         self.frequency
     }
 
+    pub(crate) fn temperature(&self) -> f32 {
+        0.0
+    }
+
+    pub(crate) fn max(&self) -> Option<f32> {
+        None
+    }
+
+    pub(crate) fn critical(&self) -> Option<f32> {
+        None
+    }
+
     pub(crate) fn vendor_id(&self) -> &str {
         &self.vendor_id
     }

--- a/src/windows/disk.rs
+++ b/src/windows/disk.rs
@@ -136,6 +136,9 @@ pub(crate) struct DiskInner {
     written_bytes: u64,
     read_bytes: u64,
     updated: bool,
+    temperature: Option<f32>,
+    temperature_max: Option<f32>,
+    temperature_critical: Option<f32>,
 }
 
 #[cfg(test)]
@@ -157,6 +160,9 @@ impl Default for DiskInner {
             written_bytes: 0,
             read_bytes: 0,
             updated: false,
+            temperature: None,
+            temperature_max: None,
+            temperature_critical: None,
         }
     }
 }
@@ -235,6 +241,18 @@ impl DiskInner {
             written_bytes: self.written_bytes.saturating_sub(self.old_written_bytes),
             total_written_bytes: self.written_bytes,
         }
+    }
+
+    pub(crate) fn temperature(&self) -> Option<f32> {
+        self.temperature
+    }
+
+    pub(crate) fn max(&self) -> Option<f32> {
+        self.temperature_max
+    }
+
+    pub(crate) fn critical(&self) -> Option<f32> {
+        self.temperature_critical
     }
 }
 
@@ -373,6 +391,9 @@ pub(crate) unsafe fn get_list(
                 read_bytes: 0,
                 written_bytes: 0,
                 updated: true,
+                temperature: None,
+                temperature_max: None,
+                temperature_critical: None,
             };
             disk.refresh_specifics(refreshes);
             disks.push(Disk { inner: disk });

--- a/src/windows/gpu.rs
+++ b/src/windows/gpu.rs
@@ -4,9 +4,10 @@ use std::collections::HashMap;
 use std::mem::{MaybeUninit, zeroed};
 
 use windows::Wdk::Graphics::Direct3D::{
-    D3DKMT_ADAPTERADDRESS, D3DKMT_CLOSEADAPTER, D3DKMT_OPENADAPTERFROMLUID,
-    D3DKMT_QUERYADAPTERINFO, D3DKMTCloseAdapter, D3DKMTOpenAdapterFromLuid, D3DKMTQueryAdapterInfo,
-    KMTQAITYPE_ADAPTERADDRESS,
+    D3DKMT_ADAPTER_PERFDATA, D3DKMT_ADAPTERADDRESS, D3DKMT_CLOSEADAPTER,
+    D3DKMT_OPENADAPTERFROMLUID, D3DKMT_QUERYADAPTERINFO, D3DKMTCloseAdapter,
+    D3DKMTOpenAdapterFromLuid, D3DKMTQueryAdapterInfo, KMTQAITYPE_ADAPTERADDRESS,
+    KMTQAITYPE_ADAPTERPERFDATA,
 };
 use windows::Win32::Devices::DeviceAndDriverInstallation::{
     DIGCF_PRESENT, GUID_DEVCLASS_DISPLAY, HDEVINFO, SETUP_DI_REGISTRY_PROPERTY, SP_DEVINFO_DATA,
@@ -31,6 +32,7 @@ pub(crate) struct GpuInner {
     total_memory: Option<u64>,
     used_memory: Option<u64>,
     usage: Option<f32>,
+    temperature: Option<f32>,
     model: Option<String>,
     vendor: Option<String>,
     pci: PCI,
@@ -56,6 +58,9 @@ impl GpuInner {
     }
     pub(crate) fn used_memory(&self) -> Option<u64> {
         self.used_memory
+    }
+    pub(crate) fn temperature(&self) -> Option<f32> {
+        self.temperature
     }
 }
 
@@ -116,6 +121,7 @@ impl GpusInner {
                 let Ok(desc) = adapter.GetDesc1() else {
                     continue;
                 };
+                let luid_adapter = LUIDAdapter::new(desc.AdapterLuid);
                 let gpu = match self
                     .gpus
                     .iter_mut()
@@ -130,8 +136,9 @@ impl GpusInner {
                             pcis = get_all_pcis();
                         }
                         if let Some(ref pcis) = pcis
-                            && let Some(addr) = LUIDAdapter::new(desc.AdapterLuid)
-                                .and_then(|adapter| adapter.query())
+                            && let Some(addr) = luid_adapter
+                                .as_ref()
+                                .and_then(|adapter| adapter.address())
                             // Why not using the `addr` info instead of iterating through PCIs?
                             // Because it might return a "fake" GPU, and PCIs allow us to filter.
                             && let Some(pci) = pcis.iter().find(|pci| {
@@ -148,6 +155,7 @@ impl GpusInner {
                                 total_memory: None,
                                 used_memory: None,
                                 usage: None,
+                                temperature: None,
                                 updated: true,
                                 luid: desc.AdapterLuid,
                             };
@@ -160,6 +168,9 @@ impl GpusInner {
                 };
 
                 gpu.total_memory = Some(desc.DedicatedVideoMemory as u64);
+                gpu.temperature = luid_adapter
+                    .as_ref()
+                    .and_then(|adapter| adapter.temperature());
 
                 if let Ok(adapter3) = adapter.cast::<IDXGIAdapter3>() {
                     let mut mem = MaybeUninit::<DXGI_QUERY_VIDEO_MEMORY_INFO>::uninit();
@@ -382,7 +393,7 @@ impl LUIDAdapter {
         }
     }
 
-    unsafe fn query(self) -> Option<D3DKMT_ADAPTERADDRESS> {
+    unsafe fn address(&self) -> Option<D3DKMT_ADAPTERADDRESS> {
         let mut address = D3DKMT_ADAPTERADDRESS::default();
 
         let mut query = D3DKMT_QUERYADAPTERINFO {
@@ -395,6 +406,25 @@ impl LUIDAdapter {
         unsafe {
             if D3DKMTQueryAdapterInfo(&mut query).is_ok() {
                 Some(address)
+            } else {
+                None
+            }
+        }
+    }
+
+    unsafe fn temperature(&self) -> Option<f32> {
+        let mut perf_data = D3DKMT_ADAPTER_PERFDATA::default();
+
+        let mut query = D3DKMT_QUERYADAPTERINFO {
+            hAdapter: self.0.hAdapter,
+            Type: KMTQAITYPE_ADAPTERPERFDATA,
+            pPrivateDriverData: &mut perf_data as *mut _ as _,
+            PrivateDriverDataSize: size_of::<D3DKMT_ADAPTER_PERFDATA>() as u32,
+        };
+
+        unsafe {
+            if D3DKMTQueryAdapterInfo(&mut query).is_ok() && perf_data.Temperature != 0 {
+                Some(perf_data.Temperature as f32 / 10.0)
             } else {
                 None
             }

--- a/src/windows/motherboard.rs
+++ b/src/windows/motherboard.rs
@@ -72,4 +72,8 @@ impl MotherboardInner {
             .copied()
             .map(str::to_string)
     }
+
+    pub(crate) fn temperatures(&self) -> Vec<f32> {
+        Vec::new()
+    }
 }


### PR DESCRIPTION
Add support for reading the GPU temperature for linux macos and windows.
For nvidia it uses the nvml library, for amd it reads the files directly.

I don't have the means to test macos or windows support (I can test windows soon), it is verified against their documentation and I made sure it compiles. If anyone else can test those it would be great, else I can remove that code and return None as an unsupported platform.