### PR TITLE
Correctly handle network interface name with `OsString` instead of `String`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Guillaume Gomez <guillaume1.gomez@gmail.com>"]
 description = "Library to get system information such as processes, CPUs, disks, components and networks"
 repository = "https://github.com/GuillaumeGomez/sysinfo"
 license = "MIT"
-readme = "README.md"
 rust-version = "1.95"
 exclude = ["/test-unknown"]
 keywords = ["system-information", "disk", "process", "network", "cpu"]

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ if let Ok(networks) = Networks::new_with_refreshed_list() {
     println!("=> networks:");
     for (interface_name, data) in &networks {
         println!(
-            "{interface_name}: {} B (down) / {} B (up)",
+            "{}: {} B (down) / {} B (up)",
+            interface_name.display(),
             data.total_received(),
             data.total_transmitted(),
         );

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -304,11 +304,12 @@ fn interpret_input(
                 for (interface_name, data) in networks.iter() {
                     println!(
                         "\
-    {interface_name}:
+    {}:
       operational state {}
       ether {}
       input data  (new / total): {} / {} B
       output data (new / total): {} / {} B",
+                        interface_name.display(),
                         data.operational_state(),
                         data.mac_address(),
                         data.received(),

--- a/src/common/network.rs
+++ b/src/common/network.rs
@@ -1,6 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use std::collections::HashMap;
+use std::ffi::OsString;
 use std::fmt;
 use std::net::{AddrParseError, IpAddr};
 use std::num::ParseIntError;
@@ -15,7 +16,7 @@ use crate::{Error, NetworkDataInner, NetworksInner};
 ///
 /// if let Ok(networks) = Networks::new_with_refreshed_list() {
 ///     for (interface_name, network) in &networks {
-///         println!("[{interface_name}]: {network:?}");
+///         println!("[{}]: {network:?}", interface_name.display());
 ///     }
 /// }
 /// ```
@@ -24,8 +25,8 @@ pub struct Networks {
 }
 
 impl<'a> IntoIterator for &'a Networks {
-    type Item = (&'a String, &'a NetworkData);
-    type IntoIter = std::collections::hash_map::Iter<'a, String, NetworkData>;
+    type Item = (&'a OsString, &'a NetworkData);
+    type IntoIter = std::collections::hash_map::Iter<'a, OsString, NetworkData>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -43,7 +44,7 @@ impl Networks {
     /// if let Ok(mut networks) = Networks::new() {
     ///     networks.refresh(true);
     ///     for (interface_name, network) in &networks {
-    ///         println!("[{interface_name}]: {network:?}");
+    ///         println!("[{}]: {network:?}", interface_name.display());
     ///     }
     /// }
     /// ```
@@ -82,7 +83,7 @@ impl Networks {
     ///     }
     /// }
     /// ```
-    pub fn list(&self) -> &HashMap<String, NetworkData> {
+    pub fn list(&self) -> &HashMap<OsString, NetworkData> {
         self.inner.list()
     }
 
@@ -102,7 +103,7 @@ impl Networks {
 }
 
 impl std::ops::Deref for Networks {
-    type Target = HashMap<String, NetworkData>;
+    type Target = HashMap<OsString, NetworkData>;
 
     fn deref(&self) -> &Self::Target {
         self.list()
@@ -116,7 +117,7 @@ impl std::ops::Deref for Networks {
 ///
 /// if let Ok(networks) = Networks::new_with_refreshed_list() {
 ///     for (interface_name, network) in &networks {
-///         println!("[{interface_name}] {network:?}");
+///         println!("[{}] {network:?}", interface_name.display());
 ///     }
 /// }
 /// ```

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,11 +1,12 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use std::collections::HashMap;
+use std::ffi::OsString;
 
 use crate::NetworkData;
 
 /// Interface addresses are OS-independent
-pub(crate) fn refresh_networks_addresses(interfaces: &mut HashMap<String, NetworkData>) {
+pub(crate) fn refresh_networks_addresses(interfaces: &mut HashMap<OsString, NetworkData>) {
     #[cfg(windows)]
     {
         let interface_networks = unsafe { crate::network_helper::get_interface_ip_networks() };

--- a/src/unix/apple/network.rs
+++ b/src/unix/apple/network.rs
@@ -6,7 +6,9 @@ use libc::{
 };
 
 use std::collections::{HashMap, hash_map};
+use std::ffi::OsString;
 use std::mem::{MaybeUninit, size_of};
+use std::os::unix::ffi::OsStringExt;
 use std::ptr::null_mut;
 
 use crate::network::refresh_networks_addresses;
@@ -65,7 +67,7 @@ fn update_network_data(inner: &mut NetworkDataInner, data: &if_data64) {
 }
 
 pub(crate) struct NetworksInner {
-    pub(crate) interfaces: HashMap<String, NetworkData>,
+    pub(crate) interfaces: HashMap<OsString, NetworkData>,
 }
 
 impl NetworksInner {
@@ -75,7 +77,7 @@ impl NetworksInner {
         })
     }
 
-    pub(crate) fn list(&self) -> &HashMap<String, NetworkData> {
+    pub(crate) fn list(&self) -> &HashMap<OsString, NetworkData> {
         &self.interfaces
     }
 
@@ -156,7 +158,7 @@ impl NetworksInner {
                         continue;
                     }
                     name.set_len(libc::strlen(pname));
-                    let name = String::from_utf8_unchecked(name);
+                    let name = OsString::from_vec(name);
                     let mtu = (*if2m).ifm_data.ifi_mtu as u64;
 
                     // FIXME: the documentation I could find was rather spars and unclear, are these the right flags?

--- a/src/unix/bsd/freebsd/network.rs
+++ b/src/unix/bsd/freebsd/network.rs
@@ -1,6 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use std::collections::{HashMap, hash_map};
+use std::ffi::OsString;
 use std::mem::MaybeUninit;
 
 use super::utils;
@@ -16,7 +17,7 @@ macro_rules! old_and_new {
 }
 
 pub(crate) struct NetworksInner {
-    pub(crate) interfaces: HashMap<String, NetworkData>,
+    pub(crate) interfaces: HashMap<OsString, NetworkData>,
 }
 
 impl NetworksInner {
@@ -26,7 +27,7 @@ impl NetworksInner {
         })
     }
 
-    pub(crate) fn list(&self) -> &HashMap<String, NetworkData> {
+    pub(crate) fn list(&self) -> &HashMap<OsString, NetworkData> {
         &self.interfaces
     }
 
@@ -83,55 +84,57 @@ impl NetworksInner {
             if unsafe { !utils::get_sys_value(&mib, &mut data) } {
                 continue;
             }
-            if let Some(name) = utils::c_buf_to_utf8_string(&data.ifmd_name) {
-                let flags = data.ifmd_flags;
-                let data = &data.ifmd_data;
-                let mtu = data.ifi_mtu as u64;
-                let operational_state =
-                    InterfaceOperationalState::from_flag(flags, data.ifi_link_state.into());
+            let name = utils::c_buf_to_os_string(&data.ifmd_name);
+            if name.is_empty() {
+                continue;
+            }
+            let flags = data.ifmd_flags;
+            let data = &data.ifmd_data;
+            let mtu = data.ifi_mtu as u64;
+            let operational_state =
+                InterfaceOperationalState::from_flag(flags, data.ifi_link_state.into());
 
-                match self.interfaces.entry(name) {
-                    hash_map::Entry::Occupied(mut e) => {
-                        let interface = e.get_mut();
-                        let interface = &mut interface.inner;
+            match self.interfaces.entry(name) {
+                hash_map::Entry::Occupied(mut e) => {
+                    let interface = e.get_mut();
+                    let interface = &mut interface.inner;
 
-                        old_and_new!(interface, ifi_ibytes, old_ifi_ibytes, data);
-                        old_and_new!(interface, ifi_obytes, old_ifi_obytes, data);
-                        old_and_new!(interface, ifi_ipackets, old_ifi_ipackets, data);
-                        old_and_new!(interface, ifi_opackets, old_ifi_opackets, data);
-                        old_and_new!(interface, ifi_ierrors, old_ifi_ierrors, data);
-                        old_and_new!(interface, ifi_oerrors, old_ifi_oerrors, data);
-                        interface.mtu = mtu;
-                        interface.operational_state = operational_state;
-                        interface.updated = true;
+                    old_and_new!(interface, ifi_ibytes, old_ifi_ibytes, data);
+                    old_and_new!(interface, ifi_obytes, old_ifi_obytes, data);
+                    old_and_new!(interface, ifi_ipackets, old_ifi_ipackets, data);
+                    old_and_new!(interface, ifi_opackets, old_ifi_opackets, data);
+                    old_and_new!(interface, ifi_ierrors, old_ifi_ierrors, data);
+                    old_and_new!(interface, ifi_oerrors, old_ifi_oerrors, data);
+                    interface.mtu = mtu;
+                    interface.operational_state = operational_state;
+                    interface.updated = true;
+                }
+                hash_map::Entry::Vacant(e) => {
+                    if !refresh_all {
+                        // This is simply a refresh, we don't want to add new interfaces!
+                        continue;
                     }
-                    hash_map::Entry::Vacant(e) => {
-                        if !refresh_all {
-                            // This is simply a refresh, we don't want to add new interfaces!
-                            continue;
-                        }
-                        e.insert(NetworkData {
-                            inner: NetworkDataInner {
-                                ifi_ibytes: data.ifi_ibytes,
-                                old_ifi_ibytes: 0,
-                                ifi_obytes: data.ifi_obytes,
-                                old_ifi_obytes: 0,
-                                ifi_ipackets: data.ifi_ipackets,
-                                old_ifi_ipackets: 0,
-                                ifi_opackets: data.ifi_opackets,
-                                old_ifi_opackets: 0,
-                                ifi_ierrors: data.ifi_ierrors,
-                                old_ifi_ierrors: 0,
-                                ifi_oerrors: data.ifi_oerrors,
-                                old_ifi_oerrors: 0,
-                                updated: true,
-                                mac_addr: MacAddr::UNSPECIFIED,
-                                ip_networks: vec![],
-                                mtu,
-                                operational_state,
-                            },
-                        });
-                    }
+                    e.insert(NetworkData {
+                        inner: NetworkDataInner {
+                            ifi_ibytes: data.ifi_ibytes,
+                            old_ifi_ibytes: 0,
+                            ifi_obytes: data.ifi_obytes,
+                            old_ifi_obytes: 0,
+                            ifi_ipackets: data.ifi_ipackets,
+                            old_ifi_ipackets: 0,
+                            ifi_opackets: data.ifi_opackets,
+                            old_ifi_opackets: 0,
+                            ifi_ierrors: data.ifi_ierrors,
+                            old_ifi_ierrors: 0,
+                            ifi_oerrors: data.ifi_oerrors,
+                            old_ifi_oerrors: 0,
+                            updated: true,
+                            mac_addr: MacAddr::UNSPECIFIED,
+                            ip_networks: vec![],
+                            mtu,
+                            operational_state,
+                        },
+                    });
                 }
             }
         }

--- a/src/unix/bsd/freebsd/utils.rs
+++ b/src/unix/bsd/freebsd/utils.rs
@@ -1,8 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-#[cfg(feature = "system")]
-use std::ffi::{CStr, OsStr, OsString};
-#[cfg(feature = "system")]
+#[cfg(any(feature = "system", feature = "network"))]
+use std::ffi::{OsStr, OsString};
+#[cfg(any(feature = "system", feature = "network"))]
 use std::os::unix::ffi::OsStrExt;
 
 #[cfg(any(feature = "system", feature = "network"))]
@@ -35,7 +35,7 @@ pub(crate) unsafe fn get_sys_value_array<T: Sized>(mib: &[libc::c_int], value: &
     }
 }
 
-#[cfg(any(feature = "disk", feature = "system", feature = "network"))]
+#[cfg(any(feature = "disk", feature = "system"))]
 pub(crate) fn c_buf_to_utf8_str(buf: &[libc::c_char]) -> Option<&str> {
     unsafe {
         let buf: &[u8] = std::slice::from_raw_parts(buf.as_ptr() as _, buf.len());
@@ -49,12 +49,12 @@ pub(crate) fn c_buf_to_utf8_str(buf: &[libc::c_char]) -> Option<&str> {
     }
 }
 
-#[cfg(any(feature = "disk", feature = "system", feature = "network"))]
+#[cfg(any(feature = "disk", feature = "system"))]
 pub(crate) fn c_buf_to_utf8_string(buf: &[libc::c_char]) -> Option<String> {
     c_buf_to_utf8_str(buf).map(|s| s.to_owned())
 }
 
-#[cfg(feature = "system")]
+#[cfg(any(feature = "system", feature = "network"))]
 pub(crate) fn c_buf_to_os_str(buf: &[libc::c_char]) -> &OsStr {
     unsafe {
         let buf: &[u8] = std::slice::from_raw_parts(buf.as_ptr() as _, buf.len());
@@ -67,7 +67,7 @@ pub(crate) fn c_buf_to_os_str(buf: &[libc::c_char]) -> &OsStr {
     }
 }
 
-#[cfg(feature = "system")]
+#[cfg(any(feature = "system", feature = "network"))]
 pub(crate) fn c_buf_to_os_string(buf: &[libc::c_char]) -> OsString {
     c_buf_to_os_str(buf).to_owned()
 }
@@ -196,7 +196,7 @@ pub(crate) unsafe fn from_cstr_array(ptr: *const *const libc::c_char) -> Vec<OsS
     for pos in 0..max {
         unsafe {
             let p = ptr.add(pos);
-            ret.push(OsStr::from_bytes(CStr::from_ptr(*p).to_bytes()).to_os_string());
+            ret.push(OsStr::from_bytes(std::ffi::CStr::from_ptr(*p).to_bytes()).to_os_string());
         }
     }
     ret

--- a/src/unix/bsd/netbsd/network.rs
+++ b/src/unix/bsd/netbsd/network.rs
@@ -1,6 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use std::collections::{HashMap, hash_map};
+use std::ffi::{CStr, OsString};
+use std::os::unix::ffi::OsStringExt;
 
 use crate::network::refresh_networks_addresses;
 use crate::unix::bsd::NetworkDataInner;
@@ -14,7 +16,7 @@ macro_rules! old_and_new {
 }
 
 pub(crate) struct NetworksInner {
-    pub(crate) interfaces: HashMap<String, NetworkData>,
+    pub(crate) interfaces: HashMap<OsString, NetworkData>,
 }
 
 impl NetworksInner {
@@ -24,7 +26,7 @@ impl NetworksInner {
         })
     }
 
-    pub(crate) fn list(&self) -> &HashMap<String, NetworkData> {
+    pub(crate) fn list(&self) -> &HashMap<OsString, NetworkData> {
         &self.interfaces
     }
 
@@ -56,60 +58,60 @@ impl NetworksInner {
 
             for ifa in ifaddrs {
                 let ifa = &*ifa;
-                if let Some(name) = std::ffi::CStr::from_ptr(ifa.ifa_name)
-                    .to_str()
-                    .ok()
-                    .map(|s| s.to_string())
-                {
-                    let flags = ifa.ifa_flags;
-                    let data: &libc::if_data = &*(ifa.ifa_data as *mut libc::if_data);
-                    let mtu = data.ifi_mtu;
-                    let operational_state = InterfaceOperationalState::from_flag(
-                        flags as core::ffi::c_int,
-                        data.ifi_link_state,
-                    );
-                    match self.interfaces.entry(name) {
-                        hash_map::Entry::Occupied(mut e) => {
-                            let interface = e.get_mut();
-                            let interface = &mut interface.inner;
+                if ifa.ifa_name.is_null() {
+                    continue;
+                }
+                // SAFETY: `ifa_name` is terminated by `\0`.
+                let bytes = CStr::from_ptr(ifa.ifa_name).to_bytes();
+                let name = OsString::from_vec(bytes.to_owned());
+                let flags = ifa.ifa_flags;
+                let data: &libc::if_data = &*(ifa.ifa_data as *mut libc::if_data);
+                let mtu = data.ifi_mtu;
+                let operational_state = InterfaceOperationalState::from_flag(
+                    flags as core::ffi::c_int,
+                    data.ifi_link_state,
+                );
+                match self.interfaces.entry(name) {
+                    hash_map::Entry::Occupied(mut e) => {
+                        let interface = e.get_mut();
+                        let interface = &mut interface.inner;
 
-                            old_and_new!(interface, ifi_ibytes, old_ifi_ibytes, data);
-                            old_and_new!(interface, ifi_obytes, old_ifi_obytes, data);
-                            old_and_new!(interface, ifi_ipackets, old_ifi_ipackets, data);
-                            old_and_new!(interface, ifi_opackets, old_ifi_opackets, data);
-                            old_and_new!(interface, ifi_ierrors, old_ifi_ierrors, data);
-                            old_and_new!(interface, ifi_oerrors, old_ifi_oerrors, data);
-                            interface.mtu = mtu;
-                            interface.operational_state = operational_state;
-                            interface.updated = true;
+                        old_and_new!(interface, ifi_ibytes, old_ifi_ibytes, data);
+                        old_and_new!(interface, ifi_obytes, old_ifi_obytes, data);
+                        old_and_new!(interface, ifi_ipackets, old_ifi_ipackets, data);
+                        old_and_new!(interface, ifi_opackets, old_ifi_opackets, data);
+                        old_and_new!(interface, ifi_ierrors, old_ifi_ierrors, data);
+                        old_and_new!(interface, ifi_oerrors, old_ifi_oerrors, data);
+                        interface.mtu = mtu;
+                        interface.operational_state = operational_state;
+                        interface.updated = true;
+                    }
+                    hash_map::Entry::Vacant(e) => {
+                        if !refresh_all {
+                            // This is simply a refresh, we don't want to add new interfaces!
+                            continue;
                         }
-                        hash_map::Entry::Vacant(e) => {
-                            if !refresh_all {
-                                // This is simply a refresh, we don't want to add new interfaces!
-                                continue;
-                            }
-                            e.insert(NetworkData {
-                                inner: NetworkDataInner {
-                                    ifi_ibytes: data.ifi_ibytes,
-                                    old_ifi_ibytes: 0,
-                                    ifi_obytes: data.ifi_obytes,
-                                    old_ifi_obytes: 0,
-                                    ifi_ipackets: data.ifi_ipackets,
-                                    old_ifi_ipackets: 0,
-                                    ifi_opackets: data.ifi_opackets,
-                                    old_ifi_opackets: 0,
-                                    ifi_ierrors: data.ifi_ierrors,
-                                    old_ifi_ierrors: 0,
-                                    ifi_oerrors: data.ifi_oerrors,
-                                    old_ifi_oerrors: 0,
-                                    updated: true,
-                                    mac_addr: MacAddr::UNSPECIFIED,
-                                    ip_networks: vec![],
-                                    mtu,
-                                    operational_state,
-                                },
-                            });
-                        }
+                        e.insert(NetworkData {
+                            inner: NetworkDataInner {
+                                ifi_ibytes: data.ifi_ibytes,
+                                old_ifi_ibytes: 0,
+                                ifi_obytes: data.ifi_obytes,
+                                old_ifi_obytes: 0,
+                                ifi_ipackets: data.ifi_ipackets,
+                                old_ifi_ipackets: 0,
+                                ifi_opackets: data.ifi_opackets,
+                                old_ifi_opackets: 0,
+                                ifi_ierrors: data.ifi_ierrors,
+                                old_ifi_ierrors: 0,
+                                ifi_oerrors: data.ifi_oerrors,
+                                old_ifi_oerrors: 0,
+                                updated: true,
+                                mac_addr: MacAddr::UNSPECIFIED,
+                                ip_networks: vec![],
+                                mtu,
+                                operational_state,
+                            },
+                        });
                     }
                 }
             }

--- a/src/unix/linux/network.rs
+++ b/src/unix/linux/network.rs
@@ -1,6 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use std::collections::{HashMap, hash_map};
+use std::ffi::OsString;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
@@ -70,7 +71,7 @@ impl InterfaceOperationalState {
 }
 
 fn refresh_networks_list_from_sysfs(
-    interfaces: &mut HashMap<String, NetworkData>,
+    interfaces: &mut HashMap<OsString, NetworkData>,
     remove_not_listed_interfaces: bool,
     sysfs_net: &Path,
 ) {
@@ -86,10 +87,6 @@ fn refresh_networks_list_from_sysfs(
         for entry in dir.flatten() {
             let parent = &entry.path().join("statistics");
             let entry_path = &entry.path();
-            let entry = match entry.file_name().into_string() {
-                Ok(entry) => entry,
-                Err(_) => continue,
-            };
             let rx_bytes = read(parent, "rx_bytes", &mut num_buf);
             let tx_bytes = read(parent, "tx_bytes", &mut num_buf);
             let rx_packets = read(parent, "rx_packets", &mut num_buf);
@@ -104,7 +101,7 @@ fn refresh_networks_list_from_sysfs(
                 read_str(entry_path, "operstate", &mut str_buf).trim_ascii(),
             );
 
-            match interfaces.entry(entry) {
+            match interfaces.entry(entry.file_name()) {
                 hash_map::Entry::Occupied(mut e) => {
                     let interface = e.get_mut();
                     let interface = &mut interface.inner;
@@ -166,7 +163,7 @@ fn refresh_networks_list_from_sysfs(
 }
 
 pub(crate) struct NetworksInner {
-    pub(crate) interfaces: HashMap<String, NetworkData>,
+    pub(crate) interfaces: HashMap<OsString, NetworkData>,
 }
 
 impl NetworksInner {
@@ -176,7 +173,7 @@ impl NetworksInner {
         })
     }
 
-    pub(crate) fn list(&self) -> &HashMap<String, NetworkData> {
+    pub(crate) fn list(&self) -> &HashMap<OsString, NetworkData> {
         &self.interfaces
     }
 
@@ -301,6 +298,7 @@ impl NetworkDataInner {
 mod test {
     use super::refresh_networks_list_from_sysfs;
     use std::collections::HashMap;
+    use std::ffi::{OsStr, OsString};
     use std::fs;
 
     #[test]
@@ -317,7 +315,7 @@ mod test {
         fs::create_dir(sys_net_dir.path().join("itf2")).expect("failed to create subdirectory");
 
         refresh_networks_list_from_sysfs(&mut interfaces, false, sys_net_dir.path());
-        let mut itf_names: Vec<String> = interfaces.keys().map(|n| n.to_owned()).collect();
+        let mut itf_names: Vec<OsString> = interfaces.keys().map(|n| n.to_owned()).collect();
         itf_names.sort();
         assert_eq!(itf_names, ["itf1", "itf2"]);
     }
@@ -334,7 +332,7 @@ mod test {
         let mut interfaces = HashMap::new();
 
         refresh_networks_list_from_sysfs(&mut interfaces, false, sys_net_dir.path());
-        let mut itf_names: Vec<String> = interfaces.keys().map(|n| n.to_owned()).collect();
+        let mut itf_names: Vec<OsString> = interfaces.keys().map(|n| n.to_owned()).collect();
         itf_names.sort();
         assert_eq!(itf_names, ["itf1", "itf2"]);
 
@@ -380,19 +378,25 @@ mod test {
         refresh_networks_list_from_sysfs(&mut interfaces, false, dir.path());
         refresh_networks_list_from_sysfs(&mut interfaces, false, dir.path());
 
-        assert_eq!(interfaces.get("if_a").unwrap().inner.rx_bytes, 100);
         assert_eq!(
-            interfaces.get("if_b").unwrap().inner.rx_bytes,
+            interfaces.get(OsStr::new("if_a")).unwrap().inner.rx_bytes,
+            100
+        );
+        assert_eq!(
+            interfaces.get(OsStr::new("if_b")).unwrap().inner.rx_bytes,
             1_234_567_890_123
         );
         assert_eq!(
-            interfaces.get("if_c").unwrap().inner.rx_bytes,
+            interfaces.get(OsStr::new("if_c")).unwrap().inner.rx_bytes,
             9_876_543_210_987
         );
-        assert_eq!(interfaces.get("if_d").unwrap().inner.rx_bytes, u64::MAX);
+        assert_eq!(
+            interfaces.get(OsStr::new("if_d")).unwrap().inner.rx_bytes,
+            u64::MAX
+        );
 
         for name in ["if_a", "if_b", "if_c", "if_d"] {
-            let interface = interfaces.get(name).unwrap();
+            let interface = interfaces.get(OsStr::new(name)).unwrap();
             assert_eq!(interface.inner.mtu, 1500, "{name}: mtu");
         }
     }

--- a/src/unix/network_helper.rs
+++ b/src/unix/network_helper.rs
@@ -2,13 +2,13 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::ffi::CStr;
+use std::ffi::{CStr, OsString};
 use std::marker::PhantomData;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::os::raw::c_char;
+use std::os::unix::ffi::OsStringExt;
 use std::ptr::null_mut;
-use std::str::from_utf8_unchecked;
 use std::{io, mem};
 
 use crate::{IpNetwork, MacAddr};
@@ -59,7 +59,7 @@ pub(crate) struct InterfaceAddressHelper {
 }
 
 impl InterfaceAddressHelper {
-    pub(crate) fn name(&self) -> Option<String> {
+    pub(crate) fn name(&self) -> Option<OsString> {
         // Safety: We assume that addr is valid for the lifetime of this body, and is not mutated.
         let addr_ref: &libc::ifaddrs = unsafe { &*self.ifap };
 
@@ -67,14 +67,16 @@ impl InterfaceAddressHelper {
 
         // Safety: ifa_name is a null terminated interface name
         let bytes = unsafe { CStr::from_ptr(c_str).to_bytes() };
-
-        // Safety: Interfaces on unix must be valid UTF-8
-        let name = unsafe { from_utf8_unchecked(bytes).to_owned() };
         // Interfaces names may be formatted as <interface name>:<sub-interface index>
-        if name.contains(':') {
-            name.split(':').next().map(|v| v.to_string())
+        let bytes = if let Some(pos) = bytes.iter().rposition(|b| *b == b':') {
+            bytes[..pos].to_owned()
         } else {
-            Some(name)
+            bytes.to_owned()
+        };
+        if bytes.is_empty() {
+            None
+        } else {
+            Some(OsString::from_vec(bytes))
         }
     }
 
@@ -194,12 +196,12 @@ unsafe fn parse_interface_address(ifap: &libc::ifaddrs) -> Option<MacAddr> {
 }
 
 pub(crate) unsafe fn refresh_network_interfaces(
-    interfaces: &mut HashMap<String, crate::NetworkData>,
+    interfaces: &mut HashMap<OsString, crate::NetworkData>,
 ) {
     let Some(interface_iter) = InterfaceAddress::new() else {
         return;
     };
-    let mut ifaces: HashMap<String, HashSet<IpNetwork>> = HashMap::new();
+    let mut ifaces: HashMap<OsString, HashSet<IpNetwork>> = HashMap::new();
 
     for entry in interface_iter.iter() {
         if let Some(interface_name) = entry.name()

--- a/src/unknown/network.rs
+++ b/src/unknown/network.rs
@@ -3,9 +3,10 @@
 use crate::{Error, InterfaceOperationalState, IpNetwork, MacAddr, NetworkData};
 
 use std::collections::HashMap;
+use std::ffi::OsString;
 
 pub(crate) struct NetworksInner {
-    pub(crate) interfaces: HashMap<String, NetworkData>,
+    pub(crate) interfaces: HashMap<OsString, NetworkData>,
 }
 
 impl NetworksInner {
@@ -13,7 +14,7 @@ impl NetworksInner {
         Err(Error::Unsupported)
     }
 
-    pub(crate) fn list(&self) -> &HashMap<String, NetworkData> {
+    pub(crate) fn list(&self) -> &HashMap<OsString, NetworkData> {
         &self.interfaces
     }
 

--- a/src/windows/network.rs
+++ b/src/windows/network.rs
@@ -4,6 +4,8 @@ use crate::network::refresh_networks_addresses;
 use crate::{Error, InterfaceOperationalState, IpNetwork, MacAddr, NetworkData};
 
 use std::collections::{HashMap, hash_map};
+use std::ffi::OsString;
+use std::os::windows::ffi::OsStringExt;
 
 use windows::Win32::NetworkManagement::IpHelper::{FreeMibTable, GetIfTable2, MIB_IF_TABLE2};
 use windows::Win32::NetworkManagement::Ndis::{
@@ -20,7 +22,7 @@ macro_rules! old_and_new {
 }
 
 pub(crate) struct NetworksInner {
-    pub(crate) interfaces: HashMap<String, NetworkData>,
+    pub(crate) interfaces: HashMap<OsString, NetworkData>,
 }
 
 impl NetworksInner {
@@ -30,7 +32,7 @@ impl NetworksInner {
         })
     }
 
-    pub(crate) fn list(&self) -> &HashMap<String, NetworkData> {
+    pub(crate) fn list(&self) -> &HashMap<OsString, NetworkData> {
         &self.interfaces
     }
 
@@ -92,10 +94,7 @@ impl NetworksInner {
                     }
                     pos += 1;
                 }
-                let interface_name = match String::from_utf16(&ptr.Alias[..pos]) {
-                    Ok(s) => s,
-                    _ => continue,
-                };
+                let interface_name = OsString::from_wide(&ptr.Alias[..pos]);
 
                 let mtu = ptr.Mtu as u64;
                 let operational_state = InterfaceOperationalState::from_enum(ptr.OperStatus);

--- a/src/windows/network_helper.rs
+++ b/src/windows/network_helper.rs
@@ -1,7 +1,9 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use std::collections::{HashMap, HashSet};
+use std::ffi::OsString;
 use std::net::IpAddr;
+use std::os::windows::ffi::OsStringExt;
 use std::ptr::{NonNull, null_mut};
 
 use windows::Win32::Foundation::{ERROR_BUFFER_OVERFLOW, ERROR_SUCCESS};
@@ -46,7 +48,7 @@ impl InterfaceAddressIterator {
 }
 
 impl Iterator for InterfaceAddressIterator {
-    type Item = (String, MacAddr);
+    type Item = (OsString, MacAddr);
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.adapter.is_null() {
@@ -56,37 +58,32 @@ impl Iterator for InterfaceAddressIterator {
             let adapter = self.adapter;
             // Move to the next adapter
             self.adapter = (*adapter).Next;
-            if let Ok(interface_name) = (*adapter).FriendlyName.to_string() {
-                // take the first 6 bytes and return the MAC address instead
-                let [mac @ .., _, _] = (*adapter).PhysicalAddress;
-                Some((interface_name, MacAddr(mac)))
-            } else {
-                // Not sure whether error can occur when parsing adapter name.
-                self.next()
-            }
+            let interface_name = OsString::from_wide((*adapter).FriendlyName.as_wide());
+            // take the first 6 bytes and return the MAC address instead
+            let [mac @ .., _, _] = (*adapter).PhysicalAddress;
+            Some((interface_name, MacAddr(mac)))
         }
     }
 }
 
 impl InterfaceAddressIterator {
-    pub fn generate_ip_networks(&mut self) -> HashMap<String, HashSet<IpNetwork>> {
+    pub fn generate_ip_networks(&mut self) -> HashMap<OsString, HashSet<IpNetwork>> {
         let mut results = HashMap::new();
         while !self.adapter.is_null() {
             unsafe {
                 let adapter = self.adapter;
                 // Move to the next adapter
                 self.adapter = (*adapter).Next;
-                if let Ok(interface_name) = (*adapter).FriendlyName.to_string() {
-                    let ip_networks = get_ip_networks((*adapter).FirstUnicastAddress);
-                    results.insert(interface_name, ip_networks);
-                }
+                let interface_name = OsString::from_wide((*adapter).FriendlyName.as_wide());
+                let ip_networks = get_ip_networks((*adapter).FirstUnicastAddress);
+                results.insert(interface_name, ip_networks);
             }
         }
         results
     }
 }
 
-pub(crate) unsafe fn get_interface_ip_networks() -> HashMap<String, HashSet<IpNetwork>> {
+pub(crate) unsafe fn get_interface_ip_networks() -> HashMap<OsString, HashSet<IpNetwork>> {
     match unsafe { get_interface_address() } {
         Ok(mut interface_iter) => interface_iter.generate_ip_networks(),
         _ => HashMap::new(),


### PR DESCRIPTION
Fixes #1704.