### PR TITLE
fix: handle null IOKit iterator in macOS disk probe

### DIFF
--- a/src/unix/apple/macos/disk.rs
+++ b/src/unix/apple/macos/disk.rs
@@ -29,8 +29,15 @@ where
         return None;
     }
 
-    // Safety: We checked for success, so there is always a valid iterator, even if its empty.
-    let service_iterator = unsafe { IOReleaser::new_unchecked(service_iterator) };
+    // IOServiceGetMatchingServices can return success with a null iterator on some macOS
+    // setups. Never construct a NonZero io_object_t from 0 (debug panic / release UB).
+    let service_iterator = match IOReleaser::new(service_iterator) {
+        Some(iterator) => iterator,
+        None => {
+            sysinfo_debug!("IOServiceGetMatchingServices succeeded but returned a null iterator");
+            return None;
+        }
+    };
 
     let mut parent_entry: io_registry_entry_t = 0;
 

--- a/src/unix/apple/utils.rs
+++ b/src/unix/apple/utils.rs
@@ -56,14 +56,6 @@ cfg_select! {
                 IoObject::new(obj).map(Self)
             }
 
-            #[cfg(feature = "disk")]
-            #[cfg(target_os = "macos")]
-            pub(crate) unsafe fn new_unchecked(obj: u32) -> Self {
-                // Chance at catching in-development mistakes
-                debug_assert_ne!(obj, 0);
-                unsafe { Self(IoObject::new_unchecked(obj)) }
-            }
-
             #[inline]
             pub(crate) fn inner(&self) -> u32 {
                 self.0.get()


### PR DESCRIPTION
## Summary

- Stop constructing `IOReleaser` with `new_unchecked` after `IOServiceGetMatchingServices` in the macOS disk media-type / I/O probe path.
- Use `IOReleaser::new` and return `None` when the iterator is null, matching the existing gpu / cpu / component call sites.
- Remove the now-unused `IOReleaser::new_unchecked` helper.

## Problem

`iterate_service_tree` assumed that a successful `IOServiceGetMatchingServices` call always yields a non-zero `io_iterator_t`:

```rust
// Safety: We checked for success, so there is always a valid iterator, even if its empty.
let service_iterator = unsafe { IOReleaser::new_unchecked(service_iterator) };
```

On some macOS setups the call can return success with a null iterator. Because `IOReleaser` wraps `NonZeroU32`, that leads to:

- **debug**: panic via `debug_assert_ne!(obj, 0)` / `NonZeroU32` construction
- **release**: undefined behavior through `NonZeroU32::new_unchecked(0)`

This was observed while refreshing disks (including via broader `System` refresh paths that touch disk media-type probing).

## Fix

Align with the safe pattern already used elsewhere in this crate, for example in `src/unix/apple/gpu.rs` and `src/unix/apple/macos/cpu.rs`:

```rust
let service_iterator = match IOReleaser::new(service_iterator) {
    Some(iterator) => iterator,
    None => {
        sysinfo_debug!("IOServiceGetMatchingServices succeeded but returned a null iterator");
        return None;
    }
};
```

When the iterator is null, disk kind / I/O stats simply remain unknown (`None`) instead of aborting the process.

## Testing

- Diff-reviewed against the existing safe IOKit call sites in this repository.
- Full `cargo check` / tests were not run in this environment because the crate MSRV is currently `1.95` and the available toolchain is older.

## Notes

This issue is present back through older releases (including 0.28.x) that still used `IOReleaser::new_unchecked` on this path. Downstream projects stuck on older MSRV may need a local patch until they can upgrade to a release containing this fix.