### PR TITLE
linux: keep a component's max temperature across refreshes

### DIFF
--- a/src/unix/linux/component.rs
+++ b/src/unix/linux/component.rs
@@ -378,12 +378,10 @@ impl ComponentInner {
             .highest_file
             .as_ref()
             .and_then(|file| get_temperature_from_file(file.as_path()))
-            .or_else(|| {
-                let last = self.temperature?;
-                let current = current?;
-                Some(last.max(current))
-            });
-        self.max = max;
+            .or(current);
+        if let Some(new_max) = max {
+            self.max = Some(self.max.map_or(new_max, |old_max| old_max.max(new_max)));
+        }
         self.temperature = current;
     }
 }
@@ -603,6 +601,31 @@ mod tests {
         assert_eq!(components[1].max(), Some(5.678));
         assert_eq!(components[1].critical(), Some(0.2));
         assert_eq!(components[1].id(), Some("hwmon0_2"));
+    }
+
+    #[test]
+    fn test_component_max_kept_across_refreshes() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temporary directory");
+        let hwmon0_dir = temp_dir.path().join("hwmon/hwmon0");
+        fs::create_dir_all(&hwmon0_dir).expect("failed to create hwmon/hwmon0 directory");
+
+        fs::write(hwmon0_dir.join("name"), "test_name").expect("failed to write to name file");
+        fs::write(hwmon0_dir.join("temp1_input"), "80000")
+            .expect("failed to write to temp1_input file");
+
+        let mut components = ComponentsInner::new().unwrap();
+        components.refresh_from_sys_class_path(temp_dir.path());
+        let mut components = Components { inner: components };
+
+        fs::write(hwmon0_dir.join("temp1_input"), "45000")
+            .expect("failed to write to temp1_input file");
+        components[0].refresh();
+        fs::write(hwmon0_dir.join("temp1_input"), "42000")
+            .expect("failed to write to temp1_input file");
+        components[0].refresh();
+
+        assert_eq!(components[0].temperature(), Some(42.0));
+        assert_eq!(components[0].max(), Some(80.0));
     }
 
     #[test]


### PR DESCRIPTION
A component's `max()` on Linux drops back down. Feed one sensor 80, then 45, then 42 and you end up with a max of 45:

```
temp1_input 80000  ->  temperature 80.0, max 80.0
temp1_input 45000  ->  temperature 45.0, max 80.0
temp1_input 42000  ->  temperature 42.0, max 45.0
```

`Component::refresh()` takes the higher of the last two readings rather than the highest its seen. The docs for `max()` say it updates on refresh once the temperature climbs above it, and Windows, macOS and FreeBSD all keep a runing one.

The `tempN_highest` half I'm less sure about - it now folds into that same running max, so a driver letting you reset its highest reading wouldn't take effect here any more. No hardware with that file here to try it against.

The whole-list `Components::refresh()` was never affected, it merges through `update_from` which already takes the larger of old and new. So you only land on this refreshing one component off `list_mut()`, on a chip with no `tempN_highest` file, which is why that fallback is there at all.
