### PR TITLE
android: fall back to /proc/cpuinfo when /proc/stat is unreadable

### DIFF
--- a/src/unix/linux/cpu.rs
+++ b/src/unix/linux/cpu.rs
@@ -62,11 +62,15 @@ impl CpusWrapper {
             let f = match File::open("/proc/stat") {
                 Ok(f) => f,
                 Err(_e) => {
+                    #[cfg(not(target_os = "android"))]
                     sysinfo_debug!("failed to retrieve CPU information: {:?}", _e);
                     #[cfg(target_os = "android")]
-                    if first {
-                        self.cpus =
-                            build_cpus_from_cpuinfo(vendors_brands, refresh_kind.frequency());
+                    {
+                        sysinfo_debug!("failed to retrieve CPU usage information: {:?}", _e);
+                        if first {
+                            self.cpus =
+                                build_cpus_from_cpuinfo(vendors_brands, refresh_kind.frequency());
+                        }
                     }
                     return;
                 }

--- a/src/unix/linux/cpu.rs
+++ b/src/unix/linux/cpu.rs
@@ -63,6 +63,11 @@ impl CpusWrapper {
                 Ok(f) => f,
                 Err(_e) => {
                     sysinfo_debug!("failed to retrieve CPU information: {:?}", _e);
+                    #[cfg(target_os = "android")]
+                    if first {
+                        self.cpus =
+                            build_cpus_from_cpuinfo(vendors_brands, refresh_kind.frequency());
+                    }
                     return;
                 }
             };
@@ -753,6 +758,49 @@ fn get_arm_part(implementer: u32, part: u32) -> Option<&'static str> {
 
         _ => return None,
     })
+}
+
+/// Builds a CPU list from `/proc/cpuinfo` when `/proc/stat` is unreadable
+/// (blocked by SELinux for apps since Android 8).
+///
+/// Note: `cpu_usage()` will remain `0.0` for these CPUs — usage percentages
+/// require successive `/proc/stat` snapshots, and there is no public
+/// Android API providing equivalent per-CPU tick counters.
+#[cfg(target_os = "android")]
+fn build_cpus_from_cpuinfo(
+    vendors_brands: HashMap<usize, (String, String)>,
+    refresh_frequency: bool,
+) -> Vec<Cpu> {
+    let mut cpus = vendors_brands.into_iter().collect::<Vec<_>>();
+    cpus.sort_unstable_by_key(|(index, _)| *index);
+
+    cpus.into_iter()
+        .map(|(index, (vendor_id, brand))| {
+            let name = format!("cpu{index}");
+            Cpu {
+                inner: CpuInner::new_with_values(
+                    &name,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    if refresh_frequency {
+                        get_cpu_frequency(index)
+                    } else {
+                        0
+                    },
+                    vendor_id,
+                    brand,
+                ),
+            }
+        })
+        .collect()
 }
 
 /// Returns the brand/vendor string for the first CPU (which should be the same for all CPUs).


### PR DESCRIPTION
## Problem

On Android, `/proc/stat` is typically unreadable by regular apps (including
Termux) — it's blocked by SELinux policy since Android 8. When this happens,
`CpusWrapper::refresh()` currently returns early with an empty `cpus` list,
so no CPU information (name, vendor, brand, frequency) is ever populated,
even though `/proc/cpuinfo` — which is readable — has all of it.

## Fix

Add an Android-only fallback, `build_cpus_from_cpuinfo`, that builds the CPU
list from `/proc/cpuinfo` (via the existing `get_vendor_id_and_brand`) when
opening `/proc/stat` fails. It's only triggered on the first refresh (`first`),
matching the existing pattern used elsewhere in this function. CPU frequency
is optionally populated via the existing `get_cpu_frequency`, which reads
`/sys/devices/system/cpu/cpuN/cpufreq/scaling_cur_freq` and doesn't depend on
`/proc/stat`.

Note that `cpu_usage()` will remain `0.0` for CPUs built this way — usage
percentages require successive `/proc/stat` snapshots, and there's no public
Android API providing equivalent per-CPU tick counters. This is documented on
the new function.

## Testing

Verified on a physical Android device (Termux):

- Before: `System::new_all()` → `cpus()` returns 0 CPUs
- After: `cpus()` returns 8 CPUs, each with correct name (`cpu0`..`cpu7`),
  vendor (`ARM`), brand (e.g. `Cortex-A725`), and frequency

This was originally surfaced while building
[`otree`](https://github.com/fioncat/otree) on Termux via `cargo install`,
where `vergen`'s `si` feature emitted `VERGEN_SYSINFO_CPU_VENDOR` /
`_CPU_BRAND` / `_CPU_FREQUENCY` warnings because `sysinfo` couldn't resolve
CPU info on this platform.

Companion PR for the same root cause, affecting `Users`: #1714 