### PR TITLE
Fix thermal zone components being dropped by `Components::refresh`

### DIFF
--- a/src/unix/linux/component.rs
+++ b/src/unix/linux/component.rs
@@ -432,7 +432,7 @@ impl ComponentsInner {
         read_temp_dir(&path.join("hwmon"), "hwmon", |path| {
             ComponentInner::from_hwmon(&mut self.components, &path);
         });
-        if self.components.is_empty() {
+        if self.components.iter().all(|c| !c.inner.updated) {
             // Normally should only be used by raspberry pi.
             read_temp_dir(&path.join("thermal"), "thermal_", |path| {
                 let temp = path.join("temp");
@@ -447,7 +447,16 @@ impl ComponentsInner {
                         ..Default::default()
                     };
                     fill_component(&mut component, "input", &path, "temp");
-                    self.components.push(Component { inner: component });
+                    if let Some(comp) = self
+                        .components
+                        .iter_mut()
+                        .find(|comp| comp.inner.id == component.id)
+                    {
+                        comp.inner.update_from(Component { inner: component });
+                    } else {
+                        component.updated = true;
+                        self.components.push(Component { inner: component });
+                    }
                 }
             });
         }


### PR DESCRIPTION
Where there's no hwmon but `/sys/class/thermal` has zones in it, the case the comment there calls "normally should only be used by raspberry pi", `Components::new_with_refreshed_list()` comes back empty. `Components::new()` then `refresh(false)` on the same machine gives you the zone and its temperature. So the fallback works, you just cant get at it through the constructor every doc example uses.

Nothing on that branch sets `updated`, and `refresh(true)` drops whatever isnt flagged. Setting it alone doesn't get you there - the scan is gated on the list being empty, so with a zone already in it the next refresh skips the scan, the flag stays down and it goes again. It now runs whenever the hwmon sweep found nothing and merges into the zone thats already there by id, which is what the hwmon path does with labels.

I measured it on a box with no hwmon and a stand-in `/sys/class/thermal` holding one zone at 45C. Four `refresh(true)` calls in a row give 0 0 0 0 components on main and 1 1 1 1 with this in. On the real `/sys`, which has no sensors on it, the patched binary still reports nothing, so it isn't inventing zones, and one that goes away still gets removed on the next `refresh(true)`.

---

One thing I deliberately left out. `refresh(false)` scans thermal once and never again, so the temperature it hands back stops moving after the first call - three calls read 45C while the zone actually went 45, 55, 65. Thats the same on main today, so it isn't something this changes. Fixing it means the fallback firing on "this sweep found no hwmon" rather than "the list is empty", which is a bigger call than belongs in a bug fix, and it would start surfacing thermal zones on machines where an hwmon read blips. Separate PR if you want it.
