### PR TITLE
Fix BSTR double-free in Connection::connect_server and exec_query (#1711)

### DIFF
--- a/src/windows/component.rs
+++ b/src/windows/component.rs
@@ -207,28 +207,17 @@ impl Connection {
     fn connect_server(mut self) -> Option<Connection> {
         let instance = self.instance.as_ref()?;
         let svc = unsafe {
-            let s = bstr!("root\\WMI");
-            let res = instance.ConnectServer(
-                &s,
+            instance.ConnectServer(
+                &bstr!("root\\WMI"),
                 &Default::default(),
                 &Default::default(),
                 &Default::default(),
                 0,
                 &Default::default(),
                 None,
-            );
-            // s is automatically freed when it goes out of scope
-            res
+            )
         }
-        let svc = instance.ConnectServer(
-            &bstr!("root\\WMI"),
-            &Default::default(),
-            &Default::default(),
-            &Default::default(),
-            0,
-            &Default::default(),
-            None,
-        ).ok()?;
+        .ok()?;
 
         self.server_connection = Some(svc);
         Some(self)
@@ -256,16 +245,12 @@ impl Connection {
         let server_connection = self.server_connection.as_ref()?;
 
         let enumerator = unsafe {
-            let s = bstr!("WQL"); // query kind
-            let query = bstr!("SELECT * FROM MSAcpi_ThermalZoneTemperature");
-            let hres = server_connection.ExecQuery(
-                &s,
-                &query,
+            server_connection.ExecQuery(
+                &bstr!("WQL"),
+                &bstr!("SELECT * FROM MSAcpi_ThermalZoneTemperature"),
                 WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY,
                 None,
-            );
-            // s & query are automatically freed when they go out of scope
-            hres
+            )
         }
         .ok()?;
 

--- a/src/windows/component.rs
+++ b/src/windows/component.rs
@@ -2,7 +2,7 @@
 
 use crate::{Component, Error};
 
-use windows::Win32::Foundation::{SysAllocString, SysFreeString};
+use windows::Win32::Foundation::SysAllocString;
 use windows::Win32::Security::PSECURITY_DESCRIPTOR;
 use windows::Win32::System::Com::{
     CLSCTX_INPROC_SERVER, CoCreateInstance, CoInitializeEx, CoInitializeSecurity,
@@ -217,7 +217,7 @@ impl Connection {
                 &Default::default(),
                 None,
             );
-            SysFreeString(&s);
+            // s is automatically freed when it goes out of scope
             res
         }
         .ok()?;
@@ -256,8 +256,7 @@ impl Connection {
                 WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY,
                 None,
             );
-            SysFreeString(&s);
-            SysFreeString(&query);
+            // s & query are automatically freed when they go out of scope
             hres
         }
         .ok()?;

--- a/src/windows/component.rs
+++ b/src/windows/component.rs
@@ -220,7 +220,15 @@ impl Connection {
             // s is automatically freed when it goes out of scope
             res
         }
-        .ok()?;
+        let svc = instance.ConnectServer(
+            &bstr!("root\\WMI"),
+            &Default::default(),
+            &Default::default(),
+            &Default::default(),
+            0,
+            &Default::default(),
+            None,
+        ).ok()?;
 
         self.server_connection = Some(svc);
         Some(self)


### PR DESCRIPTION
Fixes #1711.

`connect_server` and `exec_query` (`src/windows/component.rs`) each manually call `SysFreeString` on a `BSTR` right after passing it by reference to a WMI COM call, then let the same `BSTR` drop out of scope at the end of the `unsafe` block. `windows_core::BSTR`/`windows_strings::BSTR` already frees its string on `Drop`, and the COM calls (`ConnectServer`, `ExecQuery`) only borrow the `BSTR`s - they never take ownership. So every call double-frees: once via the explicit `SysFreeString`, once via `Drop`.

Confirmed via Application Verifier's Heaps layer (Page Heap) + WinDbg - a live `APPLICATION_VERIFIER_HEAPS_FIRST_CHANCE_ACCESS_VIOLATION` inside `oleaut32!SysFreeString`, with `!heap -p -a` reporting the target address as an already-freed allocation, bottoming out in `connect_server`. Full trace and analysis in #1711.

Fix: delete the manual `SysFreeString` calls and let `Drop` own cleanup, same as everywhere else in this file already does. 

Verified locally: built a throwaway example calling `Components::new_with_refreshed_list()` + repeated `refresh()`, ran it under Application Verifier's Heaps layer with WinDbg attached - crashes reliably before this patch, runs clean to completion after it.