### PR TITLE
Fix thermal zone temperatures freezing after the first `Components::refresh`

### DIFF
--- a/src/common/component.rs
+++ b/src/common/component.rs
@@ -143,6 +143,10 @@ impl Components {
                 c.inner.updated = false;
                 true
             });
+        } else {
+            for c in self.inner.components.iter_mut() {
+                c.inner.updated = false;
+            }
         }
     }
 }

--- a/src/unix/linux/component.rs
+++ b/src/unix/linux/component.rs
@@ -677,4 +677,30 @@ mod tests {
         assert_eq!(components[1].max(), Some(5.678));
         assert_eq!(components[1].id(), Some("thermal_zone1"));
     }
+
+    #[test]
+    fn test_thermal_zone_used_when_hwmon_has_no_temperature() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temporary directory");
+        let hwmon0_dir = temp_dir.path().join("hwmon/hwmon0");
+        let thermal_zone0_dir = temp_dir.path().join("thermal/thermal_zone0");
+
+        // An `hwmon` device with no `tempN_input` file, like the voltage monitor on a
+        // Raspberry Pi: there is an `hwmon` folder, but no temperature to read from it.
+        fs::create_dir_all(&hwmon0_dir).expect("failed to create hwmon/hwmon0 directory");
+        fs::write(hwmon0_dir.join("name"), "test_volt").expect("failed to write to name file");
+        fs::write(hwmon0_dir.join("in0_input"), "5000").expect("failed to write to in0_input file");
+
+        fs::create_dir_all(&thermal_zone0_dir)
+            .expect("failed to create thermal/thermal_zone0 directory");
+        fs::write(thermal_zone0_dir.join("type"), "test_name")
+            .expect("failed to write to type file");
+        fs::write(thermal_zone0_dir.join("temp"), "1234").expect("failed to write to temp file");
+
+        let mut components = ComponentsInner::new().unwrap();
+        components.refresh_from_sys_class_path(temp_dir.path());
+
+        assert_eq!(components.list().len(), 1);
+        assert_eq!(components.list()[0].id(), Some("thermal_zone0"));
+        assert_eq!(components.list()[0].temperature(), Some(1.234));
+    }
 }


### PR DESCRIPTION
Linux boards with no hwmon temperature source read their thermal zone once, then return that first value for the life of the process. This affects the released crate, including sysinfo 0.39.6, and isn't a regression on main.

```rust
let mut components = Components::new_with_refreshed_list().unwrap();
loop {
    components.refresh(false);
    println!("{:?}", components.list()[0].temperature());  // Some(45.0), then Some(45.0), forever
}
```

`refresh_from_sys_class_path` in `src/unix/linux/component.rs` gates the `/sys/class/thermal` fallback on `self.components.iter().all(|c| !c.inner.updated)`. `Components::refresh` only clears `updated` as part of removing the components it didn't see, so after `refresh(false)` nothing clears it and that check reads the result of the previous refresh rather than this one.

This hits boards with no hwmon at all. The fallback's own comment says "Normally should only be used by raspberry pi", and sysinfo's documentation example at `src/common/component.rs:132` uses `components.refresh(false)`. Machines with hwmon never see the freeze, beacuse that sweep runs on every refresh.

~~The tests cover a thermal value changing from `1.234` to `5.678`, plus the Raspberry Pi shape where an hwmon device exposes voltage and no temperature at all. `cargo test --lib unix::linux::component` gives 8 passed, 0 failed; reverting the fix gives 6 passed, 2 failed.~~

The fix moved into `Components::refresh` after review, and the first of those tests couldn't come with it - see the comment below. One left, covering the Raspberry Pi shape.

A temporarilly empty hwmon sweep can now add thermal-zone components which `refresh(false)` won't remove. `refresh(true)` already does this, and an empty sweep means every hwmon temperature source vansihed at once; runtime-suspended GPUs still expose `temp1_input`. It also means `refresh(true)` now drops components missed by its current sweep, rather than keeping stale flags from an earlier `refresh(false)`.

This is the follow-up to #1726 that GuillaumeGomez asked for.

---

The other shape is `from_hwmon` returning a bool, ORed into a local flag, leaving `updated` alone. I dropped it because it leaves the old flags set: a thermal zone found by an earlier `refresh(false)` survivies the next `refresh(true)` once an hwmon source turns up, and you end up with both listed. It passes the same suite, which is the bit I'm least happy about.

