### PR TITLE
[Linux] Improve process GPU information retrieval performance

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -7,8 +7,8 @@
 use std::io::{self, BufRead, Write};
 use std::str::FromStr;
 use sysinfo::{
-    Components, Disks, Error, Gpus, Groups, Motherboard, Networks, Pid, ProcessRefreshKind, Product, SUPPORTED_SIGNALS,
-    System, Users,
+    Components, Disks, Error, Gpus, Groups, Motherboard, Networks, Pid, ProcessRefreshKind,
+    Product, SUPPORTED_SIGNALS, System, Users,
 };
 
 fn print_help() {
@@ -443,7 +443,8 @@ fn interpret_input(
                                 sysinfo::ProcessesToUpdate::Some(&[pid]),
                                 true,
                                 ProcessRefreshKind::everything(),
-                            ) != 0 {
+                            ) != 0
+                            {
                                 println!("Process `{pid}` updated successfully");
                             } else {
                                 println!("Process `{pid}` couldn't be updated...");

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -7,7 +7,7 @@
 use std::io::{self, BufRead, Write};
 use std::str::FromStr;
 use sysinfo::{
-    Components, Disks, Error, Gpus, Groups, Motherboard, Networks, Pid, Product, SUPPORTED_SIGNALS,
+    Components, Disks, Error, Gpus, Groups, Motherboard, Networks, Pid, ProcessRefreshKind, Product, SUPPORTED_SIGNALS,
     System, Users,
 };
 
@@ -439,9 +439,11 @@ fn interpret_input(
                 {
                     match sys {
                         Ok(sys) => {
-                            if sys.refresh_processes(sysinfo::ProcessesToUpdate::Some(&[pid]), true)
-                                != 0
-                            {
+                            if sys.refresh_processes_specifics(
+                                sysinfo::ProcessesToUpdate::Some(&[pid]),
+                                true,
+                                ProcessRefreshKind::everything(),
+                            ) != 0 {
                                 println!("Process `{pid}` updated successfully");
                             } else {
                                 println!("Process `{pid}` couldn't be updated...");

--- a/src/common/system.rs
+++ b/src/common/system.rs
@@ -290,6 +290,7 @@ impl System {
     ///         .with_cpu()
     ///         .with_disk_usage()
     ///         .with_exe(UpdateKind::OnlyIfNotSet)
+    ///         .with_tasks()
     /// );
     /// # }
     /// ```

--- a/src/unix/linux/process.rs
+++ b/src/unix/linux/process.rs
@@ -371,17 +371,13 @@ impl ProcessInner {
 #[cfg(feature = "gpu")]
 mod gpu {
     use super::*;
-    use std::ffi::CString;
 
     // Faster `readlink` implementation which skips allocations by reusing a same buffer.
-    fn read_link(path: &Path, buf: &mut [u8; 4096]) -> Option<usize> {
-        let Ok(c_path) = CString::new(path.as_os_str().as_bytes()) else {
-            return None;
-        };
-
+    fn read_link(dir: &Dir, file_name: &[libc::c_char], buf: &mut [u8; 4096]) -> Option<usize> {
         let res = unsafe {
-            retry_eintr!(libc::readlink(
-                c_path.as_ptr(),
+            retry_eintr!(libc::readlinkat(
+                dir.dir_fd,
+                file_name.as_ptr(),
                 buf.as_mut_ptr() as *mut libc::c_char,
                 buf.len(),
             ))
@@ -392,39 +388,31 @@ mod gpu {
 
     struct Dir {
         dir_fd: libc::c_int,
-        // If we use an array instead of a Vec here, we get unaligned memory errors when we go
-        // through the `dirent64` entries. So sadly, we need to go through the allocation...
-        buf: Vec<u8>,
     }
 
     impl Dir {
-        fn new(path: &Path) -> Option<Self> {
+        fn new(path: &[u8]) -> Option<Self> {
             unsafe {
-                let c_path = CString::new(path.as_os_str().as_bytes()).ok()?;
-                let dir_fd = libc::open(
-                    c_path.as_ptr(),
+                let dir_fd = retry_eintr!(libc::open(
+                    path.as_ptr() as *const _,
                     libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_DIRECTORY | libc::O_CLOEXEC,
-                );
+                ));
                 if dir_fd < 0 {
                     None
                 } else {
-                    Some(Self {
-                        dir_fd,
-                        // 20 dir entries at once should be enough.
-                        buf: vec![0; std::mem::size_of::<libc::dirent64>() * 20],
-                    })
+                    Some(Self { dir_fd })
                 }
             }
         }
 
-        fn update_dents_buf(&mut self) -> Result<Option<usize>, ()> {
+        fn update_dents_buf(&self, buf: &mut [u8]) -> Result<Option<usize>, ()> {
             unsafe {
-                let read = libc::syscall(
+                let read = retry_eintr!(libc::syscall(
                     libc::SYS_getdents64,
                     self.dir_fd,
-                    self.buf.as_mut_ptr() as *mut _,
-                    self.buf.len() as libc::c_int,
-                );
+                    buf.as_mut_ptr() as *mut _,
+                    buf.len() as libc::c_int,
+                ));
                 if read < 0 {
                     sysinfo_debug!("getdents64 failed");
                     Err(())
@@ -436,12 +424,15 @@ mod gpu {
             }
         }
 
-        fn iter(&mut self) -> Result<Option<DirIter<'_>>, ()> {
-            if let Some(read) = self.update_dents_buf()? {
+        fn iter(&self) -> Result<Option<DirIter<'_>>, ()> {
+            // 20 dir entries at once should be enough.
+            let mut buf = vec![0; std::mem::size_of::<libc::dirent64>() * 20];
+            if let Some(read) = self.update_dents_buf(&mut buf)? {
                 Ok(Some(DirIter {
                     read,
                     pos: 0,
                     dir: self,
+                    buf,
                 }))
             } else {
                 Ok(None)
@@ -460,17 +451,20 @@ mod gpu {
     struct DirIter<'a> {
         pos: usize,
         read: usize,
-        dir: &'a mut Dir,
+        dir: &'a Dir,
+        // If we use an array instead of a Vec here, we get unaligned memory errors when we go
+        // through the `dirent64` entries. So sadly, we need to go through the allocation...
+        buf: Vec<u8>,
     }
 
     impl<'a> Iterator for DirIter<'a> {
-        type Item = &'a [u8];
+        type Item = &'a [libc::c_char];
 
         fn next(&mut self) -> Option<Self::Item> {
             loop {
                 unsafe {
                     if self.pos >= self.read {
-                        if let Ok(Some(read)) = self.dir.update_dents_buf() {
+                        if let Ok(Some(read)) = self.dir.update_dents_buf(&mut self.buf) {
                             self.read = read;
                             self.pos = 0;
                         } else {
@@ -478,7 +472,7 @@ mod gpu {
                             return None;
                         }
                     }
-                    let dir_entry = self.dir.buf.as_ptr().add(self.pos) as *const libc::dirent64;
+                    let dir_entry = self.buf.as_ptr().add(self.pos) as *const libc::dirent64;
                     let dir_entry = &*dir_entry;
                     self.pos += dir_entry.d_reclen as usize;
 
@@ -486,21 +480,9 @@ mod gpu {
                     if dir_entry.d_name[0] == b'.' as i8 {
                         continue;
                     }
-                    // If it's an invalid name, we ignore it.
-                    if let Some(name) = slice_to_slice_without_0(&dir_entry.d_name) {
-                        return Some(name);
-                    }
+                    return Some(&dir_entry.d_name);
                 }
             }
-        }
-    }
-
-    fn slice_to_slice_without_0(slice: &[libc::c_char]) -> Option<&[u8]> {
-        unsafe {
-            slice
-                .split(|c| *c == 0)
-                .next()
-                .map(|s| std::slice::from_raw_parts(s.as_ptr() as *const u8, s.len()))
         }
     }
 
@@ -516,30 +498,36 @@ mod gpu {
         refresh_kind: ProcessRefreshKind,
     ) {
         use std::fs::File;
+        use std::os::fd::FromRawFd;
 
-        let Some(mut dir) = Dir::new(proc_path.replace_and_join("fdinfo")) else {
-            return;
-        };
+        // CString is apparently expensive, so we do our own...
+        let path = proc_path.replace_and_join("fdinfo").as_os_str().as_bytes();
+        let mut c_path = Vec::with_capacity(path.len() + 1);
+        c_path.extend_from_slice(path);
+        c_path.push(0);
+        let Some(dir) = Dir::new(&c_path) else { return };
 
         let mut total_time: u64 = 0;
         let mut total_memory: u64 = 0;
         let mut found_memory = false;
-        if let Ok(Some(dir_iter)) = dir.iter() {
+        let dir_fd = dir.dir_fd;
+        if let Ok(Some(dir_iter)) = dir.iter()
+            && let Some(fd_dir) = {
+                // We remove the `info\0` part.
+                c_path.truncate(c_path.len() - 5);
+                c_path.push(0);
+                Dir::new(&c_path)
+            }
+        {
             // 4096 is the limit used in htop so why not.
             let mut buf = [0u8; 4096];
             let mut gpus: Vec<(String, String)> = Vec::with_capacity(2);
 
-            let mut fd_proc_path = PathHandler::new(proc_path.replace_and_join("fd"));
-
-            // We add an extra file name that will replaced at every iteration.
-            proc_path.replace_and_join("fdinfo/0");
-
             'main: for file_name in dir_iter {
                 // SAFETY: `d_name` is always valid UTF8 if it comes from `getdents64`/`readdir`
                 // otherwise rust always provide valid UTF8 strings.
-                let file_name = unsafe { std::ffi::OsStr::from_encoded_bytes_unchecked(file_name) };
-                let Some(size) = read_link(fd_proc_path.replace_and_join(&file_name), &mut buf)
-                else {
+
+                let Some(size) = read_link(&fd_dir, file_name, &mut buf) else {
                     continue;
                 };
                 let target_bytes = &buf[..size];
@@ -549,12 +537,18 @@ mod gpu {
                 ) {
                     continue;
                 }
-                let buf = if let Ok(mut file) = File::open(proc_path.replace_and_join(&file_name))
-                    && let Ok(read) = file.read(&mut buf)
-                {
-                    &buf[..read]
-                } else {
-                    continue;
+                let buf = unsafe {
+                    let fd = retry_eintr!(libc::openat(dir_fd, file_name.as_ptr(), libc::O_RDONLY));
+                    if fd < 0 {
+                        continue;
+                    }
+                    if let mut file = File::from_raw_fd(fd)
+                        && let Ok(read) = file.read(&mut buf)
+                    {
+                        &buf[..read]
+                    } else {
+                        continue;
+                    }
                 };
                 let mut gpu_id = None;
                 let mut pci = None;

--- a/src/unix/linux/process.rs
+++ b/src/unix/linux/process.rs
@@ -482,10 +482,9 @@ mod gpu {
                     self.pos += dir_entry.d_reclen as usize;
 
                     // It's only supposed to contain digits in any case, but that filters very well too.
-                    if dir_entry.d_name[0] == b'.' as i8 {
-                        continue;
+                    if dir_entry.d_name[0] != b'.' as i8 {
+                        return Some(&dir_entry.d_name);
                     }
-                    return Some(&dir_entry.d_name);
                 }
             }
         }
@@ -503,6 +502,7 @@ mod gpu {
         refresh_kind: ProcessRefreshKind,
     ) {
         use std::fs::File;
+        use std::mem::MaybeUninit;
         use std::os::fd::FromRawFd;
 
         // CString is apparently expensive, so we do our own...
@@ -518,17 +518,18 @@ mod gpu {
         let dir_fd = dir.dir_fd;
         if let Ok(Some(dir_iter)) = dir.iter()
             && let Some(fd_dir) = {
-                // We remove the `info\0` part.
-                c_path.truncate(c_path.len() - 5);
-                c_path.push(0);
+                // We replace `/fdinfo\0` with `/fd\0nfo\0` to the folder name becomes `fd`.
+                // So 4 characters for `info` and 1 for the `\0`.
+                let index = c_path.len() - 5;
+                c_path[index] = 0;
                 Dir::new(&c_path)
             }
         {
             // 4096 is the limit used in htop so why not.
-            let mut buf = Vec::with_capacity(4096);
+            let buf: MaybeUninit<[u8; 4096]> = MaybeUninit::uninit();
             // SAFETY: `read_link` and `openat` will initialize the values.
-            unsafe { buf.set_len(buf.capacity()); }
-            let mut gpus: Vec<(String, String)> = Vec::new();
+            let mut buf: [u8; 4096] = unsafe { buf.assume_init() };
+            let mut gpus: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
 
             'main: for file_name in dir_iter {
                 // SAFETY: `d_name` is always valid UTF8 if it comes from `getdents64`/`readdir`
@@ -569,16 +570,12 @@ mod gpu {
                     .filter_map(|line| line.strip_prefix(b"drm-"))
                 {
                     if line.starts_with(b"client-id:") {
-                        if let Some(id) = line.splitn(2, |c| *c == b':').nth(1)
-                            && let Ok(id) = str::from_utf8(id)
-                        {
-                            gpu_id = Some(id.trim().to_owned());
+                        if let Some(id) = line.splitn(2, |c| *c == b':').nth(1) {
+                            gpu_id = Some(id.trim_ascii().to_vec());
                         }
                     } else if line.starts_with(b"pdev:") {
-                        if let Some(dev) = line.splitn(2, |c| *c == b':').nth(1)
-                            && let Ok(dev) = str::from_utf8(dev)
-                        {
-                            pci = Some(dev.trim().to_owned());
+                        if let Some(dev) = line.splitn(2, |c| *c == b':').nth(1) {
+                            pci = Some(dev.trim_ascii().to_vec());
                         }
                     } else if let Some(line) = line.strip_prefix(b"engine-") {
                         if refresh_kind.gpu_usage()

--- a/src/unix/linux/process.rs
+++ b/src/unix/linux/process.rs
@@ -531,7 +531,7 @@ mod gpu {
             let mut buf: [u8; 4096] = unsafe { buf.assume_init() };
             let mut gpus: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
 
-            'main: for file_name in dir_iter {
+            for file_name in dir_iter {
                 // SAFETY: `d_name` is always valid UTF8 if it comes from `getdents64`/`readdir`
                 // otherwise rust always provide valid UTF8 strings.
 
@@ -562,7 +562,6 @@ mod gpu {
                 let mut pci = None;
                 let mut gpu_time: Option<u64> = None;
                 let mut gpu_memory: Option<u64> = None;
-                let mut checked = false;
                 // All the keys are listed in
                 // <https://www.kernel.org/doc/html/latest/gpu/drm-usage-stats.html>.
                 for line in buf
@@ -582,11 +581,10 @@ mod gpu {
                             && !line.starts_with(b"capacity-")
                             && let Some(line) = line.strip_suffix(b" ns")
                             && let Some(nb) = line.split(|c| *c == b':').nth(1)
-                            && let Ok(nb) = str::from_utf8(nb)
-                            && let Ok(nb) = nb.trim().parse::<u64>()
+                            && let Ok(nb) = str::from_utf8(nb.trim_ascii())
+                            && let Ok(nb) = nb.parse::<u64>()
                         {
                             *gpu_time.get_or_insert(0) += nb;
-                            continue;
                         }
                     } else if let Some(line) = line.strip_prefix(b"total-") {
                         if refresh_kind.gpu_memory()
@@ -596,8 +594,8 @@ mod gpu {
                                 .filter(|s| !s.is_empty())
                             && let Some(value) = nb.next()
                             && let Some(unit) = nb.next()
-                            && let Ok(value) = str::from_utf8(value)
-                            && let Ok(value) = value.trim().parse::<u64>()
+                            && let Ok(value) = str::from_utf8(value.trim_ascii())
+                            && let Ok(value) = value.parse::<u64>()
                             && unit.len() > 0
                         {
                             gpu_memory = match unit[0] {
@@ -612,23 +610,7 @@ mod gpu {
                                     None
                                 }
                             };
-                            continue;
                         }
-                    } else {
-                        continue;
-                    }
-                    if !checked
-                        && let Some(ref gpu_id) = gpu_id
-                        && let Some(ref pci) = pci
-                    {
-                        if gpus
-                            .iter()
-                            .any(|(s_id, s_pci)| s_id == gpu_id && s_pci == pci)
-                        {
-                            // We already checked this GPU so ignoring it.
-                            continue 'main;
-                        }
-                        checked = true;
                     }
                 }
                 // This is the fallback in case the gpu memory or time wasn't retrieved.

--- a/src/unix/linux/process.rs
+++ b/src/unix/linux/process.rs
@@ -369,187 +369,311 @@ impl ProcessInner {
 }
 
 #[cfg(feature = "gpu")]
-fn read_link(path: &Path, buf: &mut [u8; 4096]) -> Option<usize> {
-    let Ok(c_path) = std::ffi::CString::new(path.as_os_str().as_bytes()) else {
-        return None;
-    };
+mod gpu {
+    use super::*;
+    use std::ffi::CString;
 
-    let res = unsafe {
-        retry_eintr!(libc::readlink(
-            c_path.as_ptr(),
-            buf.as_mut_ptr() as *mut libc::c_char,
-            buf.len(),
-        ))
-    };
-
-    if res < 1 { None } else { Some(res as usize) }
-}
-
-// Maybe something to do in the future: if it's not an AMD or NVIDIA GPU, we can still compute the
-// total % usage by adding all processes GPU time. However: we need to have access to `Gpus` all the
-// time, so likely needs to be part of `System`, just like `Cpu`. Not really worth it since it comes
-// with limitations (such as: only gives information for current user, unless it's an admin), so for
-// now ignoring it.
-#[cfg(feature = "gpu")]
-fn compute_gpu_usage(
-    proc_path: &mut PathHandler,
-    gpu_info: &mut GpuInfo,
-    now: Instant,
-    refresh_kind: ProcessRefreshKind,
-) {
-    use std::fs::File;
-
-    let Ok(dir) = read_dir(proc_path.replace_and_join("fdinfo")) else {
-        gpu_info.gpu_usage = None;
-        return;
-    };
-    // 4096 is the limit used in htop so why not.
-    let mut buf = [0u8; 4096];
-    let mut gpus: Vec<(String, String)> = Vec::with_capacity(2);
-    let mut total_time: u64 = 0;
-    let mut total_memory: u64 = 0;
-    let mut found_memory = false;
-
-    let mut fd_proc_path = PathHandler::new(proc_path.replace_and_join("fd"));
-
-    // We add an extra file name that will replaced at every iteration.
-    proc_path.replace_and_join("fdinfo/0");
-
-    'main: for entry in dir.flatten() {
-        let file_name = entry.file_name();
-        if file_name.as_bytes().first() == Some(&b'.') {
-            continue;
-        }
-        let Some(size) = read_link(fd_proc_path.replace_and_join(&file_name), &mut buf) else {
-            continue;
+    // Faster `readlink` implementation which skips allocations by reusing a same buffer.
+    fn read_link(path: &Path, buf: &mut [u8; 4096]) -> Option<usize> {
+        let Ok(c_path) = CString::new(path.as_os_str().as_bytes()) else {
+            return None;
         };
-        let target_bytes = &buf[..size];
-        if !matches!(
-            target_bytes.strip_prefix(b"/dev/"),
-            Some(part) if part.starts_with(b"dri/") || part.starts_with(b"accel/")
-        ) {
-            continue;
-        }
-        let buf = if let Ok(mut file) = File::open(proc_path.replace_and_join(&file_name))
-            && let Ok(read) = file.read(&mut buf)
-        {
-            &buf[..read]
-        } else {
-            continue;
+
+        let res = unsafe {
+            retry_eintr!(libc::readlink(
+                c_path.as_ptr(),
+                buf.as_mut_ptr() as *mut libc::c_char,
+                buf.len(),
+            ))
         };
-        let mut gpu_id = None;
-        let mut pci = None;
-        let mut gpu_time: Option<u64> = None;
-        let mut gpu_memory: Option<u64> = None;
-        let mut checked = false;
-        // All the keys are listed in
-        // <https://www.kernel.org/doc/html/latest/gpu/drm-usage-stats.html>.
-        for line in buf
-            .split(|c| *c == b'\n')
-            .filter_map(|line| line.strip_prefix(b"drm-"))
-        {
-            if line.starts_with(b"client-id:") {
-                if let Some(id) = line.splitn(2, |c| *c == b':').nth(1)
-                    && let Ok(id) = str::from_utf8(id)
-                {
-                    gpu_id = Some(id.trim().to_owned());
+
+        if res < 1 { None } else { Some(res as usize) }
+    }
+
+    struct Dir {
+        dir_fd: libc::c_int,
+        // If we use an array instead of a Vec here, we get unaligned memory errors when we go
+        // through the `dirent64` entries. So sadly, we need to go through the allocation...
+        buf: Vec<u8>,
+    }
+
+    impl Dir {
+        fn new(path: &Path) -> Option<Self> {
+            unsafe {
+                let c_path = CString::new(path.as_os_str().as_bytes()).ok()?;
+                let dir_fd = libc::open(
+                    c_path.as_ptr(),
+                    libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_DIRECTORY | libc::O_CLOEXEC,
+                );
+                if dir_fd < 0 {
+                    None
+                } else {
+                    Some(Self {
+                        dir_fd,
+                        // 20 dir entries at once should be enough.
+                        buf: vec![0; std::mem::size_of::<libc::dirent64>() * 20],
+                    })
                 }
-            } else if line.starts_with(b"pdev:") {
-                if let Some(dev) = line.splitn(2, |c| *c == b':').nth(1)
-                    && let Ok(dev) = str::from_utf8(dev)
-                {
-                    pci = Some(dev.trim().to_owned());
+            }
+        }
+
+        fn update_dents_buf(&mut self) -> Result<Option<usize>, ()> {
+            unsafe {
+                let read = libc::syscall(
+                    libc::SYS_getdents64,
+                    self.dir_fd,
+                    self.buf.as_mut_ptr() as *mut _,
+                    self.buf.len() as libc::c_int,
+                );
+                if read < 0 {
+                    sysinfo_debug!("getdents64 failed");
+                    Err(())
+                } else if read == 0 {
+                    Ok(None)
+                } else {
+                    Ok(Some(read as usize))
                 }
-            } else if let Some(line) = line.strip_prefix(b"engine-") {
-                if refresh_kind.gpu_usage()
-                    && !line.starts_with(b"capacity-")
-                    && line.ends_with(b" ns")
-                    && let Some(nb) = line.split(|c| *c == b':').nth(1)
-                    && let Ok(nb) = str::from_utf8(nb)
-                    && let Ok(nb) = nb.trim().parse::<u64>()
-                {
-                    *gpu_time.get_or_insert(0) += nb;
-                    continue;
-                }
-            } else if let Some(line) = line.strip_prefix(b"total-") {
-                if refresh_kind.gpu_memory()
-                    && let Some(nb) = line.splitn(2, |c| *c == b':').nth(1)
-                    && let mut nb = nb.split(|c| *c == b' ')
-                    && let Some(value) = nb.next()
-                    && let Some(unit) = nb.next()
-                    && let Ok(value) = str::from_utf8(value)
-                    && let Ok(value) = value.trim().parse::<u64>()
-                    && !unit.is_empty()
-                {
-                    gpu_memory = match unit[0] {
-                        b'K' | b'k' => Some(value / 1024),
-                        b'M' | b'm' => Some(value / 1024 / 1024),
-                        b'G' | b'g' => Some(value / 1024 / 1024 / 1024),
-                        _ => {
-                            eprintln!("Unknown GPU memory unit {unit:?} in {:?}", entry.path());
-                            None
-                        }
-                    };
-                    continue;
-                }
+            }
+        }
+
+        fn iter(&mut self) -> Result<Option<DirIter<'_>>, ()> {
+            if let Some(read) = self.update_dents_buf()? {
+                Ok(Some(DirIter {
+                    read,
+                    pos: 0,
+                    dir: self,
+                }))
             } else {
-                continue;
-            }
-            if !checked
-                && let Some(ref gpu_id) = gpu_id
-                && let Some(ref pci) = pci
-            {
-                if gpus
-                    .iter()
-                    .any(|(s_id, s_pci)| s_id == gpu_id && s_pci == pci)
-                {
-                    // We already checked this GPU so ignoring it.
-                    continue 'main;
-                }
-                checked = true;
-            }
-        }
-        // This is the fallback in case the gpu memory or time wasn't retrieved.
-        if let Some(gpu_id) = gpu_id
-            && let Some(pci) = pci
-            && !gpus
-                .iter()
-                .any(|(s_id, s_pci)| *s_id == gpu_id && *s_pci == pci)
-        {
-            gpus.push((gpu_id, pci));
-            if let Some(gpu_time) = gpu_time {
-                total_time = total_time.saturating_add(gpu_time);
-            }
-            if let Some(gpu_memory) = gpu_memory {
-                total_memory = total_memory.saturating_add(gpu_memory);
-                found_memory = true;
+                Ok(None)
             }
         }
     }
-    if found_memory {
-        gpu_info.memory = Some(total_memory);
-    } else {
-        gpu_info.memory = None;
-    }
-    if total_time != 0 {
-        let elapsed_time = if let Some(last_update) = gpu_info.last_update {
-            now.duration_since(last_update).as_millis()
-        } else {
-            0
-        };
-        let gpu_time_delta = total_time.saturating_sub(gpu_info.gpu_time);
 
-        if gpu_time_delta == 0 || elapsed_time == 0 {
-            gpu_info.gpu_usage = None;
-        } else {
-            // We need to convert from nanos to millis, hence the `/ 1_000_000.`.
-            gpu_info.gpu_usage =
-                Some(100. * (gpu_time_delta as f32) / 1_000_000. / (elapsed_time as f32));
+    impl Drop for Dir {
+        fn drop(&mut self) {
+            unsafe {
+                libc::close(self.dir_fd);
+            }
         }
-        gpu_info.last_update = Some(now);
-        gpu_info.gpu_time = total_time;
-    } else {
-        gpu_info.gpu_usage = Some(0.);
+    }
+
+    struct DirIter<'a> {
+        pos: usize,
+        read: usize,
+        dir: &'a mut Dir,
+    }
+
+    impl<'a> Iterator for DirIter<'a> {
+        type Item = &'a [u8];
+
+        fn next(&mut self) -> Option<Self::Item> {
+            loop {
+                unsafe {
+                    if self.pos >= self.read {
+                        if let Ok(Some(read)) = self.dir.update_dents_buf() {
+                            self.read = read;
+                            self.pos = 0;
+                        } else {
+                            // Reached the end!
+                            return None;
+                        }
+                    }
+                    let dir_entry = self.dir.buf.as_ptr().add(self.pos) as *const libc::dirent64;
+                    let dir_entry = &*dir_entry;
+                    self.pos += dir_entry.d_reclen as usize;
+
+                    // It's only supposed to contain digits in any case, but that filters very well too.
+                    if dir_entry.d_name[0] == b'.' as i8 {
+                        continue;
+                    }
+                    // If it's an invalid name, we ignore it.
+                    if let Some(name) = slice_to_slice_without_0(&dir_entry.d_name) {
+                        return Some(name);
+                    }
+                }
+            }
+        }
+    }
+
+    fn slice_to_slice_without_0(slice: &[libc::c_char]) -> Option<&[u8]> {
+        unsafe {
+            slice
+                .split(|c| *c == 0)
+                .next()
+                .map(|s| std::slice::from_raw_parts(s.as_ptr() as *const u8, s.len()))
+        }
+    }
+
+    // Maybe something to do in the future: if it's not an AMD or NVIDIA GPU, we can still compute the
+    // total % usage by adding all processes GPU time. However: we need to have access to `Gpus` all the
+    // time, so likely needs to be part of `System`, just like `Cpu`. Not really worth it since it comes
+    // with limitations (such as: only gives information for current user, unless it's an admin), so for
+    // now ignoring it.
+    pub fn compute_gpu_usage(
+        proc_path: &mut PathHandler,
+        gpu_info: &mut GpuInfo,
+        now: Instant,
+        refresh_kind: ProcessRefreshKind,
+    ) {
+        use std::fs::File;
+
+        let Some(mut dir) = Dir::new(proc_path.replace_and_join("fdinfo")) else {
+            return;
+        };
+
+        let mut total_time: u64 = 0;
+        let mut total_memory: u64 = 0;
+        let mut found_memory = false;
+        if let Ok(Some(dir_iter)) = dir.iter() {
+            // 4096 is the limit used in htop so why not.
+            let mut buf = [0u8; 4096];
+            let mut gpus: Vec<(String, String)> = Vec::with_capacity(2);
+
+            let mut fd_proc_path = PathHandler::new(proc_path.replace_and_join("fd"));
+
+            // We add an extra file name that will replaced at every iteration.
+            proc_path.replace_and_join("fdinfo/0");
+
+            'main: for file_name in dir_iter {
+                // SAFETY: `d_name` is always valid UTF8 if it comes from `getents64`/`readdir` otherwise
+                // rust always provide valid UTF8 strings.
+                let file_name = unsafe { std::ffi::OsStr::from_encoded_bytes_unchecked(file_name) };
+                let Some(size) = read_link(fd_proc_path.replace_and_join(&file_name), &mut buf)
+                else {
+                    continue;
+                };
+                let target_bytes = &buf[..size];
+                if !matches!(
+                    target_bytes.strip_prefix(b"/dev/"),
+                    Some(part) if part.starts_with(b"dri/") || part.starts_with(b"accel/")
+                ) {
+                    continue;
+                }
+                let buf = if let Ok(mut file) = File::open(proc_path.replace_and_join(&file_name))
+                    && let Ok(read) = file.read(&mut buf)
+                {
+                    &buf[..read]
+                } else {
+                    continue;
+                };
+                let mut gpu_id = None;
+                let mut pci = None;
+                let mut gpu_time: Option<u64> = None;
+                let mut gpu_memory: Option<u64> = None;
+                let mut checked = false;
+                // All the keys are listed in
+                // <https://www.kernel.org/doc/html/latest/gpu/drm-usage-stats.html>.
+                for line in buf
+                    .split(|c| *c == b'\n')
+                    .filter_map(|line| line.strip_prefix(b"drm-"))
+                {
+                    if line.starts_with(b"client-id:") {
+                        if let Some(id) = line.splitn(2, |c| *c == b':').nth(1)
+                            && let Ok(id) = str::from_utf8(id)
+                        {
+                            gpu_id = Some(id.trim().to_owned());
+                        }
+                    } else if line.starts_with(b"pdev:") {
+                        if let Some(dev) = line.splitn(2, |c| *c == b':').nth(1)
+                            && let Ok(dev) = str::from_utf8(dev)
+                        {
+                            pci = Some(dev.trim().to_owned());
+                        }
+                    } else if let Some(line) = line.strip_prefix(b"engine-") {
+                        if refresh_kind.gpu_usage()
+                            && !line.starts_with(b"capacity-")
+                            && line.ends_with(b" ns")
+                            && let Some(nb) = line.split(|c| *c == b':').nth(1)
+                            && let Ok(nb) = str::from_utf8(nb)
+                            && let Ok(nb) = nb.trim().parse::<u64>()
+                        {
+                            *gpu_time.get_or_insert(0) += nb;
+                            continue;
+                        }
+                    } else if let Some(line) = line.strip_prefix(b"total-") {
+                        if refresh_kind.gpu_memory()
+                            && let Some(nb) = line.splitn(2, |c| *c == b':').nth(1)
+                            && let mut nb = nb.split(|c| *c == b' ')
+                            && let Some(value) = nb.next()
+                            && let Some(unit) = nb.next()
+                            && let Ok(value) = str::from_utf8(value)
+                            && let Ok(value) = value.trim().parse::<u64>()
+                            && unit.len() > 0
+                        {
+                            gpu_memory = match unit[0] {
+                                b'K' | b'k' => Some(value / 1024),
+                                b'M' | b'm' => Some(value / 1024 / 1024),
+                                b'G' | b'g' => Some(value / 1024 / 1024 / 1024),
+                                _ => {
+                                    eprintln!(
+                                        "Unknown GPU memory unit {unit:?} in {:?}",
+                                        proc_path.as_path()
+                                    );
+                                    None
+                                }
+                            };
+                            continue;
+                        }
+                    } else {
+                        continue;
+                    }
+                    if !checked
+                        && let Some(ref gpu_id) = gpu_id
+                        && let Some(ref pci) = pci
+                    {
+                        if gpus
+                            .iter()
+                            .any(|(s_id, s_pci)| s_id == gpu_id && s_pci == pci)
+                        {
+                            // We already checked this GPU so ignoring it.
+                            continue 'main;
+                        }
+                        checked = true;
+                    }
+                }
+                // This is the fallback in case the gpu memory or time wasn't retrieved.
+                if let Some(gpu_id) = gpu_id
+                    && let Some(pci) = pci
+                    && !gpus
+                        .iter()
+                        .any(|(s_id, s_pci)| *s_id == gpu_id && *s_pci == pci)
+                {
+                    gpus.push((gpu_id, pci));
+                    if let Some(gpu_time) = gpu_time {
+                        total_time = total_time.saturating_add(gpu_time);
+                    }
+                    if let Some(gpu_memory) = gpu_memory {
+                        total_memory = total_memory.saturating_add(gpu_memory);
+                        found_memory = true;
+                    }
+                }
+            }
+        }
+        if found_memory {
+            gpu_info.memory = Some(total_memory);
+        } else {
+            gpu_info.memory = None;
+        }
+        if total_time != 0 {
+            let elapsed_time = if let Some(last_update) = gpu_info.last_update {
+                now.duration_since(last_update).as_millis()
+            } else {
+                0
+            };
+            let gpu_time_delta = total_time.saturating_sub(gpu_info.gpu_time);
+
+            if gpu_time_delta == 0 || elapsed_time == 0 {
+                gpu_info.gpu_usage = None;
+            } else {
+                // We need to convert from nanos to millis, hence the `/ 1_000_000.`.
+                gpu_info.gpu_usage =
+                    Some(100. * (gpu_time_delta as f32) / 1_000_000. / (elapsed_time as f32));
+            }
+            gpu_info.last_update = Some(now);
+            gpu_info.gpu_time = total_time;
+        } else {
+            gpu_info.gpu_usage = Some(0.);
+        }
     }
 }
 
@@ -760,7 +884,7 @@ fn update_proc_info(
     }
     #[cfg(feature = "gpu")]
     if refresh_kind.gpu_usage() || refresh_kind.gpu_memory() {
-        compute_gpu_usage(proc_path, &mut p.gpu_info, now, refresh_kind);
+        self::gpu::compute_gpu_usage(proc_path, &mut p.gpu_info, now, refresh_kind);
     }
     p.updated = true;
 }

--- a/src/unix/linux/process.rs
+++ b/src/unix/linux/process.rs
@@ -374,16 +374,16 @@ mod gpu {
 
     // Faster `readlink` implementation which skips allocations by reusing a same buffer.
     fn read_link(dir: &Dir, file_name: &[libc::c_char], buf: &mut [u8; 4096]) -> Option<usize> {
-        let res = unsafe {
-            retry_eintr!(libc::readlinkat(
+        unsafe {
+            let res = libc::readlinkat(
                 dir.dir_fd,
                 file_name.as_ptr(),
                 buf.as_mut_ptr() as *mut libc::c_char,
                 buf.len(),
-            ))
-        };
+            );
 
-        if res < 1 { None } else { Some(res as usize) }
+            if res < 1 { None } else { Some(res as usize) }
+        }
     }
 
     struct Dir {
@@ -407,12 +407,12 @@ mod gpu {
 
         fn update_dents_buf(&self, buf: &mut [u8]) -> Result<Option<usize>, ()> {
             unsafe {
-                let read = retry_eintr!(libc::syscall(
+                let read = libc::syscall(
                     libc::SYS_getdents64,
                     self.dir_fd,
                     buf.as_mut_ptr() as *mut _,
                     buf.len() as libc::c_int,
-                ));
+                );
                 if read < 0 {
                     sysinfo_debug!("getdents64 failed");
                     Err(())

--- a/src/unix/linux/process.rs
+++ b/src/unix/linux/process.rs
@@ -535,8 +535,8 @@ mod gpu {
             proc_path.replace_and_join("fdinfo/0");
 
             'main: for file_name in dir_iter {
-                // SAFETY: `d_name` is always valid UTF8 if it comes from `getents64`/`readdir` otherwise
-                // rust always provide valid UTF8 strings.
+                // SAFETY: `d_name` is always valid UTF8 if it comes from `getdents64`/`readdir`
+                // otherwise rust always provide valid UTF8 strings.
                 let file_name = unsafe { std::ffi::OsStr::from_encoded_bytes_unchecked(file_name) };
                 let Some(size) = read_link(fd_proc_path.replace_and_join(&file_name), &mut buf)
                 else {
@@ -582,7 +582,7 @@ mod gpu {
                     } else if let Some(line) = line.strip_prefix(b"engine-") {
                         if refresh_kind.gpu_usage()
                             && !line.starts_with(b"capacity-")
-                            && line.ends_with(b" ns")
+                            && let Some(line) = line.strip_suffix(b" ns")
                             && let Some(nb) = line.split(|c| *c == b':').nth(1)
                             && let Ok(nb) = str::from_utf8(nb)
                             && let Ok(nb) = nb.trim().parse::<u64>()
@@ -593,7 +593,9 @@ mod gpu {
                     } else if let Some(line) = line.strip_prefix(b"total-") {
                         if refresh_kind.gpu_memory()
                             && let Some(nb) = line.splitn(2, |c| *c == b':').nth(1)
-                            && let mut nb = nb.split(|c| *c == b' ')
+                            && let mut nb = nb
+                                .split(|c| *c == b' ' || *c == b'\t')
+                                .filter(|s| !s.is_empty())
                             && let Some(value) = nb.next()
                             && let Some(unit) = nb.next()
                             && let Ok(value) = str::from_utf8(value)
@@ -601,9 +603,9 @@ mod gpu {
                             && unit.len() > 0
                         {
                             gpu_memory = match unit[0] {
-                                b'K' | b'k' => Some(value / 1024),
-                                b'M' | b'm' => Some(value / 1024 / 1024),
-                                b'G' | b'g' => Some(value / 1024 / 1024 / 1024),
+                                b'K' | b'k' => Some(value * 1024),
+                                b'M' | b'm' => Some(value * 1024 * 1024),
+                                b'G' | b'g' => Some(value * 1024 * 1024 * 1024),
                                 _ => {
                                     eprintln!(
                                         "Unknown GPU memory unit {unit:?} in {:?}",

--- a/src/unix/linux/process.rs
+++ b/src/unix/linux/process.rs
@@ -373,7 +373,8 @@ mod gpu {
     use super::*;
 
     // Faster `readlink` implementation which skips allocations by reusing a same buffer.
-    fn read_link(dir: &Dir, file_name: &[libc::c_char], buf: &mut [u8; 4096]) -> Option<usize> {
+    #[inline(always)]
+    fn read_link(dir: &Dir, file_name: &[libc::c_char], buf: &mut [u8]) -> Option<usize> {
         unsafe {
             let res = libc::readlinkat(
                 dir.dir_fd,
@@ -426,7 +427,11 @@ mod gpu {
 
         fn iter(&self) -> Result<Option<DirIter<'_>>, ()> {
             // 20 dir entries at once should be enough.
-            let mut buf = vec![0; std::mem::size_of::<libc::dirent64>() * 20];
+            let mut buf = Vec::with_capacity(std::mem::size_of::<libc::dirent64>() * 20);
+            // SAFETY: Data is set by syscalls, so no need to initialize it ourselves.
+            unsafe {
+                buf.set_len(buf.capacity());
+            }
             if let Some(read) = self.update_dents_buf(&mut buf)? {
                 Ok(Some(DirIter {
                     read,
@@ -520,8 +525,10 @@ mod gpu {
             }
         {
             // 4096 is the limit used in htop so why not.
-            let mut buf = [0u8; 4096];
-            let mut gpus: Vec<(String, String)> = Vec::with_capacity(2);
+            let mut buf = Vec::with_capacity(4096);
+            // SAFETY: `read_link` and `openat` will initialize the values.
+            unsafe { buf.set_len(buf.capacity()); }
+            let mut gpus: Vec<(String, String)> = Vec::new();
 
             'main: for file_name in dir_iter {
                 // SAFETY: `d_name` is always valid UTF8 if it comes from `getdents64`/`readdir`

--- a/src/unix/linux/process.rs
+++ b/src/unix/linux/process.rs
@@ -483,7 +483,7 @@ mod gpu {
                     self.pos += dir_entry.d_reclen as usize;
 
                     // It's only supposed to contain digits in any case, but that filters very well too.
-                    if dir_entry.d_name[0] != b'.' as i8 {
+                    if dir_entry.d_name[0] != b'.' as libc::c_char {
                         return Some(&dir_entry.d_name);
                     }
                 }

--- a/src/unix/linux/process.rs
+++ b/src/unix/linux/process.rs
@@ -425,6 +425,7 @@ mod gpu {
             }
         }
 
+        #[allow(clippy::uninit_vec)]
         fn iter(&self) -> Result<Option<DirIter<'_>>, ()> {
             // 20 dir entries at once should be enough.
             let mut buf = Vec::with_capacity(std::mem::size_of::<libc::dirent64>() * 20);
@@ -488,6 +489,17 @@ mod gpu {
                 }
             }
         }
+    }
+
+    fn parse_ascii_checked(bytes: &[u8]) -> Option<u64> {
+        let mut num = 0u64;
+        for &b in bytes {
+            if !b.is_ascii_digit() {
+                return None;
+            }
+            num = num.checked_mul(10)?.checked_add((b - b'0') as u64)?;
+        }
+        Some(num)
     }
 
     // Maybe something to do in the future: if it's not an AMD or NVIDIA GPU, we can still compute the
@@ -581,12 +593,12 @@ mod gpu {
                             && !line.starts_with(b"capacity-")
                             && let Some(line) = line.strip_suffix(b" ns")
                             && let Some(nb) = line.split(|c| *c == b':').nth(1)
-                            && let Ok(nb) = str::from_utf8(nb.trim_ascii())
-                            && let Ok(nb) = nb.parse::<u64>()
+                            && let Some(nb) = parse_ascii_checked(nb.trim_ascii())
                         {
                             *gpu_time.get_or_insert(0) += nb;
                         }
                     } else if let Some(line) = line.strip_prefix(b"total-") {
+                        #[allow(clippy::collapsible_if)]
                         if refresh_kind.gpu_memory()
                             && let Some(nb) = line.splitn(2, |c| *c == b':').nth(1)
                             && let mut nb = nb
@@ -594,9 +606,8 @@ mod gpu {
                                 .filter(|s| !s.is_empty())
                             && let Some(value) = nb.next()
                             && let Some(unit) = nb.next()
-                            && let Ok(value) = str::from_utf8(value.trim_ascii())
-                            && let Ok(value) = value.parse::<u64>()
-                            && unit.len() > 0
+                            && !unit.is_empty()
+                            && let Some(value) = parse_ascii_checked(value.trim_ascii())
                         {
                             gpu_memory = match unit[0] {
                                 b'K' | b'k' => Some(value * 1024),

--- a/src/unix/linux/utils.rs
+++ b/src/unix/linux/utils.rs
@@ -45,6 +45,7 @@ impl PathHandler {
         Self(path.as_ref().join("a"))
     }
 
+    #[inline(always)]
     pub(crate) fn as_path(&self) -> &Path {
         &self.0
     }
@@ -57,6 +58,7 @@ pub(crate) trait PathPush {
 
 #[cfg(feature = "system")]
 impl PathPush for PathHandler {
+    #[inline(always)]
     fn replace_and_join<S: AsRef<OsStr> + ?Sized>(&mut self, p: &S) -> &Path {
         self.0.pop();
         self.0.push(p.as_ref());
@@ -67,6 +69,7 @@ impl PathPush for PathHandler {
 // This implementation allows to skip one allocation that is done in `PathHandler`.
 #[cfg(feature = "system")]
 impl PathPush for std::path::PathBuf {
+    #[inline(always)]
     fn replace_and_join<S: AsRef<OsStr> + ?Sized>(&mut self, p: &S) -> &Path {
         self.push(p.as_ref());
         self.as_path()


### PR DESCRIPTION
Follow-up of https://github.com/GuillaumeGomez/sysinfo/pull/1718.

With this code:

```rust
use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System};

fn main() {
    let mut sys = System::new().unwrap();
    sys.refresh_processes_specifics(
        ProcessesToUpdate::All,
        false,
        ProcessRefreshKind::nothing()
            .with_gpu_usage()
            .with_gpu_memory(),
    );
    println!("{}", sys.processes().len());
}
```

Before this PR, running with `time` gave (first line is the number of processes retrieved by `sysinfo`):

```console
1875

real	0m0.348s
user	0m0.075s
sys 	0m0.273s
```

With this PR:

```console
1888

real	0m0.292s
user	0m0.043s
sys 	0m0.248s
```

Final flamegraph:

<img width="1200" height="502" alt="flamegraph-new" src="https://github.com/user-attachments/assets/5b9d75e6-24bf-4d5f-8f2e-00ee191a23ef" />
