### PR TITLE
Improve performance of `split_content`

### DIFF
--- a/src/unix/linux/process.rs
+++ b/src/unix/linux/process.rs
@@ -1307,19 +1307,11 @@ fn get_proc_tasks(path: &Path, parent_pid: Pid) -> Vec<ProcAndTasks> {
         .unwrap_or_default()
 }
 
-fn split_content(mut data: &[u8]) -> Vec<OsString> {
+fn split_content(data: &[u8]) -> Vec<OsString> {
     let mut out = Vec::with_capacity(10);
-    while let Some(pos) = data.iter().position(|c| *c == 0) {
-        let s = &data[..pos].trim_ascii();
-        if !s.is_empty() {
-            out.push(OsStr::from_bytes(s).to_os_string());
-        }
-        data = &data[pos + 1..];
-    }
-    if !data.is_empty() {
-        let s = data.trim_ascii();
-        if !s.is_empty() {
-            out.push(OsStr::from_bytes(s).to_os_string());
+    for part in data.split(|c| *c == 0) {
+        if !part.is_empty() {
+            out.push(OsStr::from_bytes(part).to_os_string());
         }
     }
     out


### PR DESCRIPTION
Tested with this code:

```rust
use std::os::unix::ffi::OsStrExt;
use std::ffi::{OsStr, OsString};
use std::hint::black_box;

fn split_content_new(data: &[u8]) -> Vec<OsString> {
    let mut out = Vec::with_capacity(10);
    for part in data.split(|c| *c == 0) {
        if !part.is_empty() {
            out.push(OsStr::from_bytes(part).to_os_string());
        }
    }
    out
}

fn split_content_old(mut data: &[u8]) -> Vec<OsString> {
    let mut out = Vec::with_capacity(10);
    while let Some(pos) = data.iter().position(|c| *c == 0) {
        let s = &data[..pos].trim_ascii();
        if !s.is_empty() {
            out.push(OsStr::from_bytes(s).to_os_string());
        }
        data = &data[pos + 1..];
    }
    if !data.is_empty() {
        let s = data.trim_ascii();
        if !s.is_empty() {
            out.push(OsStr::from_bytes(s).to_os_string());
        }
    }
    out
}

#[bench]
fn bench_split_new(b: &mut test::Bencher) {
    b.iter(|| {
         black_box(split_content_new(b"a\0b\0c\0d\0e\0f\0g\0h\0i\0j\0k\0l\0m\0n\0o"));
    });
}

#[bench]
fn bench_split_old(b: &mut test::Bencher) {
    b.iter(|| {
         black_box(split_content_old(b"a\0b\0c\0d\0e\0f\0g\0h\0i\0j\0k\0l\0m\0n\0o"));
    });
}
```

Which gave this results:

```console
running 2 tests
test bench_split_new               ... bench:         330.19 ns/iter (+/- 10.64)
test bench_split_old               ... bench:         361.64 ns/iter (+/- 14.69)
```